### PR TITLE
Plan: Group Mode Foundation — Parsing and Helper Functions

### DIFF
--- a/src/ralph.test.ts
+++ b/src/ralph.test.ts
@@ -1635,4 +1635,577 @@ echo "$PROMPT_MODE"
     expect(result.stdout).toContain("update");
     expect(result.stdout).toContain("uninstall");
   });
+
+  // -------------------------------------------------------------------------
+  // Group mode foundation: extract_group, group-state, collect_group_plans
+  // -------------------------------------------------------------------------
+
+  it("scaffolded ralph.sh contains group mode foundation functions", () => {
+    runCliOutput(["init", "--yes"], testDir);
+
+    const ralphSh = readFileSync(join(testDir, ".ralph", "ralph.sh"), "utf-8");
+    expect(ralphSh).toContain("extract_group()");
+    expect(ralphSh).toContain("write_group_state()");
+    expect(ralphSh).toContain("read_group_state()");
+    expect(ralphSh).toContain("cleanup_group_state()");
+    expect(ralphSh).toContain("collect_group_plans()");
+    expect(ralphSh).toContain("GROUP_STATE_FILE=");
+  });
+
+  describe.skipIf(process.platform === "win32")(
+    "extract_group function",
+    () => {
+      /** Helper: run extract_group on a temp file with given content */
+      function extractGroup(content: string): string {
+        const planFile = join(
+          tmpdir(),
+          `ralph-test-plan-${Date.now()}-${Math.random().toString(36).slice(2)}.md`,
+        );
+        const script = `#!/bin/bash
+extract_group() {
+  local file="$1"
+  if [[ ! -f "$file" ]] || [[ "$(head -1 "$file" 2>/dev/null)" != "---" ]]; then
+    return 0
+  fi
+  awk '
+    BEGIN { in_fm=0 }
+    NR==1 && $0=="---" { in_fm=1; next }
+    in_fm && $0=="---" { exit }
+    in_fm && match($0, /^[[:space:]]*group:[[:space:]]*(.+)/, arr) {
+      val=arr[1]
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+      gsub(/^"|"$/, "", val)
+      gsub(/^\\047|\\047$/, "", val)
+      if (val != "") print val
+      exit
+    }
+  ' "$file"
+}
+extract_group ${JSON.stringify(planFile)}
+`;
+        const scriptFile = join(
+          tmpdir(),
+          `ralph-test-script-${Date.now()}-${Math.random().toString(36).slice(2)}.sh`,
+        );
+        try {
+          writeFileSync(planFile, content);
+          writeFileSync(scriptFile, script);
+          const result = execSync(`bash ${JSON.stringify(scriptFile)}`, {
+            encoding: "utf-8",
+          });
+          return result.trim();
+        } finally {
+          try {
+            rmSync(planFile);
+          } catch {
+            /* ignore */
+          }
+          try {
+            rmSync(scriptFile);
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+
+      it("extracts group name from frontmatter", () => {
+        expect(extractGroup("---\ngroup: my-feature\n---\n# Plan")).toBe(
+          "my-feature",
+        );
+      });
+
+      it("returns empty for no frontmatter", () => {
+        expect(extractGroup("# Just a plan\nNo frontmatter")).toBe("");
+      });
+
+      it("returns empty for frontmatter without group", () => {
+        expect(extractGroup("---\ntitle: something\n---\n# Plan")).toBe("");
+      });
+
+      it("handles quoted group value (double quotes)", () => {
+        expect(extractGroup('---\ngroup: "my-feature"\n---\n')).toBe(
+          "my-feature",
+        );
+      });
+
+      it("handles quoted group value (single quotes)", () => {
+        expect(extractGroup("---\ngroup: 'my-feature'\n---\n")).toBe(
+          "my-feature",
+        );
+      });
+
+      it("handles whitespace around group value", () => {
+        expect(extractGroup("---\ngroup:   my-feature  \n---\n")).toBe(
+          "my-feature",
+        );
+      });
+
+      it("returns empty when group value is empty", () => {
+        expect(extractGroup("---\ngroup:\n---\n")).toBe("");
+      });
+
+      it("extracts group even with other frontmatter keys", () => {
+        expect(
+          extractGroup(
+            "---\ntitle: Plan A\ngroup: shared-feature\ndepends-on: [plan-b.md]\n---\n# Content",
+          ),
+        ).toBe("shared-feature");
+      });
+    },
+  );
+
+  describe.skipIf(process.platform === "win32")(
+    "group-state management functions",
+    () => {
+      let stateDir: string;
+
+      beforeEach(() => {
+        stateDir = join(
+          tmpdir(),
+          `ralph-group-state-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        );
+        mkdirSync(stateDir, { recursive: true });
+      });
+
+      afterEach(() => {
+        if (existsSync(stateDir)) {
+          rmSync(stateDir, { recursive: true, force: true });
+        }
+      });
+
+      it("write_group_state creates state file with key=value pairs", () => {
+        const stateFile = join(stateDir, ".group-state");
+        const script = `#!/bin/bash
+WIP_DIR=${JSON.stringify(stateDir)}
+GROUP_STATE_FILE="$WIP_DIR/.group-state"
+write_group_state() {
+  mkdir -p "$WIP_DIR"
+  printf '%s\\n' "$@" > "$GROUP_STATE_FILE"
+}
+write_group_state "group=test-feature" "branch=ralph/test-feature" "plans_total=3" "plans_completed=1" "current_plan=prd-b.md"
+cat "$GROUP_STATE_FILE"
+`;
+        const scriptFile = join(stateDir, "test.sh");
+        writeFileSync(scriptFile, script);
+        const result = execSync(`bash ${JSON.stringify(scriptFile)}`, {
+          encoding: "utf-8",
+        });
+
+        expect(result.trim()).toBe(
+          "group=test-feature\nbranch=ralph/test-feature\nplans_total=3\nplans_completed=1\ncurrent_plan=prd-b.md",
+        );
+        expect(existsSync(stateFile)).toBe(true);
+      });
+
+      it("read_group_state sets shell variables from state file", () => {
+        const stateFile = join(stateDir, ".group-state");
+        writeFileSync(
+          stateFile,
+          "group=my-group\nbranch=ralph/my-group\nplans_total=5\nplans_completed=2\ncurrent_plan=prd-c.md\npr_url=https://github.com/example/pull/42\n",
+        );
+        const script = `#!/bin/bash
+WIP_DIR=${JSON.stringify(stateDir)}
+GROUP_STATE_FILE="$WIP_DIR/.group-state"
+GROUP_NAME="" GROUP_BRANCH="" GROUP_PLANS_TOTAL="" GROUP_PLANS_COMPLETED="" GROUP_CURRENT_PLAN="" GROUP_PR_URL=""
+read_group_state() {
+  [[ -f "$GROUP_STATE_FILE" ]] || return 1
+  local line key val
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" == \\#* ]] && continue
+    case "$key" in
+      group)           GROUP_NAME="$val" ;;
+      branch)          GROUP_BRANCH="$val" ;;
+      plans_total)     GROUP_PLANS_TOTAL="$val" ;;
+      plans_completed) GROUP_PLANS_COMPLETED="$val" ;;
+      current_plan)    GROUP_CURRENT_PLAN="$val" ;;
+      pr_url)          GROUP_PR_URL="$val" ;;
+    esac
+  done < "$GROUP_STATE_FILE"
+}
+read_group_state
+echo "name=$GROUP_NAME"
+echo "branch=$GROUP_BRANCH"
+echo "total=$GROUP_PLANS_TOTAL"
+echo "completed=$GROUP_PLANS_COMPLETED"
+echo "current=$GROUP_CURRENT_PLAN"
+echo "pr=$GROUP_PR_URL"
+`;
+        const scriptFile = join(stateDir, "test.sh");
+        writeFileSync(scriptFile, script);
+        const result = execSync(`bash ${JSON.stringify(scriptFile)}`, {
+          encoding: "utf-8",
+        });
+
+        expect(result.trim()).toBe(
+          [
+            "name=my-group",
+            "branch=ralph/my-group",
+            "total=5",
+            "completed=2",
+            "current=prd-c.md",
+            "pr=https://github.com/example/pull/42",
+          ].join("\n"),
+        );
+      });
+
+      it("read_group_state returns 1 when no state file exists", () => {
+        const script = `#!/bin/bash
+WIP_DIR=${JSON.stringify(stateDir)}
+GROUP_STATE_FILE="$WIP_DIR/.group-state-nonexistent"
+read_group_state() {
+  [[ -f "$GROUP_STATE_FILE" ]] || return 1
+}
+read_group_state
+echo "exit=$?"
+`;
+        const scriptFile = join(stateDir, "test.sh");
+        writeFileSync(scriptFile, script);
+        const result = execSync(`bash ${JSON.stringify(scriptFile)}`, {
+          encoding: "utf-8",
+        });
+
+        // read_group_state returns 1, so $? in the echo after is 0 (echo succeeds)
+        // but bash -e isn't set, so we need to capture the return code differently
+        const script2 = `#!/bin/bash
+WIP_DIR=${JSON.stringify(stateDir)}
+GROUP_STATE_FILE="$WIP_DIR/.group-state-nonexistent"
+read_group_state() {
+  [[ -f "$GROUP_STATE_FILE" ]] || return 1
+}
+read_group_state; echo "exit=$?"
+`;
+        writeFileSync(scriptFile, script2);
+        const result2 = execSync(`bash ${JSON.stringify(scriptFile)}`, {
+          encoding: "utf-8",
+        });
+        expect(result2.trim()).toBe("exit=1");
+      });
+
+      it("cleanup_group_state removes the state file", () => {
+        const stateFile = join(stateDir, ".group-state");
+        writeFileSync(stateFile, "group=test\n");
+        expect(existsSync(stateFile)).toBe(true);
+
+        const script = `#!/bin/bash
+WIP_DIR=${JSON.stringify(stateDir)}
+GROUP_STATE_FILE="$WIP_DIR/.group-state"
+cleanup_group_state() {
+  rm -f "$GROUP_STATE_FILE"
+}
+cleanup_group_state
+`;
+        const scriptFile = join(stateDir, "test.sh");
+        writeFileSync(scriptFile, script);
+        execSync(`bash ${JSON.stringify(scriptFile)}`);
+
+        expect(existsSync(stateFile)).toBe(false);
+      });
+
+      it("read_group_state ignores comments and unknown keys", () => {
+        const stateFile = join(stateDir, ".group-state");
+        writeFileSync(
+          stateFile,
+          "# comment line\ngroup=valid-group\nunknown_key=should-be-ignored\nbranch=ralph/valid\n",
+        );
+        const script = `#!/bin/bash
+WIP_DIR=${JSON.stringify(stateDir)}
+GROUP_STATE_FILE="$WIP_DIR/.group-state"
+GROUP_NAME="" GROUP_BRANCH=""
+read_group_state() {
+  [[ -f "$GROUP_STATE_FILE" ]] || return 1
+  local line key val
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" == \\#* ]] && continue
+    case "$key" in
+      group)           GROUP_NAME="$val" ;;
+      branch)          GROUP_BRANCH="$val" ;;
+      plans_total)     GROUP_PLANS_TOTAL="$val" ;;
+      plans_completed) GROUP_PLANS_COMPLETED="$val" ;;
+      current_plan)    GROUP_CURRENT_PLAN="$val" ;;
+      pr_url)          GROUP_PR_URL="$val" ;;
+    esac
+  done < "$GROUP_STATE_FILE"
+}
+read_group_state
+echo "name=$GROUP_NAME"
+echo "branch=$GROUP_BRANCH"
+`;
+        const scriptFile = join(stateDir, "test.sh");
+        writeFileSync(scriptFile, script);
+        const result = execSync(`bash ${JSON.stringify(scriptFile)}`, {
+          encoding: "utf-8",
+        });
+
+        expect(result.trim()).toBe("name=valid-group\nbranch=ralph/valid");
+      });
+    },
+  );
+
+  describe.skipIf(process.platform === "win32")(
+    "collect_group_plans function",
+    () => {
+      let groupDir: string;
+      let backlogDir: string;
+
+      beforeEach(() => {
+        groupDir = join(
+          tmpdir(),
+          `ralph-group-collect-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        );
+        backlogDir = join(groupDir, "backlog");
+        mkdirSync(backlogDir, { recursive: true });
+      });
+
+      afterEach(() => {
+        if (existsSync(groupDir)) {
+          rmSync(groupDir, { recursive: true, force: true });
+        }
+      });
+
+      /** Helper: build a bash script that defines extract_group, extract_depends_on,
+       *  and collect_group_plans, then calls collect_group_plans with the given group name */
+      function runCollectGroupPlans(groupName: string, dir: string): string[] {
+        const script = `#!/bin/bash
+BACKLOG_DIR=${JSON.stringify(join(dir, "backlog"))}
+
+extract_group() {
+  local file="$1"
+  if [[ ! -f "$file" ]] || [[ "$(head -1 "$file" 2>/dev/null)" != "---" ]]; then
+    return 0
+  fi
+  awk '
+    BEGIN { in_fm=0 }
+    NR==1 && $0=="---" { in_fm=1; next }
+    in_fm && $0=="---" { exit }
+    in_fm && match($0, /^[[:space:]]*group:[[:space:]]*(.+)/, arr) {
+      val=arr[1]
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+      gsub(/^"|"$/, "", val)
+      gsub(/^\\047|\\047$/, "", val)
+      if (val != "") print val
+      exit
+    }
+  ' "$file"
+}
+
+extract_depends_on() {
+  local file="$1"
+  if [[ ! -f "$file" ]] || [[ "$(head -1 "$file" 2>/dev/null)" != "---" ]]; then
+    return 0
+  fi
+  awk '
+    BEGIN { in_fm=0; dep_mode=0 }
+    NR==1 && $0=="---" { in_fm=1; next }
+    in_fm && $0=="---" { exit }
+    in_fm {
+      line=$0
+      if (match(line, /^[[:space:]]*depends-on:[[:space:]]*\\[[^\\]]*\\][[:space:]]*$/)) {
+        dep_mode=0
+        sub(/^[[:space:]]*depends-on:[[:space:]]*\\[/, "", line)
+        sub(/\\][[:space:]]*$/, "", line)
+        n=split(line, parts, ",")
+        for (i=1; i<=n; i++) {
+          dep=parts[i]
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", dep)
+          if (dep != "") print dep
+        }
+        next
+      }
+      if (match(line, /^[[:space:]]*depends-on:[[:space:]]*$/)) {
+        dep_mode=1; next
+      }
+      if (dep_mode == 1 && match(line, /^[[:space:]]*-[[:space:]]+/)) {
+        dep=line
+        sub(/^[[:space:]]*-[[:space:]]+/, "", dep)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", dep)
+        if (dep != "") print dep
+        next
+      }
+      if (dep_mode == 1 && match(line, /^[[:alnum:]_-]+:[[:space:]]*/)) {
+        dep_mode=0
+      }
+    }
+  ' "$file"
+}
+
+collect_group_plans() {
+  local group_name="$1"
+  local -a group_files=()
+  local -a ordered=()
+  local -A seen=()
+  local -A deps_map=()
+  for f in "$BACKLOG_DIR"/*.md; do
+    [[ -f "$f" ]] || continue
+    local fg
+    fg=$(extract_group "$f")
+    if [[ "$fg" == "$group_name" ]]; then
+      group_files+=("$f")
+      local fb
+      fb=$(basename "$f")
+      local dep_list
+      dep_list=$(extract_depends_on "$f")
+      deps_map["$fb"]="$dep_list"
+    fi
+  done
+  local -A group_basenames=()
+  for f in "\${group_files[@]}"; do
+    group_basenames["$(basename "$f")"]=1
+  done
+  local -A in_degree=()
+  for f in "\${group_files[@]}"; do
+    local fb
+    fb=$(basename "$f")
+    in_degree["$fb"]=0
+  done
+  for fb in "\${!deps_map[@]}"; do
+    while IFS= read -r dep; do
+      [[ -z "$dep" ]] && continue
+      dep=$(basename "$dep")
+      if [[ -n "\${group_basenames[$dep]+x}" ]]; then
+        in_degree["$fb"]=$(( \${in_degree["$fb"]} + 1 ))
+      fi
+    done <<< "\${deps_map[$fb]}"
+  done
+  local -a queue=()
+  for fb in "\${!in_degree[@]}"; do
+    if [[ \${in_degree["$fb"]} -eq 0 ]]; then
+      queue+=("$fb")
+    fi
+  done
+  IFS=$'\\n' queue=($(sort <<< "\${queue[*]}")); unset IFS
+  while [[ \${#queue[@]} -gt 0 ]]; do
+    local current="\${queue[0]}"
+    queue=("\${queue[@]:1}")
+    ordered+=("$current")
+    seen["$current"]=1
+    for fb in "\${!deps_map[@]}"; do
+      [[ -n "\${seen[$fb]+x}" ]] && continue
+      while IFS= read -r dep; do
+        [[ -z "$dep" ]] && continue
+        dep=$(basename "$dep")
+        if [[ "$dep" == "$current" ]]; then
+          in_degree["$fb"]=$(( \${in_degree["$fb"]} - 1 ))
+          if [[ \${in_degree["$fb"]} -eq 0 ]]; then
+            queue+=("$fb")
+          fi
+        fi
+      done <<< "\${deps_map[$fb]}"
+    done
+    if [[ \${#queue[@]} -gt 1 ]]; then
+      IFS=$'\\n' queue=($(sort <<< "\${queue[*]}")); unset IFS
+    fi
+  done
+  for fb in "\${ordered[@]}"; do
+    echo "$BACKLOG_DIR/$fb"
+  done
+}
+
+collect_group_plans ${JSON.stringify(groupName)}
+`;
+        const scriptFile = join(dir, "test-collect.sh");
+        writeFileSync(scriptFile, script);
+        const result = execSync(`bash ${JSON.stringify(scriptFile)}`, {
+          encoding: "utf-8",
+        });
+        return result.trim() === "" ? [] : result.trim().split("\n");
+      }
+
+      it("collects plans matching the group name", () => {
+        writeFileSync(
+          join(backlogDir, "prd-a.md"),
+          "---\ngroup: feature-x\n---\n# Plan A\n",
+        );
+        writeFileSync(
+          join(backlogDir, "prd-b.md"),
+          "---\ngroup: feature-x\n---\n# Plan B\n",
+        );
+        writeFileSync(
+          join(backlogDir, "prd-c.md"),
+          "---\ngroup: other-feature\n---\n# Plan C\n",
+        );
+
+        const plans = runCollectGroupPlans("feature-x", groupDir);
+        expect(plans).toHaveLength(2);
+        expect(plans.map((p: string) => p.split("/").pop())).toEqual([
+          "prd-a.md",
+          "prd-b.md",
+        ]);
+      });
+
+      it("returns plans in dependency order", () => {
+        writeFileSync(
+          join(backlogDir, "prd-a.md"),
+          "---\ngroup: feature-x\ndepends-on: [prd-b.md]\n---\n# Plan A depends on B\n",
+        );
+        writeFileSync(
+          join(backlogDir, "prd-b.md"),
+          "---\ngroup: feature-x\n---\n# Plan B (no deps)\n",
+        );
+
+        const plans = runCollectGroupPlans("feature-x", groupDir);
+        const names = plans.map((p: string) => p.split("/").pop());
+        expect(names).toEqual(["prd-b.md", "prd-a.md"]);
+      });
+
+      it("returns empty for non-existent group", () => {
+        writeFileSync(
+          join(backlogDir, "prd-a.md"),
+          "---\ngroup: feature-x\n---\n# Plan A\n",
+        );
+
+        const plans = runCollectGroupPlans("nonexistent", groupDir);
+        expect(plans).toEqual([]);
+      });
+
+      it("handles plans with no frontmatter", () => {
+        writeFileSync(
+          join(backlogDir, "prd-a.md"),
+          "---\ngroup: feature-x\n---\n# Plan A\n",
+        );
+        writeFileSync(
+          join(backlogDir, "prd-no-fm.md"),
+          "# No frontmatter plan\n",
+        );
+
+        const plans = runCollectGroupPlans("feature-x", groupDir);
+        expect(plans).toHaveLength(1);
+        expect(plans[0]).toContain("prd-a.md");
+      });
+
+      it("handles chain of three dependencies in correct order", () => {
+        writeFileSync(
+          join(backlogDir, "prd-a.md"),
+          "---\ngroup: chain\ndepends-on: [prd-b.md]\n---\n# A depends on B\n",
+        );
+        writeFileSync(
+          join(backlogDir, "prd-b.md"),
+          "---\ngroup: chain\ndepends-on: [prd-c.md]\n---\n# B depends on C\n",
+        );
+        writeFileSync(
+          join(backlogDir, "prd-c.md"),
+          "---\ngroup: chain\n---\n# C (root)\n",
+        );
+
+        const plans = runCollectGroupPlans("chain", groupDir);
+        const names = plans.map((p: string) => p.split("/").pop());
+        expect(names).toEqual(["prd-c.md", "prd-b.md", "prd-a.md"]);
+      });
+
+      it("ignores cross-group dependencies", () => {
+        writeFileSync(
+          join(backlogDir, "prd-a.md"),
+          "---\ngroup: feature-x\ndepends-on: [prd-external.md]\n---\n# A depends on external plan\n",
+        );
+        writeFileSync(
+          join(backlogDir, "prd-b.md"),
+          "---\ngroup: feature-x\n---\n# B (no deps)\n",
+        );
+
+        const plans = runCollectGroupPlans("feature-x", groupDir);
+        const names = plans.map((p: string) => p.split("/").pop());
+        // Both should appear; the external dep should not block ordering
+        expect(names).toEqual(["prd-a.md", "prd-b.md"]);
+      });
+    },
+  );
 });

