### PR TITLE
feat: show copy-pasteable git checkout command when direct mode blocks on main/master

### DIFF
--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -37,10 +37,26 @@ plans_completed=0
 if [[ "$MODE" == "direct" ]]; then
   current_branch=$(git rev-parse --abbrev-ref HEAD)
   if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
-    echo "ERROR: Direct mode cannot run on '$current_branch'."
+    echo "Direct mode cannot run on '$current_branch'."
     echo ""
-    echo "Switch to a feature branch, or run in PR mode:"
+    echo "Either run in PR mode (a branch and pull request are created for you):"
     echo "  ralphai run --pr"
+    # Peek at backlog to suggest a branch name
+    _first_plan=""
+    for _f in "$BACKLOG_DIR"/*.md; do
+      [[ -f "$_f" ]] && _first_plan="$_f" && break
+    done
+    if [[ -n "$_first_plan" ]]; then
+      _slug=$(basename "$_first_plan")
+      _slug="${_slug#prd-}"
+      _slug="${_slug%.md}"
+      echo ""
+      echo "Or switch to a feature branch:"
+      echo "  git checkout -b ralphai/${_slug}"
+    else
+      echo ""
+      echo "Or switch to a feature branch first."
+    fi
     exit 1
   fi
 fi

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -295,10 +295,8 @@ describe("ralphai command", () => {
     const ralphaiSh = readFileSync(join(templateDir, "ralphai.sh"), "utf-8");
     // Direct mode refuses to run on main or master
     expect(ralphaiSh).toContain("Direct mode cannot run on");
-    expect(ralphaiSh).toContain(
-      "Switch to a feature branch, or run in PR mode:",
-    );
     expect(ralphaiSh).toContain("ralphai run --pr");
+    expect(ralphaiSh).toContain("git checkout -b ralphai/");
   });
 
   it("scaffolded ralphai.sh skips create_pr in direct mode", () => {


### PR DESCRIPTION
## Summary

- Move the direct-mode `main`/`master` guard to fire **before** `detect_plan`, so the plan file is never moved to `in-progress` — no rollback needed
- Drop the `ERROR:` prefix for a friendlier tone
- Show two copy-pasteable options: PR mode and manual branch checkout
- Branch name in the `git checkout` suggestion is derived from the first backlog plan file

### Before
```
Single dependency-ready backlog plan found: .ralphai/pipeline/backlog/prd-direct-mode-single-plan-default.md
Moved .ralphai/pipeline/backlog/prd-direct-mode-single-plan-default.md -> .ralphai/pipeline/in-progress/prd-direct-mode-single-plan-default.md
ERROR: Direct mode cannot run on 'main'.
Switch to a feature branch, or use --pr mode.
Rolled back: moved plan to .ralphai/pipeline/backlog/prd-direct-mode-single-plan-default.md
```

### After
```
Direct mode cannot run on 'main'.

Either run in PR mode (a branch and pull request are created for you):
  ralphai run --pr

Or switch to a feature branch:
  git checkout -b ralphai/direct-mode-single-plan-default
```