### PR TITLE
feat(cli): replace positional turns arg with --turns=<n> flag

### DIFF
--- a/.ralphai/README.md
+++ b/.ralphai/README.md
@@ -6,7 +6,7 @@ Ralphai is an autonomous task runner that drives an AI coding agent to implement
 
 ```bash
 ralphai run              # run with defaults (5 turns per plan)
-ralphai run 3            # 3 turns per plan
+ralphai run --turns=3    # 3 turns per plan
 ralphai run --dry-run    # preview what ralphai would do
 ralphai run --resume     # recover dirty state and continue
 ralphai run --pr         # create a ralphai/* branch and open a PR
@@ -32,27 +32,27 @@ Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are **gitignored** 
 
 ## Task Runner
 
-### `ralphai run [turns-per-plan] [options]`
+### `ralphai run [options]`
 
 Looped autonomous runner. Auto-detects what to work on, runs up to N turns per plan, with stuck detection.
 
 ```bash
-ralphai run 5
+ralphai run --turns=5
 
 # Preview selection and readiness without moving files or creating branches
 ralphai run --dry-run
 
 # Recover dirty state and continue on current ralphai/* branch
-ralphai run 5 --resume
+ralphai run --turns=5 --resume
 
 # Override agent command, base branch, or stuck threshold
-ralphai run 5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
+ralphai run --turns=5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
 
 # Override via env vars
-RALPHAI_AGENT_COMMAND='codex exec' ralphai run 5
+RALPHAI_AGENT_COMMAND='codex exec' ralphai run --turns=5
 
 # Direct mode: commit on current branch, no PR
-ralphai run 5 --direct
+ralphai run --turns=5 --direct
 ```
 
 No file arguments needed. The script auto-detects:
@@ -296,7 +296,7 @@ Environment variables override config file values:
 | `RALPHAI_ISSUE_COMMENT_PROGRESS`  | `issueCommentProgress` |
 
 ```bash
-RALPHAI_AGENT_COMMAND='claude -p' RALPHAI_MAX_STUCK=5 ralphai run 5
+RALPHAI_AGENT_COMMAND='claude -p' RALPHAI_MAX_STUCK=5 ralphai run --turns=5
 ```
 
 ### CLI Flag Overrides
@@ -308,6 +308,7 @@ CLI flags have the highest priority:
 | `--agent-command=<command>`         | `agentCommand`         |
 | `--feedback-commands=<list>`        | `feedbackCommands`     |
 | `--base-branch=<branch>`            | `baseBranch`           |
+| `--turns=<n>`                       | turn budget            |
 | `--direct`                          | `mode` (sets `direct`) |
 | `--pr`                              | `mode` (sets `pr`)     |
 | `--max-stuck=<n>`                   | `maxStuck`             |
@@ -321,7 +322,7 @@ CLI flags have the highest priority:
 | `--issue-comment-progress=<bool>`   | `issueCommentProgress` |
 
 ```bash
-ralphai run 5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
+ralphai run --turns=5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
 ```
 
 ### Verifying Config (`--show-config`)
@@ -352,7 +353,7 @@ Ralphai supports working on a feature branch using direct mode. This is useful f
 2. Run Ralphai in direct mode on the feature branch:
 
 ```bash
-ralphai run 5 --direct
+ralphai run --turns=5 --direct
 ```
 
 Or via `.ralphai/ralphai.config`:
@@ -393,7 +394,7 @@ The branch name uses the first plan's slug (e.g. `ralphai/add-dark-mode`). The P
 - Files stay in `in-progress/` so `--resume` can recover
 
 ```bash
-ralphai run 10 --continuous --pr
+ralphai run --turns=10 --continuous --pr
 ```
 
 ### GitHub Issues Integration
@@ -411,8 +412,8 @@ issueSource=github
 Or via env var or CLI flag:
 
 ```bash
-RALPHAI_ISSUE_SOURCE=github ralphai run 5
-ralphai run 5 --issue-source=github
+RALPHAI_ISSUE_SOURCE=github ralphai run --turns=5
+ralphai run --turns=5 --issue-source=github
 ```
 
 **How it works:**

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Ralphai picks a plan from the backlog, hands it to your agent, and loops. Each t
 Common options:
 
 ```bash
