### PR TITLE
refactor: gitignore .ralphai/ dir and move config to ralphai.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ logs
 
 package-lock.json
 
-# pipeline runtime state
-.ralphai/pipeline/in-progress/
+# ralphai local pipeline state (fully gitignored)
+.ralphai/

--- a/.ralphai
+++ b/.ralphai
@@ -1,1 +1,0 @@
-/home/mfaux/ralphai/.ralphai

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In your project directory:
 ralphai init
 ```
 
-Ralphai scaffolds a `.ralphai/` directory into your project with config, docs, and a plan pipeline. It detects your package manager and build scripts automatically.
+Ralphai scaffolds a `.ralphai/` directory into your project with docs and a plan pipeline, and creates a `ralphai.json` config file at the repo root. It detects your package manager and build scripts automatically.
 
 > Use `ralphai init --yes` to skip prompts and accept defaults.
 
@@ -151,10 +151,9 @@ Ralphai logs mistakes to `.ralphai/LEARNINGS.md` (gitignored) during runs. After
 
 ### After you're set up
 
-1. **Commit the `.ralphai/` folder to git.** The config and docs
-   are designed to be shared with your team.
+1. **Commit `ralphai.json` to git.** It's the shared config for your team.
 
-2. **Review `.ralphai/ralphai.config.json`** and adjust settings (agent command,
+2. **Review `ralphai.json`** and adjust settings (agent command,
    feedback commands, base branch, etc.).
 
 <details>
@@ -178,10 +177,10 @@ See [How Ralphai Works](docs/HOW-RALPHAI-WORKS.md) for the full picture.
 
 ## Docs
 
-After `ralphai init`, the good stuff lives in `.ralphai/`:
+After `ralphai init`, pipeline docs live in `.ralphai/` (local-only, gitignored):
 
-- [`.ralphai/README.md`](.ralphai/README.md) — full operational docs (lifecycle, config)
-- [`.ralphai/PLANNING.md`](.ralphai/PLANNING.md) — guide for writing plan files (give this to your agent)
+- `.ralphai/README.md` — full operational docs (lifecycle, config)
+- `.ralphai/PLANNING.md` — guide for writing plan files (give this to your agent)
 - [Worktrees](docs/worktrees.md) — worktree usage, agent compatibility, and manual setup
 
 ## Supported Agents
@@ -245,7 +244,7 @@ Worktree:
 
 ## Configuration
 
-Settings resolve in this order: **CLI flags > env vars > `.ralphai/ralphai.config.json` > defaults**.
+Settings resolve in this order: **CLI flags > env vars > `ralphai.json` > defaults**.
 
 <details>
 <summary>Environment variables</summary>

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -79,7 +79,7 @@ This loop keeps the agent grounded. Instead of drifting based on stale
 assumptions, it reacts to actual project state every cycle.
 
 Feedback commands are auto-detected during `ralphai init` or can be configured
-manually via `feedbackCommands` in `.ralphai/ralphai.config.json`. When configured, the
+manually via `feedbackCommands` in `ralphai.json`. When configured, the
 agent prompt includes the specific commands. When absent, the prompt uses a
 generic fallback: "Run your project's build, test, and lint commands."
 
@@ -95,7 +95,7 @@ in `in-progress/` for you to inspect.
 
 The threshold is configurable:
 
-- **Config file:** `"maxStuck": 5` in `.ralphai/ralphai.config.json`
+- **Config file:** `"maxStuck": 5` in `ralphai.json`
 - **Env var:** `RALPHAI_MAX_STUCK=5`
 - **CLI flag:** `--max-stuck=5`
 
@@ -180,8 +180,8 @@ files automatically. See the [operational docs](../.ralphai/README.md) for
 details.
 
 **File tracking:** Plan files in `backlog/`, `in-progress/`, and `out/` are
-gitignored (local-only state). Only `.gitkeep` files are tracked. Moving files
-between lifecycle stages requires no git commits.
+gitignored (local-only state). The entire `.ralphai/` directory is gitignored.
+Moving files between lifecycle stages requires no git commits.
 
 ## Learnings System
 

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -60,10 +60,13 @@ active plans are preserved.
    If that plan is already in progress, it reuses the existing managed
    worktree instead of creating a second one.
 2. A **symlink** is created from the worktree's `.ralphai/` to the main repo's
-   `.ralphai/` directory. This is critical for agent compatibility (see below).
+   `.ralphai/` directory. Since `.ralphai/` is fully gitignored, it won't exist
+   in the worktree after `git worktree add` — the symlink is simply created.
 3. The runner is spawned with the worktree as its working directory.
 4. When the runner detects the symlink, it uses **relative paths** (e.g.,
    `.ralphai/pipeline/in-progress/`) in the prompt sent to the agent.
+5. Config (`ralphai.json`) lives at the repo root and is tracked by git, so
+   `git worktree add` checks it out automatically — no special handling needed.
 
 Pipeline state (`.ralphai/pipeline/`) lives in the main worktree and is shared
 across all worktrees via the symlink.
@@ -93,7 +96,7 @@ read and write pipeline files through relative paths.
 | Codex       | No               | Container sandbox may not follow symlinks outside the mount |
 
 **Workaround for unsupported agents:** Set `"promptMode": "inline"` in
-`.ralphai/ralphai.config.json`. This causes the runner (bash) to read pipeline files
+`ralphai.json`. This causes the runner (bash) to read pipeline files
 and embed their contents directly in the prompt, bypassing the agent's need to
 access external paths. This increases prompt size but works with all agents.
 

--- a/runner/lib/config.sh
+++ b/runner/lib/config.sh
@@ -4,7 +4,7 @@
 # and agentCommand validation.
 
 # --- Config file loader ---
-# Parses .ralphai/ralphai.config.json (JSON format via jq).
+# Parses ralphai.json (JSON format via jq).
 # Sets CONFIG_AGENT_COMMAND, CONFIG_FEEDBACK_COMMANDS, CONFIG_BASE_BRANCH,
 # CONFIG_MAX_STUCK, CONFIG_MODE, CONFIG_PROMPT_MODE when present.
 # Fails fast on unknown keys or invalid values.
@@ -959,7 +959,7 @@ fi
 
 # --- Validate agentCommand is set ---
 if [[ -z "$AGENT_COMMAND" ]]; then
-  echo "ERROR: agentCommand is required. Set it in .ralphai/ralphai.config.json, RALPHAI_AGENT_COMMAND env var, or --agent-command= flag."
+  echo "ERROR: agentCommand is required. Set it in ralphai.json, RALPHAI_AGENT_COMMAND env var, or --agent-command= flag."
   echo "Examples: \"agentCommand\": \"opencode run --agent build\""
   echo "          \"agentCommand\": \"claude -p\""
   echo "          \"agentCommand\": \"codex exec\""

--- a/runner/lib/defaults.sh
+++ b/runner/lib/defaults.sh
@@ -40,7 +40,7 @@ AUTO_COMMIT="$DEFAULT_AUTO_COMMIT"
 WIP_DIR=".ralphai/pipeline/in-progress"
 BACKLOG_DIR=".ralphai/pipeline/backlog"
 ARCHIVE_DIR=".ralphai/pipeline/out"
-CONFIG_FILE=".ralphai/ralphai.config.json"
+CONFIG_FILE="ralphai.json"
 PROGRESS_FILE="$WIP_DIR/progress.md"
 
 # --- Worktree detection ---
@@ -60,19 +60,21 @@ unset _git_common_dir
 
 if [[ "$RALPHAI_IS_WORKTREE" == true ]]; then
   if [[ -L ".ralphai" ]]; then
-    # Symlink exists — keep the default relative paths (lines 38-42).
+    # Symlink exists — keep the default relative paths for pipeline dirs.
     # The symlink resolves to the main repo's .ralphai/ directory, so
     # relative paths like .ralphai/pipeline/in-progress/ work correctly
     # AND stay within the agent's working directory (avoids "external
     # directory" rejection in sandboxed agents like OpenCode/Claude Code).
+    # Config (ralphai.json) is at repo root and checked out by git, so
+    # the default CONFIG_FILE="ralphai.json" already works.
     :
   else
-    # No symlink — use absolute paths to the main repo (legacy behavior
-    # for manually-created worktrees without the symlink).
+    # No symlink — use absolute paths to the main repo's pipeline dirs
+    # (for manually-created worktrees without the symlink).
+    # Config is at repo root and checked out by git, so it's already local.
     WIP_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/in-progress"
     BACKLOG_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/backlog"
     ARCHIVE_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/out"
-    CONFIG_FILE="$RALPHAI_MAIN_WORKTREE/.ralphai/ralphai.config.json"
     PROGRESS_FILE="$WIP_DIR/progress.md"
   fi
 fi

--- a/runner/lib/git.sh
+++ b/runner/lib/git.sh
@@ -2,17 +2,13 @@
 # Sourced by ralphai.sh. Do not execute directly.
 
 is_tree_dirty() {
-  # Exclude .ralphai from all checks. In worktrees, .ralphai/ is replaced
-  # with a symlink to the main repo, which makes git see tracked files as
-  # deleted and the symlink as untracked. This is intentional and should
-  # not block the runner.
-  if ! git diff --quiet HEAD -- ':!.ralphai' 2>/dev/null; then
+  if ! git diff --quiet HEAD 2>/dev/null; then
     return 0
   fi
-  if ! git diff --cached --quiet -- ':!.ralphai' 2>/dev/null; then
+  if ! git diff --cached --quiet 2>/dev/null; then
     return 0
   fi
-  if [[ -n "$(git ls-files --others --exclude-standard -- ':!.ralphai')" ]]; then
+  if [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
     return 0
   fi
   return 1

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -46,10 +46,10 @@ describe("ralphai command", () => {
 
     expect(output).toContain("Ralphai initialized");
 
-    // User-owned files (scripts are no longer scaffolded)
-    expect(existsSync(join(testDir, ".ralphai", "ralphai.config.json"))).toBe(
-      true,
-    );
+    // Config at repo root (not inside .ralphai/)
+    expect(existsSync(join(testDir, "ralphai.json"))).toBe(true);
+
+    // User-owned files inside .ralphai/ (local-only, gitignored)
     expect(existsSync(join(testDir, ".ralphai", "README.md"))).toBe(true);
     expect(existsSync(join(testDir, ".ralphai", "PLANNING.md"))).toBe(true);
     expect(existsSync(join(testDir, ".ralphai", "LEARNINGS.md"))).toBe(true);
@@ -58,36 +58,22 @@ describe("ralphai command", () => {
     expect(existsSync(join(testDir, ".ralphai", "ralphai.sh"))).toBe(false);
     expect(existsSync(join(testDir, ".ralphai", "lib"))).toBe(false);
 
-    // Subdirectories with .gitkeep
+    // Pipeline subdirectories (no .gitkeep — .ralphai/ is fully gitignored)
+    expect(existsSync(join(testDir, ".ralphai", "pipeline", "backlog"))).toBe(
+      true,
+    );
+    expect(existsSync(join(testDir, ".ralphai", "pipeline", "wip"))).toBe(true);
     expect(
-      existsSync(join(testDir, ".ralphai", "pipeline", "backlog", ".gitkeep")),
+      existsSync(join(testDir, ".ralphai", "pipeline", "in-progress")),
     ).toBe(true);
-    expect(
-      existsSync(join(testDir, ".ralphai", "pipeline", "wip", ".gitkeep")),
-    ).toBe(true);
-    expect(
-      existsSync(
-        join(testDir, ".ralphai", "pipeline", "in-progress", ".gitkeep"),
-      ),
-    ).toBe(true);
-    expect(
-      existsSync(join(testDir, ".ralphai", "pipeline", "out", ".gitkeep")),
-    ).toBe(true);
+    expect(existsSync(join(testDir, ".ralphai", "pipeline", "out"))).toBe(true);
   });
 
-  it("init --yes creates .gitignore for plan files", () => {
+  it("init --yes adds .ralphai/ to root .gitignore", () => {
     runCliOutput(["init", "--yes"], testDir);
 
-    const gitignore = readFileSync(
-      join(testDir, ".ralphai", ".gitignore"),
-      "utf-8",
-    );
-    expect(gitignore).toContain("pipeline/backlog/*.md");
-    expect(gitignore).toContain("pipeline/wip/*.md");
-    expect(gitignore).toContain("pipeline/in-progress/*.md");
-    expect(gitignore).toContain("pipeline/in-progress/progress.md");
-    expect(gitignore).toContain("pipeline/out/");
-    expect(gitignore).toContain("LEARNINGS.md");
+    const gitignore = readFileSync(join(testDir, ".gitignore"), "utf-8");
+    expect(gitignore).toContain(".ralphai/");
   });
 
   it("init --yes creates LEARNINGS.md with seed content", () => {
@@ -105,10 +91,7 @@ describe("ralphai command", () => {
   it("init --yes generates config with default agent command", () => {
     runCliOutput(["init", "--yes"], testDir);
 
-    const config = readFileSync(
-      join(testDir, ".ralphai", "ralphai.config.json"),
-      "utf-8",
-    );
+    const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
     const parsed = JSON.parse(config);
     expect(parsed.agentCommand).toBe("opencode run --agent build");
     expect(parsed.baseBranch).toBeDefined();
@@ -120,10 +103,7 @@ describe("ralphai command", () => {
   it("init --yes --agent-command uses the provided agent command", () => {
     runCliOutput(["init", "--yes", "--agent-command=claude -p"], testDir);
 
-    const config = readFileSync(
-      join(testDir, ".ralphai", "ralphai.config.json"),
-      "utf-8",
-    );
+    const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
     const parsed = JSON.parse(config);
     expect(parsed.agentCommand).toBe("claude -p");
   });
@@ -133,7 +113,7 @@ describe("ralphai command", () => {
 
     expect(output).toContain("Ralphai initialized");
     expect(output).toContain("dry-run");
-    expect(output).toContain(".ralphai/ralphai.config.json");
+    expect(output).toContain("ralphai.json");
     expect(output).toContain("PLANNING.md");
     expect(output).toContain("LEARNINGS.md");
   });
@@ -182,10 +162,8 @@ describe("ralphai command", () => {
 
       expect(output).toContain("Ralphai initialized");
 
-      // .ralphai/ should exist in targetDir, NOT in testDir (cwd)
-      expect(
-        existsSync(join(targetDir, ".ralphai", "ralphai.config.json")),
-      ).toBe(true);
+      // ralphai.json should exist in targetDir (repo root), not in testDir (cwd)
+      expect(existsSync(join(targetDir, "ralphai.json"))).toBe(true);
       expect(existsSync(join(targetDir, ".ralphai", "README.md"))).toBe(true);
       expect(existsSync(join(testDir, ".ralphai"))).toBe(false);
     } finally {
@@ -517,9 +495,9 @@ describe("ralphai command", () => {
       ),
     ).toBe(true);
 
-    // in-progress should be clean (only .gitkeep)
+    // in-progress should be clean (empty)
     const remaining = readdirSync(inProgressDir);
-    expect(remaining).toEqual([".gitkeep"]);
+    expect(remaining).toEqual([]);
   });
 
   it("reset --yes reports nothing to reset when pipeline is clean", () => {
@@ -538,7 +516,7 @@ describe("ralphai command", () => {
     expect(result.stderr).toContain("ralphai init");
   });
 
-  it("reset preserves .gitkeep in in-progress directory", () => {
+  it("reset preserves in-progress directory", () => {
     runCliOutput(["init", "--yes"], testDir);
 
     const inProgressDir = join(testDir, ".ralphai", "pipeline", "in-progress");
@@ -546,8 +524,6 @@ describe("ralphai command", () => {
 
     runCliOutput(["reset", "--yes"], testDir);
 
-    // .gitkeep should still exist
-    expect(existsSync(join(inProgressDir, ".gitkeep"))).toBe(true);
     // Directory should still exist
     expect(existsSync(inProgressDir)).toBe(true);
   });
@@ -594,12 +570,12 @@ describe("ralphai command", () => {
   // --force tests
   // -------------------------------------------------------------------------
 
-  it("init --force --yes re-scaffolds from scratch, overwriting ralphai.config.json", () => {
+  it("init --force --yes re-scaffolds from scratch, overwriting ralphai.json", () => {
     runCliOutput(["init", "--yes"], testDir);
 
     // Write custom config
     writeFileSync(
-      join(testDir, ".ralphai", "ralphai.config.json"),
+      join(testDir, "ralphai.json"),
       JSON.stringify({ agentCommand: "my-agent", baseBranch: "main" }) + "\n",
     );
 
@@ -611,10 +587,7 @@ describe("ralphai command", () => {
     expect(output).toContain("Ralphai initialized");
 
     // Config should have been overwritten with defaults
-    const config = readFileSync(
-      join(testDir, ".ralphai", "ralphai.config.json"),
-      "utf-8",
-    );
+    const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
     const parsed = JSON.parse(config);
     expect(parsed.agentCommand).toBe("opencode run --agent build");
     expect(parsed.agentCommand).not.toBe("my-agent");
@@ -652,15 +625,15 @@ describe("ralphai command", () => {
     // Force re-scaffold
     runCliOutput(["init", "--force", "--yes"], testDir);
 
-    // Plan file should be gone (directory was deleted and recreated with only .gitkeep)
+    // Plan file should be gone (directory was deleted and recreated)
     expect(
       existsSync(
         join(testDir, ".ralphai", "pipeline", "backlog", "old-plan.md"),
       ),
     ).toBe(false);
-    expect(
-      existsSync(join(testDir, ".ralphai", "pipeline", "backlog", ".gitkeep")),
-    ).toBe(true);
+    expect(existsSync(join(testDir, ".ralphai", "pipeline", "backlog"))).toBe(
+      true,
+    );
   });
 
   // -------------------------------------------------------------------------
@@ -684,10 +657,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed.feedbackCommands).toEqual([
         "pnpm build",
@@ -709,10 +679,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed.feedbackCommands).toEqual(["npm run build", "npm test"]);
     });
@@ -733,10 +700,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed.feedbackCommands).toEqual([
         "yarn build",
@@ -761,10 +725,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed.feedbackCommands).toEqual([
         "bun run build",
@@ -785,10 +746,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       // No test task in deno.json, but deno has a built-in test runner
       expect(parsed.feedbackCommands).toEqual([
@@ -814,10 +772,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed.feedbackCommands).toEqual(["pnpm build", "pnpm test"]);
     });
@@ -831,10 +786,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed.feedbackCommands).toEqual(["npm test"]);
     });
@@ -852,10 +804,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed).not.toHaveProperty("feedbackCommands");
     });
@@ -864,10 +813,7 @@ describe("ralphai command", () => {
       // No package.json, no deno.json — nothing to detect
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed).not.toHaveProperty("feedbackCommands");
     });
@@ -886,10 +832,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed).not.toHaveProperty("feedbackCommands");
     });
@@ -916,10 +859,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       expect(parsed.feedbackCommands).toEqual([
         "pnpm build",
@@ -947,10 +887,7 @@ describe("ralphai command", () => {
 
       runCliOutput(["init", "--yes"], testDir);
 
-      const config = readFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "utf-8",
-      );
+      const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
       const parsed = JSON.parse(config);
       // pnpm should win because lock file beats packageManager field
       expect(parsed.feedbackCommands).toEqual(["pnpm build", "pnpm test"]);
@@ -1065,9 +1002,7 @@ describe("ralphai command", () => {
     it("init --yes succeeds in the main repo (not a worktree)", () => {
       const output = stripLogo(runCliOutput(["init", "--yes"], mainRepo));
       expect(output).toContain("Ralphai initialized");
-      expect(
-        existsSync(join(mainRepo, ".ralphai", "ralphai.config.json")),
-      ).toBe(true);
+      expect(existsSync(join(mainRepo, "ralphai.json"))).toBe(true);
     });
 
     it("run resolves .ralphai/ from the main worktree when invoked inside a worktree", () => {
@@ -1136,9 +1071,8 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         expect(result).toContain(
           `ARCHIVE_DIR=${mainRepo}/.ralphai/pipeline/out`,
         );
-        expect(result).toContain(
-          `CONFIG_FILE=${mainRepo}/.ralphai/ralphai.config.json`,
-        );
+        // Config is at repo root and checked out by git, so stays relative
+        expect(result).toContain("CONFIG_FILE=ralphai.json");
         expect(result).toContain(
           `PROGRESS_FILE=${mainRepo}/.ralphai/pipeline/in-progress/progress.md`,
         );
@@ -1159,10 +1093,6 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       });
       mkdirSync(join(ralphaiDir, "pipeline", "backlog"), { recursive: true });
       mkdirSync(join(ralphaiDir, "pipeline", "out"), { recursive: true });
-      writeFileSync(
-        join(ralphaiDir, "ralphai.config.json"),
-        "baseBranch=main\n",
-      );
 
       // Create symlink in the worktree pointing to main repo's .ralphai/
       symlinkSync(ralphaiDir, join(worktreeDir, ".ralphai"));
@@ -1200,7 +1130,7 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         expect(result).toContain("WIP_DIR=.ralphai/pipeline/in-progress");
         expect(result).toContain("BACKLOG_DIR=.ralphai/pipeline/backlog");
         expect(result).toContain("ARCHIVE_DIR=.ralphai/pipeline/out");
-        expect(result).toContain("CONFIG_FILE=.ralphai/ralphai.config.json");
+        expect(result).toContain("CONFIG_FILE=ralphai.json");
         expect(result).toContain(
           "PROGRESS_FILE=.ralphai/pipeline/in-progress/progress.md",
         );
@@ -1250,7 +1180,7 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         expect(result).toContain("WIP_DIR=.ralphai/pipeline/in-progress");
         expect(result).toContain("BACKLOG_DIR=.ralphai/pipeline/backlog");
         expect(result).toContain("ARCHIVE_DIR=.ralphai/pipeline/out");
-        expect(result).toContain("CONFIG_FILE=.ralphai/ralphai.config.json");
+        expect(result).toContain("CONFIG_FILE=ralphai.json");
         expect(result).toContain(
           "PROGRESS_FILE=.ralphai/pipeline/in-progress/progress.md",
         );
@@ -2242,7 +2172,7 @@ echo "$AUTO_COMMIT"
       runCliOutput(["init", "--yes"], testDir);
 
       const parsed = JSON.parse(
-        readFileSync(join(testDir, ".ralphai", "ralphai.config.json"), "utf-8"),
+        readFileSync(join(testDir, "ralphai.json"), "utf-8"),
       );
       expect(parsed).not.toHaveProperty("issueSource");
     });
@@ -2251,7 +2181,7 @@ echo "$AUTO_COMMIT"
       runCliOutput(["init", "--yes"], testDir);
 
       const parsed = JSON.parse(
-        readFileSync(join(testDir, ".ralphai", "ralphai.config.json"), "utf-8"),
+        readFileSync(join(testDir, "ralphai.json"), "utf-8"),
       );
       // issueSource should not appear at all in the JSON config
       expect(parsed).not.toHaveProperty("issueSource");
@@ -3072,34 +3002,17 @@ build_continuous_pr_body
       expect(readlinkSync(symlinkPath)).toBe(join(testDir, ".ralphai"));
     });
 
-    it("worktree replaces git-tracked .ralphai dir with symlink", () => {
+    it("worktree replaces existing .ralphai dir with symlink", () => {
       gitInitialCommit(testDir);
 
-      // Create .ralphai with a plan and git-track it (simulating a repo
-      // where .ralphai/ has committed files like ralphai.config.json)
+      // Create .ralphai with a plan (not git-tracked since .ralphai/ is gitignored)
       mkdirSync(join(testDir, ".ralphai", "pipeline", "backlog"), {
         recursive: true,
       });
-      mkdirSync(join(testDir, ".ralphai", "pipeline", "in-progress"), {
-        recursive: true,
-      });
-      writeFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        JSON.stringify({ agentCommand: "echo hello" }) + "\n",
-      );
       writeFileSync(
         join(testDir, ".ralphai", "pipeline", "backlog", "prd-tracked-test.md"),
         "# Tracked test\n",
       );
-      writeFileSync(
-        join(testDir, ".ralphai", "pipeline", "in-progress", ".gitkeep"),
-        "",
-      );
-      // Commit .ralphai/ so worktrees check it out as a real directory
-      execSync("git add .ralphai/ && git commit -m 'add .ralphai'", {
-        cwd: testDir,
-        stdio: "ignore",
-      });
 
       // Use a stub runner that just exits 0
       const stubScript = join(testDir, "stub-runner.sh");
@@ -3127,13 +3040,12 @@ build_continuous_pr_body
       expect(readlinkSync(symlinkPath)).toBe(join(testDir, ".ralphai"));
     });
 
-    it("is_tree_dirty ignores .ralphai changes but catches real dirty state", () => {
+    it("is_tree_dirty ignores .ralphai changes (gitignored) but catches real dirty state", () => {
       gitInitialCommit(testDir);
 
-      // Create and track .ralphai/ files
-      mkdirSync(join(testDir, ".ralphai"), { recursive: true });
-      writeFileSync(join(testDir, ".ralphai", "ralphai.config"), "test=1\n");
-      execSync("git add .ralphai/ && git commit -m 'add .ralphai'", {
+      // Add .ralphai/ to .gitignore (as scaffold does)
+      writeFileSync(join(testDir, ".gitignore"), ".ralphai/\n");
+      execSync("git add .gitignore && git commit -m 'add gitignore'", {
         cwd: testDir,
         stdio: "ignore",
       });
@@ -3156,27 +3068,14 @@ build_continuous_pr_body
       // Clean tree should not be dirty
       expect(isDirty(testDir)).toBe(false);
 
-      // Replace .ralphai/ with a symlink (simulating worktree setup)
-      const wtDir = join(testDir, "wt-dirty-test");
-      execSync(`git worktree add "${wtDir}" -b ralphai/dirty-test HEAD`, {
-        cwd: testDir,
-        stdio: "ignore",
-      });
-      rmSync(join(wtDir, ".ralphai"), { recursive: true, force: true });
-      symlinkSync(join(testDir, ".ralphai"), join(wtDir, ".ralphai"));
-
-      // .ralphai symlink replacement should NOT make the tree dirty
-      expect(isDirty(wtDir)).toBe(false);
+      // Adding files inside .ralphai/ should NOT make the tree dirty (gitignored)
+      mkdirSync(join(testDir, ".ralphai"), { recursive: true });
+      writeFileSync(join(testDir, ".ralphai", "LEARNINGS.md"), "# Learnings");
+      expect(isDirty(testDir)).toBe(false);
 
       // But a real change (outside .ralphai) should still be caught
-      writeFileSync(join(wtDir, "real-change.txt"), "dirty");
-      expect(isDirty(wtDir)).toBe(true);
-
-      // Clean up
-      execSync(`git worktree remove --force "${wtDir}"`, {
-        cwd: testDir,
-        stdio: "ignore",
-      });
+      writeFileSync(join(testDir, "real-change.txt"), "dirty");
+      expect(isDirty(testDir)).toBe(true);
     });
 
     it("worktree reuses an existing in-progress worktree and auto-resumes", () => {
@@ -3232,8 +3131,8 @@ build_continuous_pr_body
         recursive: true,
       });
       writeFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "agent=claude -p\n",
+        join(testDir, "ralphai.json"),
+        JSON.stringify({ agentCommand: "claude -p" }) + "\n",
       );
       writeFileSync(
         join(
@@ -3279,8 +3178,8 @@ build_continuous_pr_body
         recursive: true,
       });
       writeFileSync(
-        join(testDir, ".ralphai", "ralphai.config.json"),
-        "agent=claude -p\n",
+        join(testDir, "ralphai.json"),
+        JSON.stringify({ agentCommand: "claude -p" }) + "\n",
       );
       writeFileSync(
         join(testDir, ".ralphai", "pipeline", "in-progress", "prd-search.md"),

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1,7 +1,6 @@
 import { execSync, spawn } from "child_process";
 import {
   existsSync,
-  lstatSync,
   mkdirSync,
   copyFileSync,
   writeFileSync,
@@ -591,13 +590,11 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
 
   const config = JSON.stringify(configObj, null, 2) + "\n";
 
-  writeFileSync(join(ralphaiDir, "ralphai.config.json"), config);
+  writeFileSync(join(cwd, "ralphai.json"), config);
 
-  // Create subdirectories with .gitkeep
+  // Create pipeline subdirectories (no .gitkeep — .ralphai/ is fully gitignored)
   for (const subdir of ["backlog", "wip", "in-progress", "out"]) {
-    const subdirPath = join(ralphaiDir, "pipeline", subdir);
-    mkdirSync(subdirPath, { recursive: true });
-    writeFileSync(join(subdirPath, ".gitkeep"), "");
+    mkdirSync(join(ralphaiDir, "pipeline", subdir), { recursive: true });
   }
 
   // Create .ralphai/LEARNINGS.md — Ralphai-specific learnings (gitignored, local-only)
@@ -622,17 +619,20 @@ Each entry should include:
 `;
   writeFileSync(join(ralphaiDir, "LEARNINGS.md"), learningsContent);
 
