### PR TITLE
Plan: Fix docs — pipeline directory count and plan selection wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Or call the shell script directly:
 ./.ralph/ralph.sh
 ```
 
-Ralph picks the best plan from the backlog, creates a `ralph/*` branch, hands the plan to your agent, and loops: build, test, lint after every iteration. When a plan is done, it pushes the branch and opens a pull request. Defaults to 5 iterations per plan (e.g. `./.ralph/ralph.sh 3` for 3). If a plan isn't finished, it stays in `pipeline/in-progress/` on the branch — just run again to resume.
+Ralph picks a plan from the backlog, creates a `ralph/*` branch, hands the plan to your agent, and loops: build, test, lint after every iteration. When a plan is done, it pushes the branch and opens a pull request. Defaults to 5 iterations per plan (e.g. `./.ralph/ralph.sh 3` for 3). If a plan isn't finished, it stays in `pipeline/in-progress/` on the branch — just run again to resume.
 
 ### 3. Steer
 

--- a/templates/ralph/README.md
+++ b/templates/ralph/README.md
@@ -26,7 +26,7 @@ npx ralphai run -- 5 --resume
 
 ## Lifecycle
 
-Plans flow through three directories:
+Plans flow through four directories:
 
 ```
 wip/ (work in progress)  backlog/  -->  in-progress/  -->  out/


### PR DESCRIPTION
## Plan

# Plan: Fix docs — pipeline directory count and plan selection wording

> Two small copy fixes across README.md and the .ralph/README.md template. One says "three directories" but lists four; the other overstates how plan selection works.

## Background

The project has three doc files that describe the plan lifecycle and selection:
- `README.md` (repo root) — user-facing quickstart
- `templates/ralph/README.md` — scaffolded into `.ralph/README.md` on init
- `docs/HOW-RALPHAI-WORKS.md` — deep-dive reference

`HOW-RALPHAI-WORKS.md` and `.ralph/README.md` both correctly explain that LLM selection only fires when multiple dependency-ready plans exist. The root `README.md` says "picks the best plan" unconditionally, which overstates the single-plan case (where it just grabs the only ready plan).

Separately, `templates/ralph/README.md` line 29 says "Plans flow through three directories" but then lists four (`wip/`, `backlog/`, `in-progress/`, `out/`).

## Acceptance Criteria

- [ ] `templates/ralph/README.md` says "four directories" (not "three")
- [ ] `README.md` plan selection sentence no longer implies LLM selection always happens
- [ ] Wording stays concise — no over-explaining
- [ ] No other docs are changed

## Implementation Tasks

### Task 1: Fix directory count in templates/ralph/README.md

**File:** `templates/ralph/README.md`

**What:** On line 29, change "Plans flow through three directories:" to "Plans flow through four directories:". The file already lists all four (`wip/`, `backlog/`, `in-progress/`, `out/`) — only the count word is wrong.

### Task 2: Fix plan selection wording in README.md

**File:** `README.md`

**What:** On line 53, the sentence starts with "Ralph picks the best plan from the backlog". Change it to something like "Ralph picks a plan from the backlog" — drop "the best" since LLM selection only happens when multiple dependency-ready plans are available. The rest of the sentence is fine as-is.

## Verification

- Read both files and confirm the changes read naturally.
- `HOW-RALPHAI-WORKS.md` should not be modified (it's already accurate).

## Commits

```
f976fee docs: fix directory count and plan selection wording
```