-ralphai run 3            # 3 turns per plan (default: 5)
+ralphai run --turns=3    # 3 turns per plan (default: 5)
 ralphai run --pr         # create a ralphai/* branch and open a PR instead
 ralphai run --dry-run    # preview what ralphai would do without changing anything
 ```
@@ -115,6 +115,7 @@ For non-disruptive parallel work, use `ralphai worktree` to run a plan in an iso
 
 ```bash
 ralphai worktree                          # auto-pick next backlog plan
+ralphai worktree --turns=3                # run with 3 turns per plan
 ralphai worktree --plan=prd-dark-mode.md  # target a specific plan
 ```
 
@@ -125,7 +126,7 @@ ralphai worktree list    # show active ralphai-managed worktrees
 ralphai worktree clean   # remove completed/orphaned worktrees
 ```
 
-> `ralphai worktree` must be run from the **main repository**, not from inside a worktree. All runner options (`--turns`, `--agent`, `--feedback-commands`, etc.) are forwarded automatically.
+> `ralphai worktree` must be run from the **main repository**, not from inside a worktree. All runner options (`--turns`, `--agent-command`, `--feedback-commands`, etc.) are forwarded automatically.
 
 ### 3. Steer
 

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -127,7 +127,7 @@ found, the plan is skipped and Ralphai moves to the next one.
 
 **Feature branch workflow:** For large features spanning multiple plans,
 use direct mode on a feature branch (`git checkout -b feature/big-thing`
-then `ralphai run 5`). When all plans are done, you
+then `ralphai run --turns=5`). When all plans are done, you
 manually open a PR from the feature branch to `main`.
 
 **Safety guards:**

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -18,6 +18,7 @@ Back to the [README](../README.md) for setup and quickstart.
 
 ```bash
 ralphai worktree                          # auto-pick next backlog plan
+ralphai worktree --turns=3                # run with 3 turns per plan
 ralphai worktree --plan=prd-dark-mode.md  # target a specific plan
 ```
 
@@ -27,7 +28,7 @@ If the agent gets stuck or times out, the worktree is preserved. Re-run
 worktree with `ralphai run --resume`.
 
 `ralphai worktree` must be run from the **main repository**, not from inside a
-worktree. All runner options (`--turns`, `--agent`, `--feedback-commands`, etc.)
+worktree. All runner options (`--turns`, `--agent-command`, `--feedback-commands`, etc.)
 are forwarded automatically.
 
 Options:

