### PR TITLE
feat(receipt): add tasks_completed field and fix status task count

### DIFF
--- a/runner/lib/receipt.sh
+++ b/runner/lib/receipt.sh
@@ -2,12 +2,23 @@
 # Sourced by ralphai.sh — do not execute directly.
 #
 # The receipt file tracks which plan is running, where it started (main repo
-# or worktree), and how many turns have completed. It is used to prevent
-# cross-source conflicts (e.g. a worktree plan being resumed by `ralphai run`
-# in the main repo) and to provide status information.
+# or worktree), how many turns have completed, and how many tasks have been
+# completed. It is used to prevent cross-source conflicts (e.g. a worktree
+# plan being resumed by `ralphai run` in the main repo) and to provide
+# status information.
 #
 # Receipt files live at: .ralphai/pipeline/in-progress/receipt-<slug>.txt
 # Format: key=value (one per line, no quoting needed).
+#
+# Fields:
+#   started_at       — ISO 8601 UTC timestamp of when the run started
+#   source           — "main" or "worktree"
+#   worktree_path    — absolute path to worktree (only when source=worktree)
+#   branch           — git branch name
+#   slug             — plan slug (derived from filename)
+#   agent            — agent command string
+#   turns_completed  — number of agent turns completed
+#   tasks_completed  — number of plan tasks completed (parsed from progress.md)
 
 # --- Derive the receipt file path from the plan slug ---
 # Must be called after WIP_FILES is set (i.e. after detect_plan).
@@ -43,6 +54,7 @@ init_receipt() {
     echo "slug=$PLAN_SLUG"
     echo "agent=$AGENT_COMMAND"
     echo "turns_completed=0"
+    echo "tasks_completed=0"
   } > "$RECEIPT_FILE"
 
   echo "Initialized $RECEIPT_FILE"
@@ -60,6 +72,45 @@ update_receipt_turn() {
   current=${current:-0}
   local next=$((current + 1))
   sed -i "s/^turns_completed=.*/turns_completed=$next/" "$RECEIPT_FILE"
+}
+
+# --- Recount tasks_completed from progress.md ---
+# Called after each turn completes (after auto-commit).
+# Counts individual `**Status:** Complete` markers and batch `Tasks X-Y` headings
+# in $PROGRESS_FILE, then writes the total to the receipt.
+update_receipt_tasks() {
+  if [[ ! -f "$RECEIPT_FILE" ]]; then
+    return
+  fi
+  if [[ ! -f "$PROGRESS_FILE" ]]; then
+    return
+  fi
+
+  local count=0
+
+  # Count individual **Status:** Complete markers (case-insensitive)
+  local individual
+  individual=$(grep -ci '\*\*Status:\*\*[[:space:]]*Complete' "$PROGRESS_FILE" 2>/dev/null || true)
+  count=$((count + individual))
+
+  # Count batch entries: Tasks X-Y or Tasks X–Y (en-dash or hyphen)
+  # Each match contributes (end - start + 1) tasks
+  while IFS= read -r line; do
+    # Extract start and end numbers from patterns like "Tasks 1-3" or "Tasks 1–3"
+    local start_num end_num
+    start_num=$(echo "$line" | sed -n 's/.*[Tt]asks\?[[:space:]]\+\([0-9]\+\)[[:space:]]*[–-][[:space:]]*\([0-9]\+\).*/\1/p')
+    end_num=$(echo "$line" | sed -n 's/.*[Tt]asks\?[[:space:]]\+\([0-9]\+\)[[:space:]]*[–-][[:space:]]*\([0-9]\+\).*/\2/p')
+    if [[ -n "$start_num" && -n "$end_num" && "$end_num" -gt "$start_num" ]]; then
+      count=$((count + end_num - start_num + 1))
+    fi
+  done < <(grep -i 'tasks\?[[:space:]]\+[0-9]\+[[:space:]]*[–-][[:space:]]*[0-9]\+' "$PROGRESS_FILE" 2>/dev/null || true)
+
+  # Update or append tasks_completed in the receipt
+  if grep -q '^tasks_completed=' "$RECEIPT_FILE"; then
+    sed -i "s/^tasks_completed=.*/tasks_completed=$count/" "$RECEIPT_FILE"
+  else
+    echo "tasks_completed=$count" >> "$RECEIPT_FILE"
+  fi
 }
 
 # --- Check receipt source for cross-source conflicts ---