-  // Create .ralphai/.gitignore — plan files are local-only state, not tracked by git
-  const gitignoreContent = `# Plan files are local-only state (not tracked by git).
-# Only the directory structure (.gitkeep), config, and docs are committed.
-pipeline/backlog/*.md
-pipeline/wip/*.md
-pipeline/in-progress/*.md
-pipeline/in-progress/progress.md
-pipeline/out/
-LEARNINGS.md
-`;
-  writeFileSync(join(ralphaiDir, ".gitignore"), gitignoreContent);
+  // Ensure .ralphai/ is gitignored in the project's root .gitignore
+  const rootGitignore = join(cwd, ".gitignore");
+  const gitignoreEntry = ".ralphai/";
+  if (existsSync(rootGitignore)) {
+    const content = readFileSync(rootGitignore, "utf-8");
+    if (!content.split("\n").some((line) => line.trim() === gitignoreEntry)) {
+      writeFileSync(
+        rootGitignore,
+        content.trimEnd() + "\n\n# ralphai local pipeline state\n.ralphai/\n",
+      );
+    }
+  } else {
+    writeFileSync(rootGitignore, "# ralphai local pipeline state\n.ralphai/\n");
+  }
 
   // Create GitHub labels if issues integration is enabled
   let labelResult: LabelResult | null = null;