--- a/runner/lib/config.sh
+++ b/runner/lib/config.sh
@@ -315,7 +315,7 @@ apply_env_overrides() {
 }
 
 print_usage() {
-  echo "Usage: $0 [turns-per-plan] [options]"
+  echo "Usage: $0 [options]"
   echo ""
   echo "  Recommended daily invocation from an initialized repo: ralphai run ..."
   echo ""
@@ -325,6 +325,7 @@ print_usage() {
   echo "  Default: 5 turns per plan."
   echo ""
   echo "Options:"
+  echo "  --turns=<n>                     Turns per plan (default: 5, 0 = unlimited)"
   echo "  --dry-run, -n                    Preview what Ralphai would do without mutating state"
   echo "  --resume, -r                     Auto-commit dirty state and continue"
   echo "  --agent-command=<command>        Override agent CLI command (e.g. 'claude -p')"
@@ -365,24 +366,31 @@ print_usage() {
   echo "Precedence: CLI flags > env vars > config file > built-in defaults"
   echo ""
   echo "Examples:"
-  echo "  $0 10                                        # 10 turns per plan (default: 5)"
-  echo "  $0 0                                         # unlimited turns per plan"
+  echo "  $0 --turns=10                                # 10 turns per plan (default: 5)"
+  echo "  $0 --turns=0                                 # unlimited turns per plan"
   echo "  $0 --dry-run                                 # preview only"
-  echo "  $0 10 --dry-run                              # preview with explicit turns"
-  echo "  $0 10 --resume                               # recover dirty state and continue"
-  echo "  $0 10 --agent-command='claude -p'             # use Claude Code"
-  echo "  $0 10 --agent-command='opencode run --agent build'  # use OpenCode"
-  echo "  $0 10 --direct                               # commit on current branch (no PR)"
-  echo "  $0 10 --direct --continuous                  # keep draining backlog on current branch"
-  echo "  RALPHAI_AGENT_COMMAND='codex exec' $0 10       # override via env var"
+  echo "  $0 --turns=10 --dry-run                      # preview with explicit turns"
+  echo "  $0 --turns=10 --resume                       # recover dirty state and continue"
+  echo "  $0 --turns=10 --agent-command='claude -p'     # use Claude Code"
+  echo "  $0 --turns=10 --agent-command='opencode run --agent build'  # use OpenCode"
+  echo "  $0 --turns=10 --direct                       # commit on current branch (no PR)"
+  echo "  $0 --turns=10 --direct --continuous          # keep draining backlog on current branch"
+  echo "  RALPHAI_AGENT_COMMAND='codex exec' $0 --turns=10  # override via env var"
   echo ""
   echo "Feature branch workflow:"
-  echo "  $0 10 --direct --base-branch=feature/big-thing  # commit directly on a feature branch"
+  echo "  $0 --turns=10 --direct --base-branch=feature/big-thing  # commit directly on a feature branch"
 }
 
 # --- Parse args ---
 for arg in "$@"; do
   case "$arg" in
+    --turns=*)
+      CLI_TURNS="${arg#--turns=}"
+      if ! [[ "$CLI_TURNS" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: --turns must be a non-negative integer, got '$CLI_TURNS'"
+        exit 1
+      fi
+      ;;
     --help|-h)
       print_usage
       exit 0
@@ -511,13 +519,9 @@ for arg in "$@"; do
       fi
       ;;
     *)
-      if [[ -z "$TURNS" && "$arg" =~ ^[0-9]+$ ]]; then
-        TURNS="$arg"
-      else
-        echo "ERROR: Unrecognized argument: $arg"
-        print_usage
-        exit 1
-      fi
+      echo "ERROR: Unrecognized argument: $arg"
+      print_usage
+      exit 1
       ;;
   esac
 done
@@ -549,6 +553,9 @@ if [[ -n "$CLI_BASE_BRANCH" ]]; then
 fi
 if [[ -n "$CLI_MAX_STUCK" ]]; then
   MAX_STUCK="$CLI_MAX_STUCK"
+fi
+if [[ -n "$CLI_TURNS" ]]; then
+  TURNS="$CLI_TURNS"
 fi
 if [[ -n "$CLI_MODE" ]]; then
   MODE="$CLI_MODE"

--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -2,7 +2,7 @@
 # ralphai.sh — Ralphai (looped, autonomous)
 # Drives an AI coding agent to autonomously implement tasks from plan files.
 #
-# Usage: ralphai run [turns-per-plan] [--dry-run] [--resume] [--agent-command=<cmd>] [--feedback-commands=<list>] [--base-branch=<branch>] [--direct] [--pr] [--max-stuck=<n>] [--show-config] [--help]
+# Usage: ralphai run [--turns=<n>] [--dry-run] [--resume] [--agent-command=<cmd>] [--feedback-commands=<list>] [--base-branch=<branch>] [--direct] [--pr] [--max-stuck=<n>] [--show-config] [--help]
 #
 # Auto-detects what to work on:
 #   1. If .ralphai/pipeline/in-progress/ has plan files → resume on the current ralphai/* branch

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,10 +57,11 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} ralphai init                  ${DIM}# interactive setup${RESET}
   ${DIM}$${RESET} ralphai init --yes             ${DIM}# setup with defaults${RESET}
   ${DIM}$${RESET} ralphai run                    ${DIM}# run with defaults (5 turns per plan)${RESET}
