### PR TITLE
fix: make built ralphai run resolve its bundled runner

### DIFF
--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -9,7 +9,7 @@ import {
 } from "fs";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { fileURLToPath } from "url";
 import { runCli, runCliOutput, stripLogo } from "./test-utils.ts";
 import {
@@ -1445,6 +1445,49 @@ echo "$PROMPT_MODE"
         RALPHAI_RUNNER_SCRIPT: stubScript,
       });
       expect(result.stdout).toContain("ARGS:3 --resume");
+    });
+
+    it("built CLI can locate the bundled runner script", () => {
+      const repoRoot = join(__dirname, "..");
+      const distCli = join(repoRoot, "dist", "cli.mjs");
+
+      execSync("git checkout -b main", {
+        cwd: testDir,
+        stdio: "ignore",
+      });
+      execSync("git config user.name 'Test User'", {
+        cwd: testDir,
+        stdio: "ignore",
+      });
+      execSync("git config user.email 'test@example.com'", {
+        cwd: testDir,
+        stdio: "ignore",
+      });
+      execSync("git commit --allow-empty -m init", {
+        cwd: testDir,
+        stdio: "ignore",
+      });
+
+      execSync("pnpm build", {
+        cwd: repoRoot,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      const output = execFileSync(
+        "node",
+        [distCli, "run", "--dry-run"],
+        {
+          cwd: testDir,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+          env: {
+            ...process.env,
+            RALPHAI_NO_UPDATE_CHECK: "1",
+          },
+        },
+      );
+
+      expect(output).toContain("No runnable work found.");
     });
   });
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -902,6 +902,28 @@ function findBash(): string | null {
   return null;
 }
 
+function resolveBundledRunnerScript(moduleUrl: string): string {
+  if (process.env.RALPHAI_RUNNER_SCRIPT) {
+    return process.env.RALPHAI_RUNNER_SCRIPT;
+  }
+
+  const packageDir = join(dirname(fileURLToPath(moduleUrl)), "..");
+  const candidates = [
+    ["runner", "ralphai.sh"],
+    ["templates", "ralphai", "ralphai.sh"],
+  ].map((segments) => join(packageDir, ...segments));
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Could not locate bundled runner script. Tried: ${candidates.join(", ")}`,
+  );
+}
+
 function runRalphaiRunner(
   options: RalphaiOptions,
   cwd: string,
@@ -916,10 +938,15 @@ function runRalphaiRunner(
 
   // Resolve the runner script from the npm package (not the user's project).
   // RALPHAI_RUNNER_SCRIPT env var allows overriding for tests.
-  const __dir = dirname(fileURLToPath(import.meta.url));
-  const ralphaiSh =
-    process.env.RALPHAI_RUNNER_SCRIPT ||
-    join(__dir, "..", "runner", "ralphai.sh");
+  let ralphaiSh: string;
+  try {
+    ralphaiSh = resolveBundledRunnerScript(import.meta.url);
+  } catch (error) {
+    console.error(
+      `${TEXT}Error:${RESET} ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
 
   const args = options.runArgs.length > 0 ? options.runArgs : [DEFAULT_TURNS];
 
@@ -969,11 +996,25 @@ function runRalphaiRunner(
       });
     });
   } else {
-    // Unix: straightforward spawnSync with inherited stdio
+    // Unix: pipe output so parent processes can capture it in tests.
     const result = spawnSync(ralphaiSh, args, {
       cwd,
-      stdio: "inherit",
+      stdio: ["inherit", "pipe", "pipe"],
     });
+
+    if (result.stdout && result.stdout.length > 0) {
+      process.stdout.write(result.stdout);
+    }
+    if (result.stderr && result.stderr.length > 0) {
+      process.stderr.write(result.stderr);
+    }
+
+    if (result.error) {
+      console.error(
+        `${TEXT}Error:${RESET} Failed to start task runner ${ralphaiSh}: ${result.error.message}`,
+      );
+      process.exit(1);
+    }
 
     process.exit(result.status ?? 1);
   }


### PR DESCRIPTION
## Summary
- resolve the packaged runner script path at runtime instead of assuming a source-tree layout
- preserve capturable stdout/stderr and emit a clear startup error if the runner cannot be started
- add a regression test that builds and executes the packaged CLI directly

## Verification
- pnpm vitest --run src/ralphai.test.ts
- pnpm build
- ralphai run --dry-run