### PR TITLE
Plan: Group-Aware Plan Selection and Branch Strategy

### DIFF
--- a/templates/ralph/ralph.sh
+++ b/templates/ralph/ralph.sh
@@ -1913,6 +1913,21 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "[dry-run] Plan: $(basename "${WIP_FILES[0]}")"
   echo "[dry-run] Description: $PLAN_DESC"
 
+  dry_group=$(extract_group "${WIP_FILES[0]}")
+  if [[ -n "$dry_group" ]]; then
+    echo "[dry-run] Group: $dry_group"
+    echo "[dry-run] Branch would be: ralph/$dry_group"
+    dry_group_members=()
+    mapfile -t dry_group_members < <(collect_group_plans "$dry_group")
+    echo "[dry-run] Group plans (${#dry_group_members[@]} remaining in backlog + 1 selected):"
+    echo "[dry-run]   1. $(basename "${WIP_FILES[0]}") (selected)"
+    gn=2
+    for gm in "${dry_group_members[@]}"; do
+      echo "[dry-run]   $gn. $(basename "$gm")"
+      gn=$((gn + 1))
+    done
+  fi
+
   if [[ "$RESUMING" == true ]]; then
     current_branch=$(git rev-parse --abbrev-ref HEAD)
     echo "[dry-run] Mode: resume in-progress"
@@ -1929,9 +1944,13 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "[dry-run] Would initialize: $PROGRESS_FILE"
   else
     plan_basename=$(basename "${WIP_FILES[0]}")
-    slug="${plan_basename#prd-}"
-    slug="${slug%.md}"
-    branch="ralph/${slug}"
+    if [[ -n "${dry_group:-}" ]]; then
+      branch="ralph/${dry_group}"
+    else
+      slug="${plan_basename#prd-}"
+      slug="${slug%.md}"
+      branch="ralph/${slug}"
+    fi
     if git show-ref --verify --quiet "refs/heads/ralph"; then
       echo "[dry-run] WARNING: Branch 'ralph' exists and would block creation of '$branch'."
       echo "[dry-run] Fix: git branch -m ralph ralph-legacy  OR  git branch -D ralph"
@@ -2156,10 +2175,32 @@ If all tasks are complete, output <promise>COMPLETE</promise> — but ONLY after
       echo ""
       echo "Plan complete after $i iterations: $PLAN_DESC"
       archive_run
-      if [[ "$MODE" == "pr" ]]; then
-        create_pr "$branch" "$PLAN_DESC"
-      else
-        echo "Direct mode: commits are on branch '$branch'. No PR created."
+
+      if [[ -n "${GROUP_NAME:-}" ]]; then
+        # Group mode: try to advance to next plan
+        if advance_group_plan; then
+          echo ""
+          echo "=== Continuing group '$GROUP_NAME': $(basename "${WIP_FILES[0]}") ==="
+          # Reset iteration tracking for next plan
+          i=0
+          stuck_count=0
+          last_hash=$(git rev-parse HEAD)
+          # Re-initialize progress file for the new plan
+          echo "## Progress Log" > "$PROGRESS_FILE"
+          echo "" >> "$PROGRESS_FILE"
+          echo "Initialized $PROGRESS_FILE for $(basename "${WIP_FILES[0]}")"
+          continue  # Continue the iteration loop with the new plan
+        fi
+        # Group complete — PR creation handled by prd-group-mode-pr-lifecycle
+        echo "Group '$GROUP_NAME' finished. All plans completed."
+      fi
+
+      if [[ -z "${GROUP_NAME:-}" ]]; then
+        if [[ "$MODE" == "pr" ]]; then
+          create_pr "$branch" "$PLAN_DESC"
+        else
+          echo "Direct mode: commits are on branch '$branch'. No PR created."
+        fi
       fi
       plans_completed=$((plans_completed + 1))
       completed=true


### PR DESCRIPTION
## Plan

---
depends-on: [prd-group-mode-foundation.md]
---

# Plan: Group-Aware Plan Selection and Branch Strategy

> Modify `detect_plan()` and the main loop in `ralph.sh` to support group mode. When a plan with `group: <name>` is selected, ralph collects all plans in that group, creates a single `ralph/<group-name>` branch, and sequences through them on the same branch — transitioning between plans without switching branches. Non-grouped plans continue to work exactly as before.

## Background

The foundation plan (`prd-group-mode-foundation.md`) adds `extract_group()`, `.group-state` management functions, and `collect_group_plans()`. This plan wires those functions into the existing control flow.

### What exists (after foundation plan)

