### PR TITLE
Plan: Stream runner output in real time on Unix

### DIFF
--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1,4 +1,4 @@
-import { execSync, spawnSync, spawn } from "child_process";
+import { execSync, spawn } from "child_process";
 import {
   existsSync,
   mkdirSync,
@@ -952,16 +952,15 @@ function runRalphaiRunner(
 
   const isWindows = process.platform === "win32";
   // Git Bash / MSYS2 sets MSYSTEM; mintty-based terminals may also set
-  // TERM_PROGRAM=mintty.  In these environments `spawnSync` with
-  // `stdio: "inherit"` silently drops output because Node's synchronous
-  // child-process implementation cannot write to the mintty pty.
+  // TERM_PROGRAM=mintty.  In these environments Node cannot directly
+  // execute `.sh` files, so we need to locate `bash.exe` explicitly.
   const isMsys = !!(
     process.env.MSYSTEM || process.env.TERM_PROGRAM === "mintty"
   );
 
   if (isWindows || isMsys) {
-    // On Windows / MSYS: use async spawn with explicit bash to avoid
-    // swallowed output.
+    // On Windows / MSYS: locate bash explicitly since Node cannot run
+    // `.sh` files directly on this platform.
     const bash = findBash();
     if (!bash) {
       console.error(
@@ -996,26 +995,27 @@ function runRalphaiRunner(
       });
     });
   } else {
-    // Unix: pipe output so parent processes can capture it in tests.
-    const result = spawnSync(ralphaiSh, args, {
+    // Unix: use async spawn with piped output so users see output in real
+    // time AND parent processes (e.g. test harness) can still capture it.
+    const child = spawn(ralphaiSh, args, {
       cwd,
       stdio: ["inherit", "pipe", "pipe"],
+      env: { ...process.env },
     });
 
-    if (result.stdout && result.stdout.length > 0) {
-      process.stdout.write(result.stdout);
-    }
-    if (result.stderr && result.stderr.length > 0) {
-      process.stderr.write(result.stderr);
-    }
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
 
-    if (result.error) {
-      console.error(
-        `${TEXT}Error:${RESET} Failed to start task runner ${ralphaiSh}: ${result.error.message}`,
-      );
-      process.exit(1);
-    }
-
-    process.exit(result.status ?? 1);
+    return new Promise((_resolve, _reject) => {
+      child.on("close", (code) => {
+        process.exit(code ?? 1);
+      });
+      child.on("error", (err) => {
+        console.error(
+          `${TEXT}Error:${RESET} Failed to start task runner ${ralphaiSh}: ${err.message}`,
+        );
+        process.exit(1);
+      });
+    });
   }
 }


### PR DESCRIPTION
## Plan

# Plan: Stream runner output in real time on Unix

> Replace the synchronous `spawnSync` call for the Unix runner path with async
> `spawn` + pipe, so users see agent output as it happens instead of waiting
> for the entire run to finish.

## Background

The `run` command in `src/ralphai.ts` (~line 1000) spawns the runner script via
`spawnSync` on Unix. This buffers all stdout/stderr until the child exits, which
means users see zero output during long agent runs — it looks like the process
is hanging.

The Windows/MSYS branch (~line 977) already uses async `spawn` with
`child.stdout.pipe(process.stdout)` and `child.stderr.pipe(process.stderr)`,
which streams output in real time. The Unix path should do the same.

Test captureability is preserved because `pipe` mode writes to the Node process's
stdout/stderr, which `execFileSync` in test-utils.ts captures via `stdio: "pipe"`.
The AGENTS.md guidance about `stdio: ["inherit", "pipe", "pipe"]` + manual write
applies to `spawnSync`; async `spawn` + `.pipe()` achieves the same result with
real-time streaming.

## Acceptance Criteria

- [ ] `pnpm dev run` streams runner output in real time on Unix
- [ ] Exit code from the runner script is propagated correctly
- [ ] Runner script errors (e.g. missing script) are reported clearly
- [ ] Existing tests that capture CLI output via `runCli`/`execFileSync` still pass
- [ ] The built CLI (`dist/cli.mjs`) also streams correctly
- [ ] No behavior change on Windows/MSYS (already async)

## Implementation Tasks

### Task 1: Unify Unix path to use async spawn

**File:** `src/ralphai.ts`

**What:** Replace the `spawnSync` Unix branch (~line 1000–1020) with async `spawn`
matching the Windows/MSYS pattern (~line 977–997). The two branches can be merged
into one since the only Windows-specific parts are `findBash()` and path conversion:

```typescript
const child = spawn(ralphaiSh, args, {
  cwd,
  stdio: ["inherit", "pipe", "pipe"],
  env: { ...process.env },
});

child.stdout.pipe(process.stdout);
child.stderr.pipe(process.stderr);

return new Promise((_resolve, _reject) => {
  child.on("close", (code) => {
    process.exit(code ?? 1);
  });
  child.on("error", (err) => {
    console.error(`Error: Failed to start task runner: ${err.message}`);
    process.exit(1);
  });
});
```

On Windows, the spawn target is `bash` with `[scriptPath, ...args]`; on Unix it's
`ralphaiSh` directly with `args`. The `stdio`, piping, and promise handling are
identical — factor the shared logic to avoid duplication.

**Key insight:** The calling function (`handleRun`) is already `async`, so returning
a Promise is fine. The Windows branch already does this.

### Task 2: Verify test compatibility

**File:** `src/ralphai.test.ts`

**What:** Run the existing test suite — especially the "run command argument
forwarding" tests (~line 1557+) that use `RALPHAI_RUNNER_SCRIPT` with a stub
script, and the "built CLI can locate the bundled runner script" test (~line 1618)
that uses `execFileSync`. Both must still capture output correctly.

No test changes expected — `child.stdout.pipe(process.stdout)` writes to the
Node process's stdout which `execFileSync` with `stdio: "pipe"` captures. But
verify and fix if needed.

## Verification

- `pnpm dev run --dry-run` prints output incrementally (not all at once at the end)
- `pnpm test` passes — all existing tests still capture output correctly
- `pnpm build && node dist/cli.mjs run --dry-run` also streams correctly
- Exit codes are preserved (non-zero exit from runner → non-zero from CLI)

## Commits

```
76a2042 feat(runner): stream output in real time on Unix
```