### PR TITLE
ci: add CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  checks:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Tests
+        timeout-minutes: 10
+        run: pnpm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,144 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Tests
+        timeout-minutes: 10
+        run: pnpm test
+
+      - name: Determine version bump type
+        id: version
+        run: |
+          # If tag push, skip version bump (already versioned)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "bump=skip" >> $GITHUB_OUTPUT
+            echo "Tag push - skipping version bump, will publish directly"
+            exit 0
+          fi
+
+          # If manually triggered, use the input value
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "bump=${{ inputs.bump }}" >> $GITHUB_OUTPUT
+            echo "Manual trigger - will bump ${{ inputs.bump }} version"
+            exit 0
+          fi
+
+          # Get the latest version tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          if [ -z "$LATEST_TAG" ]; then
+            COMMITS=$(git log --format=%s)
+          else
+            COMMITS=$(git log ${LATEST_TAG}..HEAD --format=%s)
+          fi
+
+          echo "Commits since last tag:"
+          echo "$COMMITS"
+
+          # Check for explicit version bump markers
+          if echo "$COMMITS" | grep -q "\[minor\]"; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+            echo "Found [minor] - will bump minor version"
+          elif echo "$COMMITS" | grep -q "\[patch\]"; then
+            echo "bump=patch" >> $GITHUB_OUTPUT
+            echo "Found [patch] - will bump patch version"
+          else
+            echo "bump=none" >> $GITHUB_OUTPUT
+            echo "No version marker found - skipping release"
+          fi
+
+      - name: Configure git
+        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
+        run: |
+          npm version ${{ steps.version.outputs.bump }} -m "v%s"
+
+      - name: Push changes
+        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
+        run: |
+          git push
+          git push --tags
+
+      - name: Publish to npm
+        id: publish
+        if: steps.version.outputs.bump != 'none'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.publish.outcome == 'success'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+
+          LATEST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            SINCE=""
+          else
+            SINCE=$(git log -1 --format=%cI ${LATEST_TAG})
+          fi
+
+          if [ -z "$SINCE" ]; then
+            PRS=$(gh pr list --state merged --json number,title,author --limit 100)
+          else
+            PRS=$(gh pr list --state merged --search "merged:>=${SINCE}" --json number,title,author --limit 100)
+          fi
+
+          CHANGELOG=$(echo "$PRS" | jq -r '.[] | "- \(.title) (#\(.number))"')
+
+          gh release create "v${VERSION}" --title "v${VERSION}" --notes "${CHANGELOG:-Initial release}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds GitHub Actions CI/CD:

- **CI** (`.github/workflows/ci.yml`) — runs on PRs and pushes to main: build, type-check, tests on ubuntu + windows
- **Publish** (`.github/workflows/publish.yml`) — publishes to npm with provenance, creates GitHub Releases

### Publish triggers
- **Auto**: commit message contains `[patch]` or `[minor]` → bumps version, publishes, creates release
- **Manual**: workflow_dispatch with patch/minor selector
- **Tag**: push `v*` tag → publishes that version directly

### Setup required
1. Create an npm access token at https://www.npmjs.com/settings/tokens (type: Granular Access Token, package: ralphai)
2. Add it as a repo secret named `NPM_TOKEN` at https://github.com/mfaux/ralphai/settings/secrets/actions