### PR TITLE
Plan: Default iterations-per-plan to 5

### DIFF
--- a/.ralph/README.md
+++ b/.ralph/README.md
@@ -50,7 +50,7 @@ Plan files in `backlog/`, `in-progress/`, and `out/` are **gitignored** (local-o
 
 ## Scripts
 
-### `ralph.sh <iterations-per-plan> [options]`
+### `ralph.sh [iterations-per-plan] [options]`
 
 Looped autonomous runner. Auto-detects what to work on, runs up to N iterations per plan, with stuck detection.
 

--- a/.ralph/ralph.sh
+++ b/.ralph/ralph.sh
@@ -2,7 +2,7 @@
 # ralph.sh — Ralph (looped, autonomous)
 # Drives an AI coding agent to autonomously implement tasks from plan files.
 #
-# Usage: .ralph/ralph.sh <iterations-per-plan> [--dry-run] [--resume] [--agent-command=<cmd>] [--feedback-commands=<list>] [--base-branch=<branch>] [--merge-target=<branch>] [--protected-branches=<list>] [--max-stuck=<n>] [--show-config] [--help]
+# Usage: .ralph/ralph.sh [iterations-per-plan] [--dry-run] [--resume] [--agent-command=<cmd>] [--feedback-commands=<list>] [--base-branch=<branch>] [--merge-target=<branch>] [--protected-branches=<list>] [--max-stuck=<n>] [--show-config] [--help]
 #
 # Auto-detects what to work on:
 #   1. If .ralph/in-progress/ has plan files → resume on the current ralph/* branch
@@ -490,11 +490,12 @@ read_issue_frontmatter() {
 }
 
 print_usage() {
-  echo "Usage: $0 <iterations-per-plan> [options]"
+  echo "Usage: $0 [iterations-per-plan] [options]"
   echo ""
   echo "  Auto-detects work: resumes in-progress plans, or picks from backlog."
   echo "  Iteration budget resets for each new plan (normal mode)."
   echo "  Pass 0 for unlimited iterations (runs until complete or stuck)."
+  echo "  Default: 5 iterations per plan."
   echo ""
   echo "Options:"
   echo "  --dry-run, -n                    Preview what Ralph would do without mutating state"
@@ -845,13 +846,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$ITERATIONS" ]]; then
-  if [[ "$DRY_RUN" == true || "$SHOW_CONFIG" == true ]]; then
-    ITERATIONS="1"
-  else
-    echo "ERROR: Missing required <iterations-per-plan>"
-    print_usage
-    exit 1
-  fi
+  ITERATIONS="5"
 fi
 
 if ! [[ "$ITERATIONS" =~ ^[0-9]+$ ]]; then

--- a/src/ralph.test.ts
+++ b/src/ralph.test.ts
@@ -296,6 +296,29 @@ describe("ralphai command", () => {
     );
   });
 
+  it("scaffolded ralph.sh defaults to 5 iterations when none specified", () => {
+    runCliOutput(["init", "--yes"], testDir);
+
+    const ralphSh = readFileSync(join(testDir, ".ralph", "ralph.sh"), "utf-8");
+    // Should default ITERATIONS to "5" when unset (no error, no conditional)
+    expect(ralphSh).toContain('ITERATIONS="5"');
+    // Should NOT contain the old error message for missing iterations
+    expect(ralphSh).not.toContain(
+      "ERROR: Missing required <iterations-per-plan>",
+    );
+  });
+
+  it("scaffolded ralph.sh shows iterations-per-plan as optional in usage", () => {
+    runCliOutput(["init", "--yes"], testDir);
+
+    const ralphSh = readFileSync(join(testDir, ".ralph", "ralph.sh"), "utf-8");
+    // Usage text should use square brackets (optional) not angle brackets (required)
+    expect(ralphSh).toContain("[iterations-per-plan]");
+    expect(ralphSh).not.toContain("<iterations-per-plan>");
+    // Should mention the default
+    expect(ralphSh).toContain("Default: 5 iterations per plan.");
+  });
+
   it("scaffolded ralph.sh contains issue integration defaults", () => {
     runCliOutput(["init", "--yes"], testDir);
 
@@ -995,37 +1018,40 @@ describe("ralphai command", () => {
   // Run default iteration tests
   // -------------------------------------------------------------------------
 
-  describe.skipIf(process.platform === "win32")("run default iterations", () => {
-    beforeEach(() => {
-      // Scaffold ralph, then replace ralph.sh with a stub that echoes args
-      runCliOutput(["init", "--yes"], testDir);
-      writeFileSync(
-        join(testDir, ".ralph", "ralph.sh"),
-        '#!/bin/bash\necho "ARGS:$*"\n',
-      );
-      chmodSync(join(testDir, ".ralph", "ralph.sh"), 0o755);
-    });
+  describe.skipIf(process.platform === "win32")(
+    "run default iterations",
+    () => {
+      beforeEach(() => {
+        // Scaffold ralph, then replace ralph.sh with a stub that echoes args
+        runCliOutput(["init", "--yes"], testDir);
+        writeFileSync(
+          join(testDir, ".ralph", "ralph.sh"),
+          '#!/bin/bash\necho "ARGS:$*"\n',
+        );
+        chmodSync(join(testDir, ".ralph", "ralph.sh"), 0o755);
+      });
 
-    it("run without args passes default iteration count (5) to ralph.sh", () => {
-      const result = runCli(["run"], testDir);
-      expect(result.stdout).toContain("ARGS:5");
-    });
+      it("run without args passes default iteration count (5) to ralph.sh", () => {
+        const result = runCli(["run"], testDir);
+        expect(result.stdout).toContain("ARGS:5");
+      });
 
-    it("run -- 5 passes explicit iteration count to ralph.sh", () => {
-      const result = runCli(["run", "--", "5"], testDir);
-      expect(result.stdout).toContain("ARGS:5");
-    });
+      it("run -- 5 passes explicit iteration count to ralph.sh", () => {
+        const result = runCli(["run", "--", "5"], testDir);
+        expect(result.stdout).toContain("ARGS:5");
+      });
 
-    it("run -- --dry-run passes flags to ralph.sh", () => {
-      const result = runCli(["run", "--", "--dry-run"], testDir);
-      expect(result.stdout).toContain("ARGS:--dry-run");
-    });
+      it("run -- --dry-run passes flags to ralph.sh", () => {
+        const result = runCli(["run", "--", "--dry-run"], testDir);
+        expect(result.stdout).toContain("ARGS:--dry-run");
+      });
 
-    it("run -- 5 --resume passes multiple args to ralph.sh", () => {
-      const result = runCli(["run", "--", "5", "--resume"], testDir);
-      expect(result.stdout).toContain("ARGS:5 --resume");
-    });
-  });
+      it("run -- 5 --resume passes multiple args to ralph.sh", () => {
+        const result = runCli(["run", "--", "5", "--resume"], testDir);
+        expect(result.stdout).toContain("ARGS:5 --resume");
+      });
+    },
+  );
 
   // -------------------------------------------------------------------------
   // GitHub Issues integration tests

--- a/templates/ralph/README.md
+++ b/templates/ralph/README.md
@@ -41,7 +41,7 @@ Plan files in `backlog/`, `in-progress/`, and `out/` are **gitignored** (local-o
 
 ## Scripts
 
-### `ralph.sh <iterations-per-plan> [options]`
+### `ralph.sh [iterations-per-plan] [options]`
 
 Looped autonomous runner. Auto-detects what to work on, runs up to N iterations per plan, with stuck detection.
 
@@ -97,15 +97,15 @@ Dry run makes no mutations (no file moves, branch creation, or agent execution).
 
 ## Files
 
-| File / Directory | Purpose                                                  |
-| ---------------- | -------------------------------------------------------- |
-| `ralph.sh`       | Looped autonomous runner (+ `--dry-run`)                 |
-| `ralph.config`   | Optional repo-level config file (key=value format)       |
-| `.ralph/LEARNINGS.md` | Ralph-specific learnings — gitignored, local-only   |
-| `drafts/`        | Parked plans — not scanned by ralph                      |
-| `backlog/`       | Incoming plans queued for ralph to pick up               |
-| `in-progress/`   | Active plans and progress.txt — work in flight           |
-| `out/`           | Archived PRD files and progress logs from completed runs |
+| File / Directory      | Purpose                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `ralph.sh`            | Looped autonomous runner (+ `--dry-run`)                 |
+| `ralph.config`        | Optional repo-level config file (key=value format)       |
+| `.ralph/LEARNINGS.md` | Ralph-specific learnings — gitignored, local-only        |
+| `drafts/`             | Parked plans — not scanned by ralph                      |
+| `backlog/`            | Incoming plans queued for ralph to pick up               |
+| `in-progress/`        | Active plans and progress.txt — work in flight           |
+| `out/`                | Archived PRD files and progress logs from completed runs |
 
 ## How It Works
 
@@ -205,8 +205,10 @@ Use a lightweight review loop after runs:
 1. Review `.ralph/LEARNINGS.md` entries from the run.
 2. Compact findings by merging duplicates and removing one-off noise.
 3. Promote durable guidance:
-  - `AGENTS.md` (or equivalent agent-instruction docs) for immediate repo-specific behavior
-  - skill/reusable docs for stable patterns that should be reused across tasks/repos
+
+- `AGENTS.md` (or equivalent agent-instruction docs) for immediate repo-specific behavior
+- skill/reusable docs for stable patterns that should be reused across tasks/repos
+
 4. Add concise, high-signal takeaways to repo-level `LEARNINGS.md`.
 
 This separation keeps the repo-level `LEARNINGS.md` clean (no agent noise) and prevents auto-commit from interfering with stuck detection.

--- a/templates/ralph/ralph.sh
+++ b/templates/ralph/ralph.sh
@@ -2,7 +2,7 @@
 # ralph.sh — Ralph (looped, autonomous)
 # Drives an AI coding agent to autonomously implement tasks from plan files.
 #
-# Usage: .ralph/ralph.sh <iterations-per-plan> [--dry-run] [--resume] [--agent-command=<cmd>] [--feedback-commands=<list>] [--base-branch=<branch>] [--merge-target=<branch>] [--protected-branches=<list>] [--max-stuck=<n>] [--show-config] [--help]
+# Usage: .ralph/ralph.sh [iterations-per-plan] [--dry-run] [--resume] [--agent-command=<cmd>] [--feedback-commands=<list>] [--base-branch=<branch>] [--merge-target=<branch>] [--protected-branches=<list>] [--max-stuck=<n>] [--show-config] [--help]
 #
 # Auto-detects what to work on:
 #   1. If .ralph/in-progress/ has plan files → resume on the current ralph/* branch
@@ -490,13 +490,14 @@ read_issue_frontmatter() {
 }
 
 print_usage() {
-  echo "Usage: $0 <iterations-per-plan> [options]"
+  echo "Usage: $0 [iterations-per-plan] [options]"
   echo ""
   echo "  Recommended daily invocation from an initialized repo: ./.ralph/ralph.sh ..."
   echo ""
   echo "  Auto-detects work: resumes in-progress plans, or picks from backlog."
   echo "  Iteration budget resets for each new plan (normal mode)."
   echo "  Pass 0 for unlimited iterations (runs until complete or stuck)."
+  echo "  Default: 5 iterations per plan."
   echo ""
   echo "Options:"
   echo "  --dry-run, -n                    Preview what Ralph would do without mutating state"
@@ -847,13 +848,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$ITERATIONS" ]]; then
-  if [[ "$DRY_RUN" == true || "$SHOW_CONFIG" == true ]]; then
-    ITERATIONS="1"
-  else
-    echo "ERROR: Missing required <iterations-per-plan>"
-    print_usage
-    exit 1
-  fi
+  ITERATIONS="5"
 fi
 
 if ! [[ "$ITERATIONS" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Plan

# Plan: Default iterations-per-plan to 5

> `ralph.sh` currently errors when run without the `<iterations-per-plan>` argument, but the docs and CLI help text say it defaults to 5. Make the script actually default to 5 so `npx ralphai run` and `.ralph/ralph.sh` work without arguments.

## Background

The README.md says:

> Defaults to 5 iterations per plan (e.g. `./.ralph/ralph.sh 3` for 3).

The CLI help in `src/cli.ts` says:

> (no args)              Run with defaults (5 iterations per plan)

But in `templates/ralph/ralph.sh` (and the generated `.ralph/ralph.sh`), the iteration-missing block at line ~849 only defaults to `"1"` for `--dry-run` / `--show-config` and errors out otherwise:

```bash
if [[ -z "$ITERATIONS" ]]; then
  if [[ "$DRY_RUN" == true || "$SHOW_CONFIG" == true ]]; then
    ITERATIONS="1"
  else
    echo "ERROR: Missing required <iterations-per-plan>"
    print_usage
    exit 1
  fi
fi
```

## Acceptance Criteria

- [ ] `.ralph/ralph.sh` with no positional argument defaults to 5 iterations
- [ ] `npx ralphai run` (no `--` args) works and runs 5 iterations
- [ ] `--dry-run` and `--show-config` still work without a positional argument (can use 5 or 1, doesn't matter)
- [ ] Explicit iteration arg still overrides the default (e.g. `.ralph/ralph.sh 10` → 10)
- [ ] `0` still means unlimited
- [ ] Usage text and help output updated to show `[iterations-per-plan]` (optional) instead of `<iterations-per-plan>` (required)
- [ ] All existing tests pass
- [ ] No docs changes needed — docs already say "defaults to 5"

## Implementation Tasks

### Task 1: Change the default in `templates/ralph/ralph.sh`

**File:** `templates/ralph/ralph.sh`

**What:** Replace the `if [[ -z "$ITERATIONS" ]]` block (~line 849) so it unconditionally defaults to `"5"` instead of erroring:

```bash
if [[ -z "$ITERATIONS" ]]; then
  ITERATIONS="5"
fi
```

### Task 2: Update usage/help text in `templates/ralph/ralph.sh`

**File:** `templates/ralph/ralph.sh`

**What:**
- Line 5 comment: change `<iterations-per-plan>` → `[iterations-per-plan]`
- `print_usage()` (~line 493): change `<iterations-per-plan>` → `[iterations-per-plan]`
- Add a line to help output noting the default: `"  Default: 5 iterations per plan."`

## Verification

```bash
# No args — should run (or dry-run) with 5 iterations
.ralph/ralph.sh --dry-run

# Explicit override still works
.ralph/ralph.sh 10 --dry-run

# Help still renders correctly
.ralph/ralph.sh --help
```

## Commits

```
176a64e feat(ralph.sh): default iterations-per-plan to 5 when omitted
```