@@ -641,16 +641,16 @@ LEARNINGS.md
   }
 
   // Print success output
-  console.log(`${TEXT}Ralphai initialized in .ralphai/${RESET}`);
+  console.log(`${TEXT}Ralphai initialized${RESET}`);
   console.log();
   console.log(`${DIM}Created:${RESET}`);
   console.log(
-    `  .ralphai/ralphai.config.json ${DIM}Configuration (edit to customize)${RESET}`,
+    `  ralphai.json               ${DIM}Configuration (edit to customize)${RESET}`,
   );
   console.log(`  .ralphai/README.md         ${DIM}Operational docs${RESET}`);
   console.log(`  .ralphai/PLANNING.md   ${DIM}How to write plans${RESET}`);
   console.log(
-    `  .ralphai/LEARNINGS.md      ${DIM}Ralphai-specific learnings (gitignored)${RESET}`,
+    `  .ralphai/LEARNINGS.md      ${DIM}Ralphai-specific learnings${RESET}`,
   );
   console.log(`  .ralphai/pipeline/backlog/ ${DIM}Queue plans here${RESET}`);
   console.log(
@@ -668,9 +668,7 @@ LEARNINGS.md
   }
   console.log();
   console.log(`${DIM}Next steps:${RESET}`);
-  console.log(
-    `  1. Review ${TEXT}.ralphai/ralphai.config.json${RESET} and adjust settings`,
-  );
+  console.log(`  1. Review ${TEXT}ralphai.json${RESET} and adjust settings`);
   console.log(
     `  2. Read ${TEXT}.ralphai/PLANNING.md${RESET} for how to write plans`,
   );
