### PR TITLE
Prep release: README improvements, author, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.1.0 — Initial Release
+
+Put your AI coding agent on autopilot.
+
+Ralph takes plan files from a backlog and drives any CLI-based coding agent to implement them — with branch isolation, feedback loops, and stuck detection baked in.
+
+### Highlights
+
+- **`npx ralphai init`** — interactive wizard scaffolds `.ralph/` into your project, auto-detects package manager and build/test/lint scripts
+- **Plan-based workflow** — write plans in `.ralph/backlog/`, Ralph picks them up, creates branches, and loops your agent through build/test/lint cycles
+- **8 agent presets** — OpenCode, Claude Code, Codex, Gemini CLI, Aider, Goose, Kiro, Amp
+- **Branch isolation** — every plan runs on a `ralph/<plan-name>` branch
+- **Stuck detection** — aborts after N iterations with no progress (default: 3)
+- **Auto-PR** — opens PRs for protected branches, merges directly otherwise
+- **Resume support** — `--resume` picks up where you left off
+- **Dry-run mode** — `--dry-run` previews what Ralph would do without touching anything
+- **GitHub Issues integration** — optionally pulls labeled issues when the backlog is empty
+- **Plan dependencies** — `depends-on` field for ordering across a backlog
+- **Learnings loop** — two-tier system for logging and curating lessons across runs
+- **Update & uninstall** — `ralphai update` refreshes templates; `ralphai uninstall` cleans up

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ Put your AI coding agent on autopilot.
 
 Ralph takes plan files from a backlog and drives any CLI-based coding agent to implement them — with branch isolation, feedback loops, and stuck detection baked in. You write the plans (or have your agent write them). Ralph does the rest.
 
+## Why Ralph?
+
+AI agents degrade the longer they run. Context windows fill up, older decisions get compressed away, and the model starts hallucinating or going in circles.
+
+Ralph sidesteps this. Each iteration launches your agent with a **fresh context** — just the plan, current repo state, and build/test/lint feedback. No accumulated confusion, no compression artifacts.
+
+- **No context rot** — iteration 50 is as sharp as iteration 1
+- **Grounded feedback** — real build errors every cycle, not stale memory
+- **Stuck detection** — stops burning tokens when progress stalls
+- **Unattended** — write plans, walk away
+
 ## Get Started
 
 ```bash
@@ -28,10 +39,10 @@ Use .ralph/WRITING-PLANS.md as a guide.
 ### 2. Get ralph cooking
 
 ```bash
-npx ralphai run -- 10
+npx ralphai run
 ```
 
-For best first-run DX, `npx ralphai run -- ...` works out of the box. In initialized repos, you can also invoke `./.ralph/ralph.sh ...` directly.
+Ralph uses sensible defaults out of the box. In initialized repos, you can also invoke `./.ralph/ralph.sh` directly, passing args like iteration count (`10`) or flags (`--resume`, `--dry-run`).
 
 Ralph picks the best plan from the backlog, creates a `ralph/*` branch, hands the plan to your agent, and loops — build, test, lint after every iteration. When a plan is done, it archives the work, merges or opens a PR, and moves on to the next one.
 
@@ -51,17 +62,17 @@ out/        ← done, archived
 If you need to stop mid-run, just kill it. Your work stays in `in-progress/` on the `ralph/*` branch. Pick up where you left off:
 
 ```bash
-npx ralphai run -- 10 --resume
+npx ralphai run
 ```
 
-`--resume` auto-commits any dirty state and continues.
+Ralph auto-resumes from where you left off. You can also pass `--resume` explicitly to `./.ralph/ralph.sh`.
 
 ### 5. Preview before committing
 
 Not sure what Ralph will do? Dry-run it:
 
 ```bash
-npx ralphai run -- --dry-run
+./.ralph/ralph.sh --dry-run
 ```
 
 Shows which plan would be picked, whether it would resume or start fresh, and what the merge target is — without touching anything.
@@ -133,8 +144,8 @@ Init:
   --agent-command=CMD    Set the agent command
 
 Run:
-  -- <args>    Pass arguments to ralph.sh (e.g. -- 10 --resume)
-              In initialized repos, direct invocation via ./.ralph/ralph.sh is also available.
+  Runs with sensible defaults. Pass args to ralph.sh via -- (e.g. -- 10 --resume).
+  In initialized repos, ./.ralph/ralph.sh is also available for direct invocation.
 ```
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "bugs": {
     "url": "https://github.com/mfaux/ralphai/issues"
   },
-  "author": "",
+  "author": "mfaux",
   "license": "MIT",
   "devDependencies": {
     "@clack/prompts": "^0.11.0",


### PR DESCRIPTION
## Changes

- **package.json**: Set `author` to `mfaux`
- **README.md**: Added "Why Ralph?" section explaining fresh-context-per-iteration advantage; simplified `run` examples to use sensible defaults (no `--` flags)
- **CHANGELOG.md**: Created with v0.1.0 release notes

No code changes — docs and metadata only.