- `extract_group()`: Returns group name from plan frontmatter, or empty string.
- `read_group_state()` / `write_group_state()` / `cleanup_group_state()`: Manage `.ralph/in-progress/.group-state`.
- `collect_group_plans()`: Returns sorted list of backlog plans for a group name.
- `detect_plan()` (~line 1355): Checks in-progress first, then scans backlog, filters by dependency readiness, picks one plan (LLM selects if multiple). Moves chosen plan to `$WIP_DIR`.
- Branch creation (~line 1690): Derives `ralph/<slug>` from plan filename, creates branch from `$BASE_BRANCH`.
- Iteration loop (~line 1738): Runs agent iterations for one plan. On completion: `archive_run()` → `create_pr()` → increment counter → `break` back to outer loop.
- Outer loop (~line 1628): `while true` — calls `detect_plan()`, runs iteration loop, repeats.

### What needs to change

- `detect_plan()` must detect group context: if picked plan has `group:`, collect all group plans and initialize group state.
- `detect_plan()` must also detect *resumed* group context: if `.group-state` exists, pick the next group plan instead of scanning backlog.
- Branch creation must use `ralph/<group-name>` for grouped plans, and stay on the existing branch for subsequent group plans.
- Post-completion flow (in the main loop) must transition to the next group plan instead of looping back to `detect_plan()` for a fresh backlog scan.
- `archive_run()` must update `.group-state` after each group plan completes.

## Acceptance Criteria

- [ ] When a plan with `group: foo` is selected from backlog, all other `group: foo` plans are identified and ordered
- [ ] Group branch is named `ralph/<group-name>` (not `ralph/<plan-slug>`)
- [ ] First group plan creates the branch; subsequent group plans reuse it (no checkout/branch creation)
- [ ] `.group-state` is written when a group starts and updated after each plan completes
- [ ] After a group plan completes, the next group plan is moved from backlog to in-progress automatically
- [ ] Iteration budget resets for each group plan
- [ ] Non-grouped plans work exactly as before (no behavioral change)
- [ ] Resuming a group (`.group-state` exists) picks up the current group plan on the existing group branch
- [ ] `shellcheck templates/ralph/ralph.sh` produces no new warnings
- [ ] All existing tests continue to pass (`pnpm test`)

## Implementation Tasks

### Task 1: Modify `detect_plan()` to handle group resume

**File:** `templates/ralph/ralph.sh`

**Where:** Inside `detect_plan()` (~line 1355), in the resume detection block (~line 1365).

**What:** After detecting in-progress `.md` files, also check if `.group-state` exists. If it does, read the group state to restore `GROUP_NAME`, `GROUP_BRANCH`, etc. This ensures the outer loop knows it's in a group context when resuming.

Add after the existing resume block:
```bash
# Check for group context alongside resume
if [[ -f "$GROUP_STATE_FILE" ]]; then
  read_group_state
  echo "Resuming group '$GROUP_NAME' (plan ${GROUP_PLANS_COMPLETED}/${GROUP_PLANS_TOTAL} completed)"
fi
```

**Key insight:** Group resume and single-plan resume are not mutually exclusive. A group always has exactly one plan in `$WIP_DIR` — the currently active one. The `.group-state` file adds *group context* on top of the normal resume mechanism.

### Task 2: Modify `detect_plan()` to initialize group on fresh selection

**File:** `templates/ralph/ralph.sh`

**Where:** Inside `detect_plan()`, after the plan is chosen and moved to `$WIP_DIR` (~line 1490).

**What:** After moving the chosen plan to `$WIP_DIR`, check if it has a `group:` value. If yes:
1. Call `collect_group_plans()` to get the remaining group plans (those still in backlog).
2. Initialize `.group-state` with group metadata.
3. Set `GROUP_NAME` variable for the branch strategy to detect.

```bash
# Check if chosen plan is part of a group
local chosen_group
chosen_group=$(extract_group "$dest")
if [[ -n "$chosen_group" ]]; then
  # Collect remaining group plans (still in backlog, excluding the one we just moved)
  local remaining_group_plans
  mapfile -t remaining_group_plans < <(collect_group_plans "$chosen_group")
  local total_count=$(( ${#remaining_group_plans[@]} + 1 ))  # +1 for the one we moved

  GROUP_NAME="$chosen_group"
  GROUP_PLANS_TOTAL="$total_count"
  GROUP_PLANS_COMPLETED=0
  GROUP_CURRENT_PLAN="$dest_basename"
  GROUP_PR_URL=""

  write_group_state \
    "group=$GROUP_NAME" \
    "branch=" \
    "plans_total=$GROUP_PLANS_TOTAL" \
    "plans_completed=$GROUP_PLANS_COMPLETED" \
    "current_plan=$GROUP_CURRENT_PLAN" \
    "pr_url="

  echo "Group '$GROUP_NAME' detected: $total_count plan(s) total"
  echo "Plan order:"
  echo "  1. $dest_basename (current)"
  local n=2
  for rp in "${remaining_group_plans[@]}"; do
    echo "  $n. $(basename "$rp")"
    n=$((n + 1))
  done
fi
```