-  ${DIM}$${RESET} ralphai run 3                  ${DIM}# 3 turns per plan${RESET}
+  ${DIM}$${RESET} ralphai run --turns=3          ${DIM}# 3 turns per plan${RESET}
   ${DIM}$${RESET} ralphai run --dry-run          ${DIM}# preview only${RESET}
   ${DIM}$${RESET} ralphai run --pr               ${DIM}# create branch and open PR${RESET}
   ${DIM}$${RESET} ralphai worktree               ${DIM}# run next plan in an isolated worktree${RESET}
+  ${DIM}$${RESET} ralphai worktree --turns=3     ${DIM}# run in a worktree with 3 turns per plan${RESET}
   ${DIM}$${RESET} ralphai worktree list           ${DIM}# show active ralphai worktrees${RESET}
   ${DIM}$${RESET} ralphai worktree clean          ${DIM}# remove completed worktrees${RESET}
   ${DIM}$${RESET} ralphai status                 ${DIM}# show pipeline and worktree status${RESET}

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -218,9 +218,8 @@ describe("ralphai command", () => {
     const templateLib = join(__dirname, "..", "runner", "lib");
 
     const config = readFileSync(join(templateLib, "config.sh"), "utf-8");
-    // Usage text should use square brackets (optional) not angle brackets (required)
-    expect(config).toContain("[turns-per-plan]");
-    expect(config).not.toContain("<turns-per-plan>");
+    expect(config).toContain("--turns=<n>");
+    expect(config).not.toContain("[turns-per-plan]");
     // Should mention the default
     expect(config).toContain("Default: 5 turns per plan.");
   });
@@ -1853,18 +1852,19 @@ echo "$CONTINUOUS"
       chmodSync(stubScript, 0o755);
     });
 