@@ -825,7 +823,7 @@ async function runRalphaiReset(
     for (const wt of worktrees) {
       try {
         // Use --force because the worktree may have uncommitted changes
-        // (e.g. the .ralphai symlink replacement, or interrupted agent work).
+        // from interrupted agent work.
         execSync(`git worktree remove --force "${wt.path}"`, {
           cwd: ralphaiRoot,
           stdio: "pipe",
@@ -1362,7 +1360,7 @@ function cleanWorktrees(cwd: string): void {
       console.log(`Removing: ${wt.path} (${wt.branch})`);
       try {
         // Use --force because the worktree may have uncommitted changes
-        // (e.g. the .ralphai symlink replacement, or interrupted agent work).
+        // from interrupted agent work.
         execSync(`git worktree remove --force "${wt.path}"`, {
           cwd,
           stdio: "inherit",
@@ -1771,24 +1769,10 @@ async function runRalphaiWorktree(
   // sandboxing (OpenCode, Claude Code, Codex) reject reads/writes to the
   // main repo's .ralphai/ as "external directory" access.
   //
-  // When .ralphai/ is git-tracked, `git worktree add` checks out its
-  // tracked files as a real directory. We must replace it with a symlink
-  // so pipeline state (gitignored files like plans, receipts, progress)
-  // is shared with the main repo.
+  // Since .ralphai/ is fully gitignored, `git worktree add` won't create
+  // it in the worktree — we just need to add the symlink.
   const worktreeRalphaiLink = join(resolvedWorktreeDir, ".ralphai");
-  const needsSymlink =
-    !existsSync(worktreeRalphaiLink) ||
-    !lstatSync(worktreeRalphaiLink).isSymbolicLink();
-  if (needsSymlink) {
-    // Remove the real directory (if any) before creating the symlink.
-    // This is safe because the symlink target (main repo's .ralphai/)
-    // contains all the same tracked files plus gitignored pipeline state.
-    //
-    // The symlink replacement causes git to see tracked .ralphai/ files as
-    // deleted and the symlink as untracked. This is intentional — the
-    // runner's is_tree_dirty() excludes .ralphai from its checks so the
-    // worktree can start cleanly without extra commits.
-    rmSync(worktreeRalphaiLink, { recursive: true, force: true });
+  if (!existsSync(worktreeRalphaiLink)) {
     symlinkSync(join(cwd, ".ralphai"), worktreeRalphaiLink);
   }
 

--- a/templates/ralphai/PLANNING.md
+++ b/templates/ralphai/PLANNING.md
@@ -286,7 +286,7 @@ Fields:
 - `issue` — issue number
 - `issue-url` — full URL to the issue (used for repo detection and human reference)
 
-If `gh` is not available, the hooks are silently skipped. To disable automatic issue closing while keeping comments, set `"issueCloseOnComplete": false` in `.ralphai/ralphai.config.json`.
+If `gh` is not available, the hooks are silently skipped. To disable automatic issue closing while keeping comments, set `"issueCloseOnComplete": false` in `ralphai.json`.
 
 ### Be specific about locations
 

--- a/templates/ralphai/README.md
+++ b/templates/ralphai/README.md
@@ -28,7 +28,7 @@ wip/ (work in progress)  backlog/  -->  in-progress/  -->  out/
 3. **`in-progress/`** — Active work. Plan files and `progress.md` live here while ralphai is working. If a run is interrupted or exhausts its turns, files stay here so work can be resumed.
 4. **`out/`** — Archive. Plans and progress logs are moved here only when the agent signals `COMPLETE`.
 
-Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are **gitignored** (local-only state). Only directory structure (`.gitkeep` files) is tracked. This means moving files between lifecycle stages requires no git commits.
+Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are **gitignored** (local-only state). The entire `.ralphai/` directory is gitignored. This means moving files between lifecycle stages requires no git commits.
 
 ## Task Runner
 
@@ -63,7 +63,7 @@ No file arguments needed. The script auto-detects:
 
 The turn budget (N) resets for each new plan. After completing one plan, the script automatically picks the next one from the backlog and continues until the backlog is empty.
 
-Aborts if N consecutive turns produce no commits (stuck detection). The threshold defaults to 3 and can be configured via `maxStuck` in `.ralphai/ralphai.config.json`, `RALPHAI_MAX_STUCK` env var, or `--max-stuck=<n>` CLI flag.
+Aborts if N consecutive turns produce no commits (stuck detection). The threshold defaults to 3 and can be configured via `maxStuck` in `ralphai.json`, `RALPHAI_MAX_STUCK` env var, or `--max-stuck=<n>` CLI flag.
 
 `--dry-run` mode previews:
 
@@ -90,21 +90,19 @@ Dry run makes no mutations (no file moves, branch creation, or agent execution).
 
 ## Files
 
-| File / Directory        | Purpose                                                    |
-| ----------------------- | ---------------------------------------------------------- |
-| `ralphai.config.json`   | Optional repo-level config file (JSON format)              |
-| `README.md`             | This file — operational docs for the `.ralphai/` directory |
-| `PLANNING.md`           | Guide for writing plan files                               |
-| `.gitignore`            | Keeps plan files local-only (not tracked by git)           |
-| `.ralphai/LEARNINGS.md` | Ralphai-written learnings — gitignored, local-only         |
-| `wip/`                  | Work-in-progress plans — not scanned by ralphai            |
-| `backlog/`              | Incoming plans queued for ralphai to pick up               |
-| `in-progress/`          | Active plans and progress.md — work in flight              |
-| `out/`                  | Archived PRD files and progress logs from completed runs   |
+| File / Directory | Purpose                                                    |
+| ---------------- | ---------------------------------------------------------- |
+| `README.md`      | This file — operational docs for the `.ralphai/` directory |
+| `PLANNING.md`    | Guide for writing plan files                               |
+| `LEARNINGS.md`   | Ralphai-written learnings — local-only                     |
+| `wip/`           | Work-in-progress plans — not scanned by ralphai            |
+| `backlog/`       | Incoming plans queued for ralphai to pick up               |
+| `in-progress/`   | Active plans and progress.md — work in flight              |
+| `out/`           | Archived PRD files and progress logs from completed runs   |
 
 ## How It Works
 
-1. Ralphai loads `.ralphai/ralphai.config.json` (if present), applies env var overrides, then CLI flag overrides to resolve settings (agent command, feedback commands, base branch, mode, stuck threshold)
+1. Ralphai loads `ralphai.json` (if present), applies env var overrides, then CLI flag overrides to resolve settings (agent command, feedback commands, base branch, mode, stuck threshold)
 2. It scans `in-progress/` for existing plan files; if found, it resumes. Otherwise it picks from `backlog/` (LLM-selected when multiple ready plans exist) and moves the chosen plan to `in-progress/`, initializing `progress.md`
 3. A `ralphai/<plan-slug>` branch is created from the base branch (e.g. `ralphai/add-dark-mode` from `prd-add-dark-mode.md`; current branch reused on resume). If the branch already exists (local, remote, or has an open PR), the plan is skipped and the next one is tried.
 4. The agent receives a prompt with `@file` references to the plan files + `progress.md`
@@ -163,7 +161,7 @@ issue-url: https://github.com/owner/repo/issues/42
 **Requirements:**
 
 - `gh` CLI must be installed and authenticated (`gh auth login`). If `gh` is not available, hooks are silently skipped — no error.
-- To disable automatic issue closing while keeping completion comments, set `issueCloseOnComplete` to `false` in `.ralphai/ralphai.config.json`.
+- To disable automatic issue closing while keeping completion comments, set `issueCloseOnComplete` to `false` in `ralphai.json`.
 
 Plans without `source` frontmatter behave exactly as before.
 
@@ -215,20 +213,20 @@ Keeping learnings gitignored prevents auto-written entries from interfering with
 - **Direct mode by default**: Ralphai commits on your current branch with no branch creation or PR. Refuses to run on `main`/`master`.
 - **Direct mode safety**: `--direct` refuses to run on `main`/`master` — you must be on a feature branch.
 - **Collision detection**: Before creating a new branch, Ralphai checks for existing local/remote branches and open PRs. If a collision is found, the plan is skipped and the next one is tried.
-- **Plan files gitignored**: Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are gitignored (local-only state). Only `.gitkeep` files are tracked.
+- **Plan files gitignored**: The entire `.ralphai/` directory is gitignored. Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are local-only state.
 - **Stuck detection**: Ralphai aborts after N turns with no new commits (default 3, configurable)
 - **Turn timeout**: Optional per-invocation timeout (`turnTimeout` in seconds). When set, the agent command is killed if it exceeds the limit. Default is 0 (no timeout).
 - **Completion signal**: Agent outputs `<promise>COMPLETE</promise>` when all tasks are done
 
 ## Configuration
 
-Ralphai supports an optional config file at `.ralphai/ralphai.config.json` for repo-level defaults. Settings follow a strict precedence order:
+Ralphai supports an optional config file at `ralphai.json` (repo root) for repo-level defaults. Settings follow a strict precedence order:
 
 ```
 CLI flags  >  env vars  >  config file  >  built-in defaults
 ```
 
-### Config File (`.ralphai/ralphai.config.json`)
+### Config File (`ralphai.json`)
 
 A standard JSON file.
 
@@ -363,7 +361,7 @@ Ralphai supports working on a feature branch using direct mode. This is useful f
 ralphai run --turns=5 --direct
 ```
 
-Or via `.ralphai/ralphai.config.json`:
+Or via `ralphai.json`:
 
 ```json
 {
@@ -412,7 +410,7 @@ Ralphai can automatically pull work from GitHub Issues when the backlog is empty
 
 **Prerequisites:** The [`gh` CLI](https://cli.github.com/) must be installed and authenticated (`gh auth login`). If `gh` is not available, Ralphai silently skips issue pulling and continues normally.
 
-**Enable it** by setting `issueSource` to `"github"` in `.ralphai/ralphai.config.json`:
+**Enable it** by setting `issueSource` to `"github"` in `ralphai.json`:
 
 ```json
 {
@@ -489,11 +487,11 @@ Issue created with label "ralphai"
 
 ### Smoke Checks
 
-Use these checks to verify config behavior after changes to `.ralphai/ralphai.config.json`:
+Use these checks to verify config behavior after changes to `ralphai.json`:
 
-1. **No config** — Remove or rename `.ralphai/ralphai.config.json`. Run `--show-config` and confirm all settings show `(default)`.
+1. **No config** — Remove or rename `ralphai.json`. Run `--show-config` and confirm all settings show `(default)`.
 
-2. **Config file only** — Create `.ralphai/ralphai.config.json` with custom values (e.g. `{"agentCommand": "claude -p"}`). Run `--show-config` and confirm settings show `(config)`.
+2. **Config file only** — Create `ralphai.json` with custom values (e.g. `{"agentCommand": "claude -p"}`). Run `--show-config` and confirm settings show `(config)`.
 
 3. **Env var override** — Set an env var (e.g. `RALPHAI_AGENT_COMMAND='codex exec'`) with a config file present. Run `--show-config` and confirm the env var wins over the config file value.
 


### PR DESCRIPTION
## Summary

- **Untracks the broken `.ralphai` symlink** (was a `120000` blob pointing to itself) and gitignores the entire `.ralphai/` directory, eliminating the root cause of worktree dirty-state conflicts
- **Moves config from `.ralphai/ralphai.config.json` to `ralphai.json` at repo root** — tracked by git, auto-checked-out in worktrees, no special path handling needed
- **Removes all dirty-state workarounds** — the `:!.ralphai` pathspec hack in `is_tree_dirty()`, the `lstatSync`/`rmSync` directory-to-symlink replacement dance, `.gitkeep` files, and inner `.gitignore` creation

## Changes

| Area | What changed |
|------|-------------|
| `.gitignore` | `.ralphai/pipeline/in-progress/` → `.ralphai/` |
| `src/ralphai.ts` | scaffold writes `ralphai.json` at root; appends `.ralphai/` to project's `.gitignore`; simplified worktree symlink logic; removed `lstatSync` import |
| `runner/lib/defaults.sh` | `CONFIG_FILE="ralphai.json"`; config stays relative in worktree fallback (git checks it out) |
| `runner/lib/git.sh` | Removed `:!.ralphai` pathspec exclusions from `is_tree_dirty()` |
| `runner/lib/config.sh` | Updated comment/error references to `ralphai.json` |
| `src/ralphai.test.ts` | ~30+ config path refs updated; `.gitkeep` assertions removed; `.gitignore` and `is_tree_dirty` tests rewritten; worktree tests simplified |
| Docs/templates | All `ralphai.config.json` references updated to `ralphai.json` |

## Test results

194 tests pass, 0 failures.