**Key insight:** The branch name is left empty in `.group-state` initially — it gets filled in during the branch creation step (Task 3). The `collect_group_plans()` output excludes the already-moved plan because it's no longer in `$BACKLOG_DIR`.

### Task 3: Modify branch creation for group branches

**File:** `templates/ralph/ralph.sh`

**Where:** In the PR mode branch creation block (~line 1690), the section that derives `slug` from `plan_basename`.

**What:** Add a group-aware branch naming path. If `GROUP_NAME` is set, use `ralph/<group-name>` instead of `ralph/<plan-slug>`. Also update `.group-state` with the branch name.

Replace the slug derivation block with:
```bash
if [[ -n "${GROUP_NAME:-}" ]]; then
  # Group mode: branch named after the group
  branch="ralph/${GROUP_NAME}"
else
  # Normal mode: branch named after the plan
  slug="${plan_basename#prd-}"
  slug="${slug%.md}"
  branch="ralph/${slug}"
fi
```

After the branch is created (`git checkout -b "$branch"`), add:
```bash
# Update group state with branch name
if [[ -n "${GROUP_NAME:-}" && -f "$GROUP_STATE_FILE" ]]; then
  GROUP_BRANCH="$branch"
  write_group_state \
    "group=$GROUP_NAME" \
    "branch=$GROUP_BRANCH" \
    "plans_total=$GROUP_PLANS_TOTAL" \
    "plans_completed=$GROUP_PLANS_COMPLETED" \
    "current_plan=$GROUP_CURRENT_PLAN" \
    "pr_url=${GROUP_PR_URL:-}"
fi
```

**Key insight:** The existing collision check and `ralph` bare-branch guard still apply — they work on `$branch` regardless of how it was derived. No changes needed to those safety checks.

### Task 4: Add group plan transition function

**File:** `templates/ralph/ralph.sh`

**Where:** After `archive_run()` (~line 1315), before `create_pr()`.

**What:** Add `advance_group_plan()` — moves the next group plan from backlog to in-progress and updates `.group-state`. Returns 0 if a next plan was found, 1 if group is complete.

```bash
# Advance to the next plan in a group. Moves next plan from backlog to in-progress.
# Returns 0 if next plan loaded, 1 if group is complete (no more plans).
advance_group_plan() {
  [[ -n "${GROUP_NAME:-}" ]] || return 1

  GROUP_PLANS_COMPLETED=$((GROUP_PLANS_COMPLETED + 1))

  # Find next ready group plan from backlog
  local next_plan=""
  local candidates
  mapfile -t candidates < <(collect_group_plans "$GROUP_NAME")

  for f in "${candidates[@]}"; do
    [[ -f "$f" ]] || continue
    local readiness
    readiness=$(plan_readiness "$f")
    if [[ "$readiness" == "ready" ]]; then
      next_plan="$f"
      break
    fi
  done

  if [[ -z "$next_plan" ]]; then
    # No more group plans ready — group is complete
    echo "Group '$GROUP_NAME' complete ($GROUP_PLANS_COMPLETED/$GROUP_PLANS_TOTAL plans)"
    return 1
  fi

  # Move next plan to in-progress
  local next_basename
  next_basename=$(basename "$next_plan")
  local dest="$WIP_DIR/$next_basename"
  mv "$next_plan" "$dest"
  echo "Advanced to next group plan: $next_basename"

  # Update tracking
  WIP_FILES=("$dest")
  FILE_REFS=" $(format_file_ref "$dest")"
  GROUP_CURRENT_PLAN="$next_basename"
  PLAN_DESC=$(plan_description "$dest")

  write_group_state \
    "group=$GROUP_NAME" \
    "branch=$GROUP_BRANCH" \
    "plans_total=$GROUP_PLANS_TOTAL" \
    "plans_completed=$GROUP_PLANS_COMPLETED" \
    "current_plan=$GROUP_CURRENT_PLAN" \
    "pr_url=${GROUP_PR_URL:-}"

  return 0
}
```

**Key insight:** Uses `plan_readiness()` to respect dependencies — if the next group plan depends on the one just completed, it will be "ready" because `archive_run()` already moved the completed plan to `$ARCHIVE_DIR` (so `dependency_status()` returns "done"). This is the key insight that makes intra-group deps work without code changes to the dependency system.

### Task 5: Modify post-completion flow for group transitions

**File:** `templates/ralph/ralph.sh`

**Where:** In the main loop, inside the completion check block (~line 1827 where `<promise>COMPLETE</promise>` is detected).

