### PR TITLE
fix(worktree): replace git-tracked .ralphai dir with symlink

### DIFF
--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -2795,6 +2795,61 @@ build_continuous_pr_body
       expect(readlinkSync(symlinkPath)).toBe(join(testDir, ".ralphai"));
     });
 
+    it("worktree replaces git-tracked .ralphai dir with symlink", () => {
+      gitInitialCommit(testDir);
+
+      // Create .ralphai with a plan and git-track it (simulating a repo
+      // where .ralphai/ has committed files like ralphai.config)
+      mkdirSync(join(testDir, ".ralphai", "pipeline", "backlog"), {
+        recursive: true,
+      });
+      mkdirSync(join(testDir, ".ralphai", "pipeline", "in-progress"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(testDir, ".ralphai", "ralphai.config"),
+        "agentCommand=echo hello\n",
+      );
+      writeFileSync(
+        join(testDir, ".ralphai", "pipeline", "backlog", "prd-tracked-test.md"),
+        "# Tracked test\n",
+      );
+      writeFileSync(
+        join(testDir, ".ralphai", "pipeline", "in-progress", ".gitkeep"),
+        "",
+      );
+      // Commit .ralphai/ so worktrees check it out as a real directory
+      execSync("git add .ralphai/ && git commit -m 'add .ralphai'", {
+        cwd: testDir,
+        stdio: "ignore",
+      });
+
+      // Use a stub runner that just exits 0
+      const stubScript = join(testDir, "stub-runner.sh");
+      writeFileSync(stubScript, "#!/bin/bash\nexit 0\n");
+      chmodSync(stubScript, 0o755);
+
+      const worktreeDir = join(testDir, "wt-tracked");
+
+      const result = runCli(
+        ["worktree", "--plan=prd-tracked-test.md", `--dir=${worktreeDir}`],
+        testDir,
+        { RALPHAI_RUNNER_SCRIPT: stubScript },
+        30000,
+      );
+
+      const combined = result.stdout + result.stderr;
+
+      // The .ralphai in the worktree should be a symlink, NOT a directory
+      const symlinkPath = join(worktreeDir, ".ralphai");
+      expect(
+        existsSync(symlinkPath),
+        `Symlink not found at ${symlinkPath}. CLI output: ${combined}`,
+      ).toBe(true);
+      expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(symlinkPath)).toBe(join(testDir, ".ralphai"));
+    });
+
     it("worktree reuses an existing in-progress worktree and auto-resumes", () => {
       gitInitialCommit(testDir);
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1,6 +1,7 @@
 import { execSync, spawn } from "child_process";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   copyFileSync,
   writeFileSync,
@@ -1762,8 +1763,20 @@ async function runRalphaiWorktree(
   // pipeline files as relative paths. Without this, agents with directory
   // sandboxing (OpenCode, Claude Code, Codex) reject reads/writes to the
   // main repo's .ralphai/ as "external directory" access.
+  //
+  // When .ralphai/ is git-tracked, `git worktree add` checks out its
+  // tracked files as a real directory. We must replace it with a symlink
+  // so pipeline state (gitignored files like plans, receipts, progress)
+  // is shared with the main repo.
   const worktreeRalphaiLink = join(resolvedWorktreeDir, ".ralphai");
-  if (!existsSync(worktreeRalphaiLink)) {
+  const needsSymlink =
+    !existsSync(worktreeRalphaiLink) ||
+    !lstatSync(worktreeRalphaiLink).isSymbolicLink();
+  if (needsSymlink) {
+    // Remove the real directory (if any) before creating the symlink.
+    // This is safe because the symlink target (main repo's .ralphai/)
+    // contains all the same tracked files plus gitignored pipeline state.
+    rmSync(worktreeRalphaiLink, { recursive: true, force: true });
     symlinkSync(join(cwd, ".ralphai"), worktreeRalphaiLink);
   }
 


### PR DESCRIPTION
## Summary

- Fixes worktree runs failing with "external_directory" permission rejections when `.ralphai/` is a git-tracked directory
- When `git worktree add` checks out tracked `.ralphai/` files as a real directory, the symlink guard (`existsSync`) was returning true and skipping symlink creation — leaving the worktree with empty pipeline dirs
- Now uses `lstatSync().isSymbolicLink()` to detect real directories and replaces them with the expected symlink
- Adds a test that commits `.ralphai/` to git before creating a worktree, reproducing the actual failure scenario

## Problem

```
! permission requested: external_directory (/home/mfaux/ralphai/.ralphai/pipeline/in-progress/*); auto-rejecting
✗ read failed
```

The agent sandbox (OpenCode/Claude Code) rejected reads to the main repo's `.ralphai/` absolute path because the worktree had a real directory instead of a symlink.

## Root Cause

`.ralphai/` contains git-tracked files (`ralphai.config`, `README.md`, plan-types, `.gitkeep` files). `git worktree add` checks these out as a real directory. The old guard:

```typescript
if (!existsSync(worktreeRalphaiLink)) {  // true for real dir — skipped!
```

## Fix

```typescript
const needsSymlink =
  !existsSync(worktreeRalphaiLink) ||
  !lstatSync(worktreeRalphaiLink).isSymbolicLink();
if (needsSymlink) {
  rmSync(worktreeRalphaiLink, { recursive: true, force: true });
  symlinkSync(join(cwd, ".ralphai"), worktreeRalphaiLink);
}
```

All 177 tests pass including the new test case.