### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.3.0
+
+**Breaking** — This release includes structural changes. If upgrading from an earlier version, uninstall first:
+
+```sh
+npx ralphai uninstall && npm install -g ralphai@latest
+```
+
+### Features
+
+- **Worktree subcommand** — `ralphai worktree` runs a plan in an isolated git worktree with `list` and `clean` management commands (#41)
+- **Worktree-aware runner** — auto-detects git worktrees and adapts branch strategy, PR creation, and CLI suggestions accordingly (#39)
+- **Continuous single-branch mode** — replaced group mode with a simpler continuous + PR single-branch workflow (#38)
+- **Fallback agent rotation** — automatically rotates to a fallback agent when stuck, with per-plan agent override support (#35)
+- **Real-time streaming output** — runner streams agent output in real time on Unix (#36)
+- **Self-update command** — `ralphai update` with background update notifications (#30)
+- **Direct mode safety guard** — shows copy-pasteable `git checkout` command when direct mode blocks on main/master (#33)
+- **Single-plan default** — direct mode now stops after one plan by default (#34)
+
+### Fixes
+
+- Resolve bundled runner path for built `run` command (#32)
+- Use async spawn on Windows/MSYS to prevent swallowed output in Git Bash (#27)
+- Add extra newline after git suggestions for readability
+
+### Refactors
+
+- Rename all internal `ralph` references to `ralphai` for consistency (#28)
+- Rename `progress.txt` to `progress.md` (#37)
+- Simplify CLI, bundle scripts, consolidate to single-file learnings (#29)
+- Clean up templates structure, remove stale `sync-ralphai` (#31)
+
 ## 0.2.1
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphai",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Autonomous task runner for AI coding agents",
   "type": "module",
   "bin": {

--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -71,6 +71,7 @@ if [[ "$MODE" == "direct" ]]; then
         echo "Or switch to a feature branch first."
       fi
     fi
+    echo ""
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

- Bump version to 0.3.0 in `package.json`
- Add CHANGELOG entry for v0.3.0 covering all changes since v0.2.1 (13 commits)
- Add extra newline after git suggestions in `runner/ralphai.sh` for readability before the pnpm ELIFECYCLE message

### Breaking

This release includes structural changes (group mode removed, internal renames, template restructuring). The changelog advises consumers to uninstall first:

```sh
npx ralphai uninstall && npm install -g ralphai@latest
```