### PR TITLE
fix: use inherited stdio for run command to show real-time output

### DIFF
--- a/src/ralph.ts
+++ b/src/ralph.ts
@@ -937,10 +937,8 @@ function runRalphRunner(options: RalphOptions, cwd: string): void {
     options.runArgs.length > 0 ? options.runArgs : [DEFAULT_ITERATIONS];
   const result = spawnSync(ralphSh, args, {
     cwd,
-    stdio: ["inherit", "pipe", "pipe"],
+    stdio: "inherit",
   });
 
-  if (result.stdout?.length) process.stdout.write(result.stdout);
-  if (result.stderr?.length) process.stderr.write(result.stderr);
   process.exit(result.status ?? 1);
 }


### PR DESCRIPTION
The `run` command was using `stdio: ['inherit', 'pipe', 'pipe']`, which buffers stdout/stderr until the child process exits. Since `ralph.sh` is a long-running task runner, this meant no output was visible in the terminal until the entire run finished.

Changed to `stdio: 'inherit'` so all streams are connected directly to the terminal, giving real-time output.