--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -322,7 +322,11 @@ while true; do
    - AGENTS.md — only if your work created knowledge that future coding agents need and cannot easily infer from the code (e.g. new CLI commands, non-obvious architectural constraints, changed dev workflows). Routine bug fixes, internal refactors, and new tests do not warrant an AGENTS.md update.
    - Project documentation files that describe architecture, conventions, agent instructions, or reusable skills — update only if your changes affect them.
    Only update docs that are actually affected by your changes — do not rewrite docs unnecessarily.${LEARNINGS_STEP}
-$(if [[ -n "$LEARNINGS_STEP" ]]; then echo "7"; else echo "6"; fi). Update ${PROGRESS_FILE} with what you did, decisions made, files changed, and any blockers.
+$(if [[ -n "$LEARNINGS_STEP" ]]; then echo "7"; else echo "6"; fi). Update ${PROGRESS_FILE} with what you did, decisions made, files changed, and any blockers. For each task you completed, include a heading and status marker in this exact format:
+   ### Task N: <title>
+   **Status:** Complete
+   <summary of what was done>
+   This format is required — ralphai parses it to track task completion.
 $(if [[ -n "$LEARNINGS_STEP" ]]; then echo "8"; else echo "7"; fi). Stage and commit ALL changes using a conventional commit message (e.g. feat: ..., fix: ..., refactor: ..., test: ..., docs: ..., chore: ...). Use a scope when appropriate (e.g. feat(parser): ...). This is MANDATORY — you must never finish a turn with uncommitted changes.
 ONLY WORK ON A SINGLE TASK.
 If all tasks are complete, output <promise>COMPLETE</promise> — but ONLY after committing. Never output COMPLETE with uncommitted changes.
@@ -423,6 +427,9 @@ The <learnings> block is mandatory in every response. Ralphai will parse it and 
 
     # --- Update receipt turn counter ---
     update_receipt_turn
+
+    # --- Update receipt tasks_completed from progress.md ---
+    update_receipt_tasks
 
     # --- Check for completion ---
     if [[ "$result" == *"<promise>COMPLETE</promise>"* ]]; then

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -3192,7 +3192,7 @@ build_continuous_pr_body
       expect(output).toContain("waiting on prd-auth.md");
     });
 
