### PR TITLE
fix(worktree): use ".ralphai" gitignore pattern to match symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ logs
 package-lock.json
 
 # ralphai local pipeline state (fully gitignored)
-.ralphai/
+.ralphai

--- a/runner/lib/git.sh
+++ b/runner/lib/git.sh
@@ -2,13 +2,17 @@
 # Sourced by ralphai.sh. Do not execute directly.
 
 is_tree_dirty() {
-  if ! git diff --quiet HEAD 2>/dev/null; then
+  # Exclude .ralphai — the worktree setup creates a symlink there that may
+  # appear as an untracked file when the worktree is based on a commit whose
+  # .gitignore only ignores ".ralphai/" (trailing-slash matches directories,
+  # not symlinks).
+  if ! git diff --quiet HEAD -- ':!.ralphai' 2>/dev/null; then
     return 0
   fi
-  if ! git diff --cached --quiet 2>/dev/null; then
+  if ! git diff --cached --quiet -- ':!.ralphai' 2>/dev/null; then
     return 0
   fi
-  if [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
+  if [[ -n "$(git ls-files --others --exclude-standard -- ':!.ralphai')" ]]; then
     return 0
   fi
   return 1

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -69,11 +69,13 @@ describe("ralphai command", () => {
     expect(existsSync(join(testDir, ".ralphai", "pipeline", "out"))).toBe(true);
   });
 
-  it("init --yes adds .ralphai/ to root .gitignore", () => {
+  it("init --yes adds .ralphai to root .gitignore", () => {
     runCliOutput(["init", "--yes"], testDir);
 
     const gitignore = readFileSync(join(testDir, ".gitignore"), "utf-8");
-    expect(gitignore).toContain(".ralphai/");
+    expect(gitignore).toContain(".ralphai");
+    // Should use ".ralphai" (no trailing slash) to also match symlinks in worktrees
+    expect(gitignore).not.toContain(".ralphai/");
   });
 
   it("init --yes creates LEARNINGS.md with seed content", () => {
@@ -3043,7 +3045,8 @@ build_continuous_pr_body
     it("is_tree_dirty ignores .ralphai changes (gitignored) but catches real dirty state", () => {
       gitInitialCommit(testDir);
 
-      // Add .ralphai/ to .gitignore (as scaffold does)
+      // Add .ralphai/ to .gitignore (legacy pattern — only matches directories,
+      // not symlinks; the pathspec exclusion in is_tree_dirty handles this)
       writeFileSync(join(testDir, ".gitignore"), ".ralphai/\n");
       execSync("git add .gitignore && git commit -m 'add gitignore'", {
         cwd: testDir,
@@ -3071,6 +3074,13 @@ build_continuous_pr_body
       // Adding files inside .ralphai/ should NOT make the tree dirty (gitignored)
       mkdirSync(join(testDir, ".ralphai"), { recursive: true });
       writeFileSync(join(testDir, ".ralphai", "LEARNINGS.md"), "# Learnings");
+      expect(isDirty(testDir)).toBe(false);
+
+      // A .ralphai symlink (as created in worktrees) should also not trigger dirty
+      rmSync(join(testDir, ".ralphai"), { recursive: true, force: true });
+      const symlinkTarget = join(testDir, ".ralphai-real");
+      mkdirSync(symlinkTarget, { recursive: true });
+      symlinkSync(symlinkTarget, join(testDir, ".ralphai"));
       expect(isDirty(testDir)).toBe(false);
 
       // But a real change (outside .ralphai) should still be caught

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -619,19 +619,27 @@ Each entry should include:
 `;
   writeFileSync(join(ralphaiDir, "LEARNINGS.md"), learningsContent);
 
-  // Ensure .ralphai/ is gitignored in the project's root .gitignore
+  // Ensure .ralphai is gitignored in the project's root .gitignore
+  // Use ".ralphai" (no trailing slash) so it matches both directories and
+  // symlinks — worktrees create a .ralphai symlink that ".ralphai/" won't match.
   const rootGitignore = join(cwd, ".gitignore");
-  const gitignoreEntry = ".ralphai/";
+  const gitignoreEntry = ".ralphai";
+  const gitignoreEntryLegacy = ".ralphai/";
   if (existsSync(rootGitignore)) {
     const content = readFileSync(rootGitignore, "utf-8");
-    if (!content.split("\n").some((line) => line.trim() === gitignoreEntry)) {
+    const lines = content.split("\n").map((l) => l.trim());
+    if (
+      !lines.some(
+        (line) => line === gitignoreEntry || line === gitignoreEntryLegacy,
+      )
+    ) {
       writeFileSync(
         rootGitignore,
-        content.trimEnd() + "\n\n# ralphai local pipeline state\n.ralphai/\n",
+        content.trimEnd() + "\n\n# ralphai local pipeline state\n.ralphai\n",
       );
     }
   } else {
-    writeFileSync(rootGitignore, "# ralphai local pipeline state\n.ralphai/\n");
+    writeFileSync(rootGitignore, "# ralphai local pipeline state\n.ralphai\n");
   }
 
   // Create GitHub labels if issues integration is enabled
@@ -1137,9 +1145,7 @@ function checkReceiptSource(ralphaiDir: string, isWorktree: boolean): boolean {
 
     if (receipt.source === "worktree" && !isWorktree) {
       console.error();
-      console.error(
-        `Plan "${receipt.slug}" is running in a worktree.`,
-      );
+      console.error(`Plan "${receipt.slug}" is running in a worktree.`);
       console.error();
       console.error(`  Worktree: ${receipt.worktree_path ?? "unknown"}`);
       console.error(`  Branch:   ${receipt.branch || "unknown"}`);
@@ -1244,18 +1250,14 @@ function selectPlanForWorktree(
   }
 
   if (!existsSync(backlogDir)) {
-    console.error(
-      `No backlog directory found at ${backlogDir}`,
-    );
+    console.error(`No backlog directory found at ${backlogDir}`);
     return null;
   }
 
   if (specificPlan) {
     const planPath = join(backlogDir, specificPlan);
     if (!existsSync(planPath)) {
-      console.error(
-        `Plan '${specificPlan}' not found in backlog.`,
-      );
+      console.error(`Plan '${specificPlan}' not found in backlog.`);
       return null;
     }
     const slug = specificPlan.replace(/^prd-/, "").replace(/\.md$/, "");
@@ -1649,9 +1651,7 @@ async function runRalphaiWorktree(
 
   // Guard: must be in main repo, not a worktree
   if (isGitWorktree(cwd)) {
-    console.error(
-      `'ralphai worktree' must be run from the main repository.`,
-    );
+    console.error(`'ralphai worktree' must be run from the main repository.`);
     console.error(
       "You are inside a worktree. Run this command from the main repo.",
     );
@@ -1685,7 +1685,7 @@ async function runRalphaiWorktree(
       `Plan "${plan.slug}" is already running in the main repository.`,
     );
     console.error();
-    console.error(`  Branch:  ${receipt.branch || "unknown"}`);    
+    console.error(`  Branch:  ${receipt.branch || "unknown"}`);
     console.error(`  Started: ${receipt.started_at || "unknown"}`);
     console.error();
     console.error(`  Finish or interrupt the main-repo run first, then retry.`);


### PR DESCRIPTION
## Summary

- Fix false "Working tree is dirty" error when running `ralphai worktree` on a fresh worktree
- Root cause: `.ralphai/` (trailing slash) in `.gitignore` only matches directories, not the `.ralphai` symlink that worktree setup creates
- Add `':!.ralphai'` pathspec exclusion to `is_tree_dirty()` as defense-in-depth for worktrees branched from older commits

## Changes

- **`.gitignore`** — `.ralphai/` → `.ralphai` (matches both dirs and symlinks)
- **`runner/lib/git.sh`** — `is_tree_dirty()` excludes `.ralphai` via pathspec so worktrees from older commits still work
- **`src/ralphai.ts`** — `init` scaffolds `.ralphai` (no slash); accepts legacy `.ralphai/` to avoid double-adding
- **`src/ralphai.test.ts`** — New test: `.ralphai` symlink does not trigger dirty state; updated init assertion