**What:** After `archive_run()`, if we're in a group, call `advance_group_plan()` instead of immediately creating a PR and breaking. If more group plans remain, reset the iteration counter and continue the outer loop (which restarts with the next plan). If no more group plans remain, create the PR and break.

Current flow:
```bash
if [[ "$result" == *"<promise>COMPLETE</promise>"* ]]; then
  archive_run
  if [[ "$MODE" == "pr" ]]; then
    create_pr "$branch" "$PLAN_DESC"
  fi
  plans_completed=$((plans_completed + 1))
  completed=true
  break
fi
```

New flow:
```bash
if [[ "$result" == *"<promise>COMPLETE</promise>"* ]]; then
  echo ""
  echo "Plan complete after $i iterations: $PLAN_DESC"
  archive_run

  if [[ -n "${GROUP_NAME:-}" ]]; then
    # Group mode: try to advance to next plan
    if advance_group_plan; then
      echo ""
      echo "=== Continuing group '$GROUP_NAME': $(basename "${WIP_FILES[0]}") ==="
      # Reset iteration tracking for next plan
      i=0
      stuck_count=0
      last_hash=$(git rev-parse HEAD)
      # Re-initialize progress file for the new plan
      echo "## Progress Log" > "$PROGRESS_FILE"
      echo "" >> "$PROGRESS_FILE"
      echo "Initialized $PROGRESS_FILE for $(basename "${WIP_FILES[0]}")"
      continue  # Continue the iteration loop with the new plan
    fi
    # Group complete — PR creation handled by plan 3 (prd-group-mode-pr-lifecycle)
  fi

  if [[ "$MODE" == "pr" && -z "${GROUP_NAME:-}" ]]; then
    create_pr "$branch" "$PLAN_DESC"
  fi
  plans_completed=$((plans_completed + 1))
  completed=true
  break
fi
```

**Key insight:** The `continue` statement stays in the *iteration* while loop (not the outer `while true`), so the next group plan runs with a fresh iteration counter on the same branch. The `PLAN_DESC` is updated by `advance_group_plan()` via `plan_description()`. PR creation for groups is deferred to the PR lifecycle plan. For now, group completion just breaks out like a normal plan — the PR lifecycle plan will add draft PR support.

### Task 6: Update dry-run to show group information

**File:** `templates/ralph/ralph.sh`

**Where:** In the dry-run block (~line 1595), after plan detection.

**What:** If the detected plan has a `group:` value, show the group info (member plans and order) in the dry-run output.

After `echo "[dry-run] Description: $PLAN_DESC"`, add:
```bash
local dry_group
dry_group=$(extract_group "${WIP_FILES[0]}")
if [[ -n "$dry_group" ]]; then
  echo "[dry-run] Group: $dry_group"
  echo "[dry-run] Branch would be: ralph/$dry_group"
  local group_members
  mapfile -t group_members < <(collect_group_plans "$dry_group")
  echo "[dry-run] Group plans (${#group_members[@]} remaining in backlog + 1 selected):"
  echo "[dry-run]   1. $(basename "${WIP_FILES[0]}") (selected)"
  local gn=2
  for gm in "${group_members[@]}"; do
    echo "[dry-run]   $gn. $(basename "$gm")"
    gn=$((gn + 1))
  done
fi
```

## Verification

- `shellcheck templates/ralph/ralph.sh` — no new warnings
- `pnpm test` — all existing tests pass
- `pnpm build` — builds successfully
- **Scenario A (non-group regression):** Run with a single plan without `group:` frontmatter. Confirm behavior is identical to before — own branch, own PR, normal lifecycle.
- **Scenario B (group start):** Place 3 plans with `group: test-feat` in backlog (plan-2 depends on plan-1, plan-3 depends on plan-2). Run ralph. Confirm:
  - Branch created as `ralph/test-feat`
  - Plans execute in order: plan-1 → plan-2 → plan-3
  - All three run on same branch without branch switching
  - `.group-state` updated after each plan
  - Plans archived to `out/` after each completes
- **Scenario C (group dry-run):** Run with `--dry-run` and grouped plans. Confirm group info shown.
- **Scenario D (group resume):** Interrupt ralph mid-group (after plan-1 completes, during plan-2). Re-run. Confirm it resumes on the group branch with plan-2.

## Commits

```
85e5831 feat(ralph.sh): add group plan transitions and dry-run group display
a880fb4 feat(ralph.sh): add advance_group_plan() for group plan transitions
f510533 feat(ralph.sh): use group-named branches for grouped plans
eac8d9e feat(ralph.sh): initialize group state when selecting grouped plan from backlog
5c6cb57 feat(ralph.sh): add group mode foundation functions and detect_plan() group resume
```