-    it("status shows in-progress plan with task progress", () => {
+    it("status shows in-progress plan with task progress from receipt", () => {
       runCli(["init", "--yes"], testDir);
 
       const ipDir = join(testDir, ".ralphai", "pipeline", "in-progress");
@@ -3210,7 +3210,7 @@ build_continuous_pr_body
         "## Progress Log\n\n### Task 1: Theme\n\n**Status:** Complete\n",
       );
 
-      // Receipt for this plan
+      // Receipt for this plan — includes tasks_completed
       writeFileSync(
         join(ipDir, "receipt-dark-mode.txt"),
         [
@@ -3221,6 +3221,7 @@ build_continuous_pr_body
           "slug=dark-mode",
           "agent=claude -p",
           "turns_completed=2",
+          "tasks_completed=1",
         ].join("\n"),
       );
 
@@ -3233,6 +3234,78 @@ build_continuous_pr_body
       expect(output).toContain("prd-dark-mode.md");
       expect(output).toContain("1 of 3 tasks");
       expect(output).toContain("worktree: dark-mode");
+    });
+
+    it("status shows 0 tasks_completed for receipt without tasks_completed field", () => {
+      runCli(["init", "--yes"], testDir);
+
+      const ipDir = join(testDir, ".ralphai", "pipeline", "in-progress");
+      mkdirSync(ipDir, { recursive: true });
+
+      // Plan with 2 tasks
+      writeFileSync(
+        join(ipDir, "prd-legacy.md"),
+        "# Legacy\n\n### Task 1: Migrate\n### Task 2: Validate\n",
+      );
+
+      // Receipt WITHOUT tasks_completed (backwards compatibility)
+      writeFileSync(
+        join(ipDir, "receipt-legacy.txt"),
+        [
+          "started_at=2026-03-07T12:00:00Z",
+          "source=main",
+          "branch=ralphai/legacy",
+          "slug=legacy",
+          "agent=claude -p",
+          "turns_completed=1",
+        ].join("\n"),
+      );
+
+      const result = runCli(["status"], testDir);
+      const output = result.stdout + result.stderr;
+
+      expect(result.exitCode).toBe(0);
+      expect(output).toContain("0 of 2 tasks");
+    });
+
+    it("status shows tasks_completed from receipt, not progress.md", () => {
+      runCli(["init", "--yes"], testDir);
+
+      const ipDir = join(testDir, ".ralphai", "pipeline", "in-progress");
+      mkdirSync(ipDir, { recursive: true });
+
+      // Plan with 4 tasks
+      writeFileSync(
+        join(ipDir, "prd-feature.md"),
+        "# Feature\n\n### Task 1: A\n### Task 2: B\n### Task 3: C\n### Task 4: D\n",
+      );
+
+      // Progress file with 2 completed tasks
+      writeFileSync(
+        join(ipDir, "progress.md"),
+        "## Progress Log\n\n### Task 1: A\n**Status:** Complete\n\n### Task 2: B\n**Status:** Complete\n",
+      );
+
+      // Receipt says 3 tasks completed (receipt is authoritative)
+      writeFileSync(
+        join(ipDir, "receipt-feature.txt"),
+        [
+          "started_at=2026-03-07T12:00:00Z",
+          "source=main",
+          "branch=ralphai/feature",
+          "slug=feature",
+          "agent=claude -p",
+          "turns_completed=3",
+          "tasks_completed=3",
+        ].join("\n"),
+      );
+
+      const result = runCli(["status"], testDir);
+      const output = result.stdout + result.stderr;
+
+      expect(result.exitCode).toBe(0);
+      // Should show 3 (from receipt), not 2 (from progress.md parsing)
+      expect(output).toContain("3 of 4 tasks");
     });
 
     it("status shows orphaned receipt as a problem", () => {

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1098,6 +1098,7 @@ interface Receipt {
   slug: string;
   agent: string;
   turns_completed: number;
+  tasks_completed: number;
 }
 
 function parseReceipt(filePath: string): Receipt | null {
@@ -1118,6 +1119,7 @@ function parseReceipt(filePath: string): Receipt | null {
     slug: fields.slug ?? "",
     agent: fields.agent ?? "",
     turns_completed: parseInt(fields.turns_completed ?? "0", 10),
+    tasks_completed: parseInt(fields.tasks_completed ?? "0", 10),
   };
 }
 
@@ -1547,8 +1549,7 @@ function runRalphaiStatus(cwd: string): void {
     // Task progress
     const totalTasks = countPlanTasks(join(inProgressDir, plan));
     if (totalTasks > 0) {
-      const progressFile = join(inProgressDir, "progress.md");
-      const completed = countCompletedTasks(progressFile);
+      const completed = receipt?.tasks_completed ?? 0;
       parts.push(`${completed} of ${totalTasks} tasks`);
     }
 


### PR DESCRIPTION
## Summary
- **Adds `tasks_completed` to receipt files** — receipts now track how many plan tasks have been completed, updated after each agent turn by counting `**Status:** Complete` markers in `progress.md`
- **Fixes `ralphai status` showing "0 of N tasks"** — status now reads `tasks_completed` from the receipt instead of parsing `progress.md` directly (which always returned 0 because agents weren't instructed to write the markers)
- **Updates agent prompt** to require `**Status:** Complete` markers in `progress.md` so task completion is reliably parseable

## Changes
| File | What |
|------|------|
| `runner/lib/receipt.sh` | Add `tasks_completed=0` to `init_receipt()`, add `update_receipt_tasks()` function, document all receipt fields |
| `runner/ralphai.sh` | Call `update_receipt_tasks` after each turn, update prompt to require Status markers |
| `src/ralphai.ts` | Add `tasks_completed` to `Receipt` interface/parser, status reads from receipt |
| `src/ralphai.test.ts` | Update existing test, add backwards-compat test, add receipt-is-authoritative test |

## Testing
- 181 tests pass (`bun test`)
- Type checking clean (`bun run type-check`)
- Backwards-compatible: receipts without `tasks_completed` default to 0