### PR TITLE
chore: bump version to 0.2.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1
+
+### Fixes
+
+- Use inherited stdio for `run` command to show real-time output (#25)
+- Grant `contents:write` permission so publish workflow can create GitHub releases (#24)
+
 ## 0.2.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphai",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Autonomous task runner for AI coding agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version from 0.2.0 → 0.2.1 in `package.json`
- Add 0.2.1 section to `CHANGELOG.md` covering fixes since 0.2.0:
  - Use inherited stdio for `run` command to show real-time output (#25)
  - Grant `contents:write` permission so publish workflow can create GitHub releases (#24)