--- a/templates/ralph/ralph.sh
+++ b/templates/ralph/ralph.sh
@@ -52,6 +52,7 @@ BACKLOG_DIR=".ralph/backlog"
 ARCHIVE_DIR=".ralph/out"
 CONFIG_FILE=".ralph/ralph.config"
 PROGRESS_FILE="$WIP_DIR/progress.txt"
+GROUP_STATE_FILE="$WIP_DIR/.group-state"
 DRY_RUN=false
 RESUME=false
 ITERATIONS=""
@@ -612,6 +613,152 @@ extract_depends_on() {
       }
     }
   ' "$file"
+}
+
+# Extract group name from YAML frontmatter (returns empty if not set)
+# Supported form: group: my-feature-name
+extract_group() {
+  local file="$1"
+  if [[ ! -f "$file" ]] || [[ "$(head -1 "$file" 2>/dev/null)" != "---" ]]; then
+    return 0
+  fi
+  awk '
+    BEGIN { in_fm=0 }
+    NR==1 && $0=="---" { in_fm=1; next }
+    in_fm && $0=="---" { exit }
+    in_fm && match($0, /^[[:space:]]*group:[[:space:]]*(.+)/, arr) {
+      val=arr[1]
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+      gsub(/^"|"$/, "", val)
+      gsub(/^\047|\047$/, "", val)
+      if (val != "") print val
+      exit
+    }
+  ' "$file"
+}
+
+# Write group state (key=value file)
+# Usage: write_group_state "group=my-feature" "branch=ralph/my-feature" "plans_total=5" ...
+write_group_state() {
+  mkdir -p "$WIP_DIR"
+  printf '%s\n' "$@" > "$GROUP_STATE_FILE"
+}
+
+# Read group state into caller's scope. Sets variables like GROUP_NAME, GROUP_BRANCH, etc.
+# Returns 1 if no state file exists.
+read_group_state() {
+  [[ -f "$GROUP_STATE_FILE" ]] || return 1
+  local line key val
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" == \#* ]] && continue
+    case "$key" in
+      group)           GROUP_NAME="$val" ;;
+      branch)          GROUP_BRANCH="$val" ;;
+      plans_total)     GROUP_PLANS_TOTAL="$val" ;;
+      plans_completed) GROUP_PLANS_COMPLETED="$val" ;;
+      current_plan)    GROUP_CURRENT_PLAN="$val" ;;
+      pr_url)          GROUP_PR_URL="$val" ;;
+    esac
+  done < "$GROUP_STATE_FILE"
+}
+
+# Remove group state file (called when group completes or is abandoned)
+cleanup_group_state() {
+  rm -f "$GROUP_STATE_FILE"
+}
+
+# Collect all backlog plans belonging to a group, in dependency order.
+# Outputs one plan path per line. Plans with no intra-group deps come first (stable filesystem order).
+# Usage: mapfile -t plans < <(collect_group_plans "my-feature")
+collect_group_plans() {
+  local group_name="$1"
+  local -a group_files=()
+  local -a ordered=()
+  local -A seen=()
+  local -A deps_map=()
+
+  # Scan backlog for matching group
+  for f in "$BACKLOG_DIR"/*.md; do
+    [[ -f "$f" ]] || continue
+    local fg
+    fg=$(extract_group "$f")
+    if [[ "$fg" == "$group_name" ]]; then
+      group_files+=("$f")
+      local fb
+      fb=$(basename "$f")
+      # Store intra-group deps (only deps that are also in this group)
+      local dep_list
+      dep_list=$(extract_depends_on "$f")
+      deps_map["$fb"]="$dep_list"
+    fi
+  done
+
+  # Build set of group basenames for filtering
+  local -A group_basenames=()
+  for f in "${group_files[@]}"; do
+    group_basenames["$(basename "$f")"]=1
+  done
+
+  # Topological sort (Kahn's algorithm) on intra-group dependencies
+  # Ignore deps that point outside the group (they're handled by plan_readiness)
+  local -A in_degree=()
+  for f in "${group_files[@]}"; do
+    local fb
+    fb=$(basename "$f")
+    in_degree["$fb"]=0
+  done
+
+  for fb in "${!deps_map[@]}"; do
+    while IFS= read -r dep; do
+      [[ -z "$dep" ]] && continue
+      dep=$(basename "$dep")
+      # Only count intra-group deps
+      if [[ -n "${group_basenames[$dep]+x}" ]]; then
+        in_degree["$fb"]=$(( ${in_degree["$fb"]} + 1 ))
+      fi
+    done <<< "${deps_map[$fb]}"
+  done
+
+  # Process nodes with in_degree 0
+  local -a queue=()
+  for fb in "${!in_degree[@]}"; do
+    if [[ ${in_degree["$fb"]} -eq 0 ]]; then
+      queue+=("$fb")
+    fi
+  done
+  # Sort queue for stable ordering (filesystem alphabetical)
+  IFS=$'\n' queue=($(sort <<< "${queue[*]}")); unset IFS
+
+  while [[ ${#queue[@]} -gt 0 ]]; do
+    local current="${queue[0]}"
+    queue=("${queue[@]:1}")
+    ordered+=("$current")
+    seen["$current"]=1
+
+    # Find plans that depend on current
+    for fb in "${!deps_map[@]}"; do
+      [[ -n "${seen[$fb]+x}" ]] && continue
+      while IFS= read -r dep; do
+        [[ -z "$dep" ]] && continue
+        dep=$(basename "$dep")
+        if [[ "$dep" == "$current" ]]; then
+          in_degree["$fb"]=$(( ${in_degree["$fb"]} - 1 ))
+          if [[ ${in_degree["$fb"]} -eq 0 ]]; then
+            queue+=("$fb")
+          fi
+        fi
+      done <<< "${deps_map[$fb]}"
+    done
+    # Re-sort queue for stable ordering
+    if [[ ${#queue[@]} -gt 1 ]]; then
+      IFS=$'\n' queue=($(sort <<< "${queue[*]}")); unset IFS
+    fi
+  done
+
+  # Output full paths in topological order
+  for fb in "${ordered[@]}"; do
+    echo "$BACKLOG_DIR/$fb"
+  done
 }
 
 # Return dependency status for a plan basename:


### PR DESCRIPTION
## Plan

# Plan: Group Mode Foundation — Parsing and Helper Functions

> Add the foundational functions for group mode: YAML frontmatter extraction for `group:`, `.group-state` file management, and group plan collection with topological ordering. These are pure additions — no existing behavior is modified, no existing functions are changed. All new functions are called from subsequent plans.

## Background

Ralph currently processes one plan per branch/PR cycle (`detect_plan()` → branch → iterate → archive → `create_pr()` → loop). Plans can declare `depends-on` in YAML frontmatter, parsed by `extract_depends_on()` at ~line 549 of `templates/ralph/ralph.sh`.

Group mode will allow multiple plans to share a single branch and PR by declaring `group: <name>` in their YAML frontmatter. This foundation plan adds the parsing and state management functions that the execution plan will wire into the main loop.

### What exists

- `extract_depends_on()` (~line 549): Parses `depends-on` from YAML frontmatter using awk. Handles inline arrays and multiline lists. This is the pattern to follow for `extract_group()`.
- `dependency_status()` (~line 615): Checks if a dependency is done/pending/missing by looking in `$ARCHIVE_DIR`, `$WIP_DIR`, `$BACKLOG_DIR`.
- `plan_readiness()` (~line 633): Returns "ready" or "blocked:<reasons>" based on dependency status.
- Directory variables: `$WIP_DIR` (`.ralph/in-progress/`), `$BACKLOG_DIR` (`.ralph/backlog/`), `$ARCHIVE_DIR` (`.ralph/out/`).
- `format_file_ref()`: Formats file paths for agent prompts based on `$PROMPT_MODE`.

### What doesn't exist

- No `group:` frontmatter parsing.
- No `.group-state` file concept.
- No function to collect and order multiple plans for a group.

## Acceptance Criteria

- [ ] `extract_group()` correctly parses `group: <name>` from YAML frontmatter (returns empty string if absent)
- [ ] `extract_group()` handles edge cases: no frontmatter, empty group value, quoted values, whitespace
- [ ] `read_group_state()` reads `.ralph/in-progress/.group-state` key-value pairs into shell variables
- [ ] `write_group_state()` creates/overwrites `.group-state` with provided key-value data
- [ ] `cleanup_group_state()` removes `.group-state` file
- [ ] `collect_group_plans()` finds all backlog plans matching a group name
- [ ] `collect_group_plans()` returns plans in dependency order (topological sort within the group)
- [ ] Plans with no intra-group `depends-on` are returned in filesystem order (stable, predictable)
- [ ] All existing tests continue to pass (`pnpm test`)
- [ ] `shellcheck templates/ralph/ralph.sh` produces no new warnings
- [ ] No existing function signatures or behavior changed

## Implementation Tasks

### Task 1: Add `extract_group()` function

**File:** `templates/ralph/ralph.sh`

**Where:** Immediately after `extract_depends_on()` (~line 610), before `dependency_status()` (~line 615).

**What:** Add a function that extracts the `group:` value from YAML frontmatter. Pattern follows `extract_depends_on()` but is simpler — `group` is a scalar value, not an array.

```bash
# Extract group name from YAML frontmatter (returns empty if not set)
# Supported form: group: my-feature-name
extract_group() {
  local file="$1"
  if [[ ! -f "$file" ]] || [[ "$(head -1 "$file" 2>/dev/null)" != "---" ]]; then
    return 0
  fi
  awk '
    BEGIN { in_fm=0 }
    NR==1 && $0=="---" { in_fm=1; next }
    in_fm && $0=="---" { exit }
    in_fm && match($0, /^[[:space:]]*group:[[:space:]]*(.+)/, arr) {
      val=arr[1]
      gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
      gsub(/^"|"$/, "", val)
      gsub(/^\047|\047$/, "", val)
      if (val != "") print val
      exit
    }
  ' "$file"
}
```

**Key insight:** Uses GNU awk `match()` with capture groups. The existing `extract_depends_on()` uses a similar awk pattern, so GNU awk is already a dependency. Only prints if non-empty, exits after first match (scalar, not array). Strips quotes and whitespace like the depends-on parser.

### Task 2: Add `.group-state` management functions

**File:** `templates/ralph/ralph.sh`

**Where:** Immediately after `extract_group()` (added in Task 1), before `dependency_status()`.

**What:** Three functions to manage the `.group-state` file in `.ralph/in-progress/`:

```bash
GROUP_STATE_FILE="$WIP_DIR/.group-state"

# Write group state (key=value file)
# Usage: write_group_state "group=my-feature" "branch=ralph/my-feature" "plans_total=5" ...
write_group_state() {
  mkdir -p "$WIP_DIR"
  printf '%s\n' "$@" > "$GROUP_STATE_FILE"
}

# Read group state into caller's scope. Sets variables like GROUP_NAME, GROUP_BRANCH, etc.
# Returns 1 if no state file exists.
read_group_state() {
  [[ -f "$GROUP_STATE_FILE" ]] || return 1
  local line key val
  while IFS='=' read -r key val; do
    [[ -z "$key" || "$key" == \#* ]] && continue
    case "$key" in
      group)           GROUP_NAME="$val" ;;
      branch)          GROUP_BRANCH="$val" ;;
      plans_total)     GROUP_PLANS_TOTAL="$val" ;;
      plans_completed) GROUP_PLANS_COMPLETED="$val" ;;
      current_plan)    GROUP_CURRENT_PLAN="$val" ;;
      pr_url)          GROUP_PR_URL="$val" ;;
    esac
  done < "$GROUP_STATE_FILE"
}

# Remove group state file (called when group completes or is abandoned)
cleanup_group_state() {
  rm -f "$GROUP_STATE_FILE"
}
```

**Key insight:** The `$WIP_DIR` variable is already defined earlier in the script (~line 48). The `GROUP_STATE_FILE` variable should be defined near the other directory variable declarations. `read_group_state()` uses a whitelist `case` statement to avoid arbitrary variable injection from file contents — only known keys are accepted.

### Task 3: Add `collect_group_plans()` function

**File:** `templates/ralph/ralph.sh`

**Where:** After the `.group-state` functions (Task 2), before `dependency_status()`.

**What:** Given a group name, scan the backlog for all plans with matching `group:` frontmatter and return them in dependency order.

```bash
# Collect all backlog plans belonging to a group, in dependency order.
# Outputs one plan path per line. Plans with no intra-group deps come first (stable filesystem order).
# Usage: mapfile -t plans < <(collect_group_plans "my-feature")
collect_group_plans() {
  local group_name="$1"
  local -a group_files=()
  local -a ordered=()
  local -A seen=()
  local -A deps_map=()

  # Scan backlog for matching group
  for f in "$BACKLOG_DIR"/*.md; do
    [[ -f "$f" ]] || continue
    local fg
    fg=$(extract_group "$f")
    if [[ "$fg" == "$group_name" ]]; then
      group_files+=("$f")
      local fb
      fb=$(basename "$f")
      # Store intra-group deps (only deps that are also in this group)
      local dep_list
      dep_list=$(extract_depends_on "$f")
      deps_map["$fb"]="$dep_list"
    fi
  done

  # Build set of group basenames for filtering
  local -A group_basenames=()
  for f in "${group_files[@]}"; do
    group_basenames["$(basename "$f")"]=1
  done

  # Topological sort (Kahn's algorithm) on intra-group dependencies
  # Ignore deps that point outside the group (they're handled by plan_readiness)
  local -A in_degree=()
  for f in "${group_files[@]}"; do
    local fb
    fb=$(basename "$f")
    in_degree["$fb"]=0
  done

  for fb in "${!deps_map[@]}"; do
    while IFS= read -r dep; do
      [[ -z "$dep" ]] && continue
      dep=$(basename "$dep")
      # Only count intra-group deps
      if [[ -n "${group_basenames[$dep]+x}" ]]; then
        in_degree["$fb"]=$(( ${in_degree["$fb"]} + 1 ))
      fi
    done <<< "${deps_map[$fb]}"
  done

  # Process nodes with in_degree 0
  local -a queue=()
  for fb in "${!in_degree[@]}"; do
    if [[ ${in_degree["$fb"]} -eq 0 ]]; then
      queue+=("$fb")
    fi
  done
  # Sort queue for stable ordering (filesystem alphabetical)
  IFS=$'\n' queue=($(sort <<< "${queue[*]}")); unset IFS

  while [[ ${#queue[@]} -gt 0 ]]; do
    local current="${queue[0]}"
    queue=("${queue[@]:1}")
    ordered+=("$current")
    seen["$current"]=1

    # Find plans that depend on current
    for fb in "${!deps_map[@]}"; do
      [[ -n "${seen[$fb]+x}" ]] && continue
      while IFS= read -r dep; do
        [[ -z "$dep" ]] && continue
        dep=$(basename "$dep")
        if [[ "$dep" == "$current" ]]; then
          in_degree["$fb"]=$(( ${in_degree["$fb"]} - 1 ))
          if [[ ${in_degree["$fb"]} -eq 0 ]]; then
            queue+=("$fb")
          fi
        fi
      done <<< "${deps_map[$fb]}"
    done
    # Re-sort queue for stable ordering
    if [[ ${#queue[@]} -gt 1 ]]; then
      IFS=$'\n' queue=($(sort <<< "${queue[*]}")); unset IFS
    fi
  done

  # Output full paths in topological order
  for fb in "${ordered[@]}"; do
    echo "$BACKLOG_DIR/$fb"
  done
}
```

**Key insight:** Uses Kahn's algorithm for topological sort. Only considers intra-group dependencies — cross-group deps are filtered out (those are handled by `plan_readiness()` at the backlog level). Stable alphabetical ordering for plans with no ordering constraint. The `mapfile` usage pattern matches existing bash conventions in the script.

### Task 4: Add `GROUP_STATE_FILE` variable declaration

**File:** `templates/ralph/ralph.sh`

**Where:** Near the existing directory variable declarations. Find where `PROGRESS_FILE` is defined (search for `PROGRESS_FILE=`) and add `GROUP_STATE_FILE` nearby.

**What:** A single line:
```bash
GROUP_STATE_FILE="$WIP_DIR/.group-state"
```

**Key insight:** Ensure this variable is declared before any function that references it. If it's already declared inline in Task 2's function block, move it to the top-level declarations section and remove the duplicate.

## Verification

- `shellcheck templates/ralph/ralph.sh` — no new warnings
- `pnpm test` — all existing tests pass (these are TypeScript CLI tests; they exercise `ralph.ts`, not `ralph.sh` directly, so no regressions expected)
- `pnpm build` — builds successfully
- Manual verification: create a test plan with `group: test-feature` frontmatter and confirm `extract_group()` returns `test-feature`
- Manual verification: call `write_group_state` with test values, then `read_group_state` and confirm variables are set
- Manual verification: create 3 plans with `group: foo` and chained `depends-on`, run `collect_group_plans "foo"`, confirm correct topological order

## Commits

```
d8968b9 feat(ralph): add group mode foundation — parsing and state management
```