-    it("run without args passes default turn count (5) to ralphai.sh", () => {
+    it("run without args lets the runner apply its default turn count", () => {
       const result = runCli(["run"], testDir, {
         RALPHAI_RUNNER_SCRIPT: stubScript,
       });
-      expect(result.stdout).toContain("ARGS:5");
+      expect(result.stdout).toContain("ARGS:");
+      expect(result.stdout).not.toContain("ARGS:5");
     });
 
-    it("run -- 5 passes explicit turn count to ralphai.sh", () => {
-      const result = runCli(["run", "--", "5"], testDir, {
+    it("run -- --turns=5 passes explicit turn count to ralphai.sh", () => {
+      const result = runCli(["run", "--", "--turns=5"], testDir, {
         RALPHAI_RUNNER_SCRIPT: stubScript,
       });
-      expect(result.stdout).toContain("ARGS:5");
+      expect(result.stdout).toContain("ARGS:--turns=5");
     });
 
     it("run -- --dry-run passes flags to ralphai.sh", () => {
@@ -1874,18 +1874,18 @@ echo "$CONTINUOUS"
       expect(result.stdout).toContain("ARGS:--dry-run");
     });
 
-    it("run -- 5 --resume passes multiple args to ralphai.sh", () => {
-      const result = runCli(["run", "--", "5", "--resume"], testDir, {
+    it("run -- --turns=5 --resume passes multiple args to ralphai.sh", () => {
+      const result = runCli(["run", "--", "--turns=5", "--resume"], testDir, {
         RALPHAI_RUNNER_SCRIPT: stubScript,
       });
-      expect(result.stdout).toContain("ARGS:5 --resume");
+      expect(result.stdout).toContain("ARGS:--turns=5 --resume");
     });
 
-    it("run 3 passes turn count without -- separator", () => {
-      const result = runCli(["run", "3"], testDir, {
+    it("run --turns=3 passes turn count without -- separator", () => {
+      const result = runCli(["run", "--turns=3"], testDir, {
         RALPHAI_RUNNER_SCRIPT: stubScript,
       });
-      expect(result.stdout).toContain("ARGS:3");
+      expect(result.stdout).toContain("ARGS:--turns=3");
     });
 
     it("run --dry-run passes flags without -- separator", () => {
@@ -1895,11 +1895,18 @@ echo "$CONTINUOUS"
       expect(result.stdout).toContain("ARGS:--dry-run");
     });
 
-    it("run 3 --resume passes multiple args without -- separator", () => {
-      const result = runCli(["run", "3", "--resume"], testDir, {
+    it("run --turns=3 --resume passes multiple args without -- separator", () => {
+      const result = runCli(["run", "--turns=3", "--resume"], testDir, {
         RALPHAI_RUNNER_SCRIPT: stubScript,
       });
-      expect(result.stdout).toContain("ARGS:3 --resume");
+      expect(result.stdout).toContain("ARGS:--turns=3 --resume");
+    });
+
+    it("run 3 is rejected by the bundled runner", () => {
+      const result = runCli(["run", "3"], testDir);
+      const combined = result.stdout + result.stderr;
+      expect(result.exitCode).not.toBe(0);
+      expect(combined).toContain("Unrecognized argument: 3");
     });
 
     it("built CLI can locate the bundled runner script", () => {
@@ -2570,6 +2577,7 @@ build_continuous_pr_body
       expect(output).toContain("clean");
       expect(output).toContain("--plan=");
       expect(output).toContain("--dir=");
+      expect(output).toContain("--turns=<n>");
     });
 
     it("worktree refuses inside a worktree", () => {
@@ -2811,7 +2819,7 @@ build_continuous_pr_body
       );
       chmodSync(stubScript, 0o755);
 
-      const result = runCli(["worktree"], testDir, {
+      const result = runCli(["worktree", "--turns=3"], testDir, {
         RALPHAI_RUNNER_SCRIPT: stubScript,
       });
       const combined = result.stdout + result.stderr;
@@ -2819,7 +2827,7 @@ build_continuous_pr_body
       expect(result.exitCode).toBe(0);
       expect(combined).toContain(`Reusing existing worktree: ${worktreeDir}`);
       expect(combined).toContain(`PWD=${worktreeDir}`);
-      expect(combined).toContain("ARGS=--pr --resume");
+      expect(combined).toContain("ARGS=--pr --resume --turns=3");
 
       const symlinkPath = join(worktreeDir, ".ralphai");
       expect(existsSync(symlinkPath)).toBe(true);

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -35,7 +35,7 @@ interface WorktreeOptions {
   subcommand: WorktreeSubcommand;
   plan?: string; // --plan=<file>
   dir?: string; // --dir=<path>
-  runArgs: string[]; // passthrough args for the runner (--turns, --agent, etc.)
+  runArgs: string[]; // passthrough args for the runner (--turns, --agent-command, etc.)
 }
 
 interface RalphaiOptions {
@@ -1310,7 +1310,7 @@ function showWorktreeHelp(): void {
   );
   console.log();
   console.log(
-    `${DIM}All other options are forwarded to the task runner.${RESET}`,
+    `${DIM}All other options are forwarded to the task runner (for example, --turns=<n>, --resume, --feedback-commands=...).${RESET}`,
   );
 }
 
@@ -1799,9 +1799,6 @@ async function runRalphaiWorktree(
   // an exit code instead of calling process.exit. That's a future improvement.
 }
 
-/** Default turn count when `ralphai run` is invoked without args. */
-const DEFAULT_TURNS = "5";
-
 /**
  * Resolve the path to a bash executable.
  *
@@ -1909,7 +1906,7 @@ function runRalphaiRunner(
     process.exit(1);
   }
 
-  const args = options.runArgs.length > 0 ? options.runArgs : [DEFAULT_TURNS];
+  const args = options.runArgs;
 
   const isWindows = process.platform === "win32";
   // Git Bash / MSYS2 sets MSYSTEM; mintty-based terminals may also set

--- a/templates/ralphai/README.md
+++ b/templates/ralphai/README.md
@@ -6,7 +6,7 @@ Ralphai is an autonomous task runner that drives an AI coding agent to implement
 
 ```bash
 ralphai run              # run with defaults (5 turns per plan)
-ralphai run 3            # 3 turns per plan
+ralphai run --turns=3    # 3 turns per plan
 ralphai run --dry-run    # preview what ralphai would do
 ralphai run --resume     # recover dirty state and continue
 ralphai run --pr         # create a ralphai/* branch and open a PR
@@ -32,27 +32,27 @@ Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are **gitignored** 
 
 ## Task Runner
 
-### `ralphai run [turns-per-plan] [options]`
+### `ralphai run [options]`
 
 Looped autonomous runner. Auto-detects what to work on, runs up to N turns per plan, with stuck detection.
 
 ```bash
-ralphai run 5
+ralphai run --turns=5
 
 # Preview selection and readiness without moving files or creating branches
 ralphai run --dry-run
 
 # Recover dirty state and continue on current ralphai/* branch
-ralphai run 5 --resume
+ralphai run --turns=5 --resume
 
 # Override agent command, base branch, or stuck threshold
-ralphai run 5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
+ralphai run --turns=5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
 
 # Override via env vars
-RALPHAI_AGENT_COMMAND='codex exec' ralphai run 5
+RALPHAI_AGENT_COMMAND='codex exec' ralphai run --turns=5
 
 # Direct mode: commit on current branch, no PR
-ralphai run 5 --direct
+ralphai run --turns=5 --direct
 ```
 
 No file arguments needed. The script auto-detects:
@@ -296,7 +296,7 @@ Environment variables override config file values:
 | `RALPHAI_ISSUE_COMMENT_PROGRESS`  | `issueCommentProgress` |
 
 ```bash
-RALPHAI_AGENT_COMMAND='claude -p' RALPHAI_MAX_STUCK=5 ralphai run 5
+RALPHAI_AGENT_COMMAND='claude -p' RALPHAI_MAX_STUCK=5 ralphai run --turns=5
 ```
 
 ### CLI Flag Overrides
@@ -308,6 +308,7 @@ CLI flags have the highest priority:
 | `--agent-command=<command>`         | `agentCommand`         |
 | `--feedback-commands=<list>`        | `feedbackCommands`     |
 | `--base-branch=<branch>`            | `baseBranch`           |
+| `--turns=<n>`                       | turn budget            |
 | `--direct`                          | `mode` (sets `direct`) |
 | `--pr`                              | `mode` (sets `pr`)     |
 | `--max-stuck=<n>`                   | `maxStuck`             |
@@ -321,7 +322,7 @@ CLI flags have the highest priority:
 | `--issue-comment-progress=<bool>`   | `issueCommentProgress` |
 
 ```bash
-ralphai run 5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
+ralphai run --turns=5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
 ```
 
 ### Verifying Config (`--show-config`)
@@ -352,7 +353,7 @@ Ralphai supports working on a feature branch using direct mode. This is useful f
 2. Run Ralphai in direct mode on the feature branch:
 
 ```bash
-ralphai run 5 --direct
+ralphai run --turns=5 --direct
 ```
 
 Or via `.ralphai/ralphai.config`:
@@ -393,7 +394,7 @@ The branch name uses the first plan's slug (e.g. `ralphai/add-dark-mode`). The P
 - Files stay in `in-progress/` so `--resume` can recover
 
 ```bash
-ralphai run 10 --continuous --pr
+ralphai run --turns=10 --continuous --pr
 ```
 
 ### GitHub Issues Integration
@@ -411,8 +412,8 @@ issueSource=github
 Or via env var or CLI flag:
 
 ```bash
-RALPHAI_ISSUE_SOURCE=github ralphai run 5
-ralphai run 5 --issue-source=github
+RALPHAI_ISSUE_SOURCE=github ralphai run --turns=5
+ralphai run --turns=5 --issue-source=github
 ```
 
 **How it works:**


### PR DESCRIPTION
## Summary

- **Replaces positional `ralphai run 3` syntax with explicit `--turns=3` flag** for setting the turn budget, making the CLI more consistent and self-documenting.
- The runner's built-in default of 5 turns is preserved when `--turns` is omitted; bare numeric positional args are now rejected with a clear error.
- Updates all docs (README, templates, worktrees, how-ralphai-works), the runner script (`config.sh`, `ralphai.sh`), CLI help text, and tests to reflect the new flag syntax.