### PR TITLE
Plan: Promote `turns` to config key + all defaults in ralphai.json + expand init wizard

### DIFF
--- a/runner/lib/receipt.sh
+++ b/runner/lib/receipt.sh
@@ -17,6 +17,7 @@
 #   branch           — git branch name
 #   slug             — plan slug (derived from filename)
 #   agent            — agent command string
+#   turns_budget     — total turn budget for the run (resolved $TURNS; 0 = unlimited)
 #   turns_completed  — number of agent turns completed
 #   tasks_completed  — number of plan tasks completed (parsed from progress.md)
 
@@ -53,6 +54,7 @@ init_receipt() {
     echo "branch=$branch"
     echo "slug=$PLAN_SLUG"
     echo "agent=$AGENT_COMMAND"
+    echo "turns_budget=${TURNS:-5}"
     echo "turns_completed=0"
     echo "tasks_completed=0"
   } > "$RECEIPT_FILE"

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -3585,6 +3585,107 @@ build_continuous_pr_body
       expect(output).toContain("3 of 4 tasks");
     });
 
+    it("status shows turns remaining when receipt has turns_budget", () => {
+      runCli(["init", "--yes"], testDir);
+
+      const ipDir = join(testDir, ".ralphai", "pipeline", "in-progress");
+      mkdirSync(ipDir, { recursive: true });
+
+      // Plan with 2 tasks
+      writeFileSync(
+        join(ipDir, "prd-search.md"),
+        "# Search\n\n### Task 1: Index\n### Task 2: Query\n",
+      );
+
+      // Receipt with turns_budget=5, turns_completed=2 → 3 remaining
+      writeFileSync(
+        join(ipDir, "receipt-search.txt"),
+        [
+          "started_at=2026-03-07T12:00:00Z",
+          "source=main",
+          "branch=ralphai/search",
+          "slug=search",
+          "agent=claude -p",
+          "turns_budget=5",
+          "turns_completed=2",
+          "tasks_completed=1",
+        ].join("\n"),
+      );
+
+      const result = runCli(["status"], testDir);
+      const output = result.stdout + result.stderr;
+
+      expect(result.exitCode).toBe(0);
+      expect(output).toContain("3 turns remaining");
+    });
+
+    it("status shows unlimited turns when turns_budget is 0", () => {
+      runCli(["init", "--yes"], testDir);
+
+      const ipDir = join(testDir, ".ralphai", "pipeline", "in-progress");
+      mkdirSync(ipDir, { recursive: true });
+
+      // Plan with 1 task
+      writeFileSync(
+        join(ipDir, "prd-refactor.md"),
+        "# Refactor\n\n### Task 1: Cleanup\n",
+      );
+
+      // Receipt with turns_budget=0 (unlimited)
+      writeFileSync(
+        join(ipDir, "receipt-refactor.txt"),
+        [
+          "started_at=2026-03-07T12:00:00Z",
+          "source=main",
+          "branch=ralphai/refactor",
+          "slug=refactor",
+          "agent=claude -p",
+          "turns_budget=0",
+          "turns_completed=4",
+          "tasks_completed=0",
+        ].join("\n"),
+      );
+
+      const result = runCli(["status"], testDir);
+      const output = result.stdout + result.stderr;
+
+      expect(result.exitCode).toBe(0);
+      expect(output).toContain("unlimited turns");
+    });
+
+    it("status shows no turns info for old receipt without turns_budget", () => {
+      runCli(["init", "--yes"], testDir);
+
+      const ipDir = join(testDir, ".ralphai", "pipeline", "in-progress");
+      mkdirSync(ipDir, { recursive: true });
+
+      writeFileSync(
+        join(ipDir, "prd-old-plan.md"),
+        "# Old Plan\n\n### Task 1: Stuff\n",
+      );
+
+      // Old receipt without turns_budget field — defaults to 0 in parseReceipt
+      writeFileSync(
+        join(ipDir, "receipt-old-plan.txt"),
+        [
+          "started_at=2026-03-07T12:00:00Z",
+          "source=main",
+          "branch=ralphai/old-plan",
+          "slug=old-plan",
+          "agent=claude -p",
+          "turns_completed=1",
+          "tasks_completed=0",
+        ].join("\n"),
+      );
+
+      const result = runCli(["status"], testDir);
+      const output = result.stdout + result.stderr;
+
+      expect(result.exitCode).toBe(0);
+      // Old receipts without turns_budget default to 0, which shows "unlimited turns"
+      expect(output).toContain("unlimited turns");
+    });
+
     it("status shows orphaned receipt as a problem", () => {
       runCli(["init", "--yes"], testDir);
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1197,6 +1197,7 @@ interface Receipt {
   branch: string;
   slug: string;
   agent: string;
+  turns_budget: number;
   turns_completed: number;
   tasks_completed: number;
 }
@@ -1218,6 +1219,7 @@ function parseReceipt(filePath: string): Receipt | null {
     branch: fields.branch ?? "",
     slug: fields.slug ?? "",
     agent: fields.agent ?? "",
+    turns_budget: parseInt(fields.turns_budget ?? "0", 10),
     turns_completed: parseInt(fields.turns_completed ?? "0", 10),
     tasks_completed: parseInt(fields.tasks_completed ?? "0", 10),
   };
@@ -1645,6 +1647,16 @@ function runRalphaiStatus(cwd: string): void {
     if (totalTasks > 0) {
       const completed = receipt?.tasks_completed ?? 0;
       parts.push(`${completed} of ${totalTasks} tasks`);
+    }
+
+    // Turns remaining
+    if (receipt) {
+      if (receipt.turns_budget > 0) {
+        const remaining = receipt.turns_budget - receipt.turns_completed;
+        parts.push(`${remaining} turns remaining`);
+      } else if (receipt.turns_budget === 0) {
+        parts.push("unlimited turns");
+      }
     }
 
     // Worktree info from receipt


### PR DESCRIPTION
## Plan

## Progress Log

### Task 1: Add `turns` to bash config infrastructure
**Status:** Complete

Added `turns` as a first-class config key in the bash runner infrastructure, matching the pattern used by all 16 existing config keys.

**Changes made:**
- `runner/lib/defaults.sh`: Added `CONFIG_TURNS=""` and `CLI_TURNS=""` variable initializations
- `runner/lib/config.sh`:
  - Added `"turns"` to the known-keys whitelist (jq array in `load_config()`)
  - Added `turns` parsing block in `load_config()` — validates as non-negative integer (`^[0-9]+$`), 0 = unlimited
  - Added `CONFIG_TURNS` merging in `apply_config()`
  - Added `RALPHAI_TURNS` env var handling in `apply_env_overrides()` with validation
  - Added `turns` source tracking in `--show-config` block (CLI > env > config > default)
  - Added `turns` display in `--show-config` output (shows "unlimited" when 0)
  - Updated `print_usage()` help text: added `turns` to supported config keys list and `RALPHAI_TURNS` to env var list

**Precedence chain (verified):**
`--turns` CLI > `RALPHAI_TURNS` env > `ralphai.json turns` > default 5

**Verification:** All feedback loops pass — `pnpm build`, `pnpm test` (194 tests), `pnpm type-check`.

### Task 2: Expand WizardAnswers and add 4 new wizard questions
**Status:** Complete

Expanded the init wizard from 4 questions to 8, adding turns, mode, autoCommit, and maxStuck.

**Changes made:**
- `src/ralphai.ts`:
  - Expanded `WizardAnswers` interface with 4 new optional fields: `turns?: number`, `mode?: "direct" | "pr"`, `autoCommit?: boolean`, `maxStuck?: number`
  - Added 4 new wizard questions in `runWizard()` (questions 4-7, shifting GitHub Issues to question 8):
    - turns: `clack.text()` with non-negative integer validation, default "5"
    - mode: `clack.select()` with "Direct" and "PR" options, cast via `as "direct" | "pr"`
    - autoCommit: `clack.confirm()` only shown when mode is "direct"
    - maxStuck: `clack.text()` with positive integer validation (`^[1-9]\d*$`), default "3"
  - Each new question follows the existing `clack.isCancel()` bail pattern
  - Updated return value to include all 4 new fields
  - Updated `runRalphaiInit()` `--yes` defaults to include `turns: 5`, `mode: "direct"`, `autoCommit: false`, `maxStuck: 3`

**Verification:** All feedback loops pass — `pnpm build`, `pnpm test` (194 tests), `pnpm type-check`.

---

## PRD: Show turns remaining in `ralphai status` output

### Task 1: Write turns_budget in init_receipt()
**Status:** Complete

Added `turns_budget` field to the receipt file written by `init_receipt()` in `runner/lib/receipt.sh`.

**Changes made:**
- `runner/lib/receipt.sh`:
  - Added `turns_budget` to the Fields comment header documentation
  - Added `echo "turns_budget=${TURNS:-5}"` line in `init_receipt()`, after `agent=` and before `turns_completed=0`
  - Uses `${TURNS:-5}` to default to 5 if `$TURNS` is empty (matching the runner's default)

### Task 2: Parse turns_budget in TypeScript
**Status:** Complete

Added `turns_budget` to the `Receipt` interface and `parseReceipt()` function.

**Changes made:**
- `src/ralphai.ts`:
  - Added `turns_budget: number` to the `Receipt` interface (L1185)
  - Added `turns_budget: parseInt(fields.turns_budget ?? "0", 10)` to `parseReceipt()` return (L1208)
  - Default of 0 provides backward compatibility with old receipts lacking the field

### Task 3: Show turns remaining in status output
**Status:** Complete

Added turns remaining display to the in-progress plan loop in `runRalphaiStatus()`.

**Changes made:**
- `src/ralphai.ts`:
  - Added "Turns remaining" block in the in-progress plan loop (after task progress, before worktree info)
  - When `turns_budget > 0`: computes `remaining = turns_budget - turns_completed`, shows "N turns remaining"
  - When `turns_budget === 0`: shows "unlimited turns"
  - When no receipt exists: shows nothing (no change)

### Task 4: Add tests
**Status:** Complete

Added 3 new tests in `src/ralphai.test.ts` for the turns remaining status feature.

**Changes made:**
- `src/ralphai.test.ts`:
  - Added "status shows turns remaining when receipt has turns_budget" — verifies "3 turns remaining" with `turns_budget=5`, `turns_completed=2`
  - Added "status shows unlimited turns when turns_budget is 0" — verifies "unlimited turns" with explicit `turns_budget=0`
  - Added "status shows no turns info for old receipt without turns_budget" — verifies backward compat (old receipts default to `turns_budget=0`, showing "unlimited turns")

**Verification:** All feedback loops pass — `pnpm build`, `pnpm test` (197 tests), `pnpm type-check`.

## Commits

```
38be6cf feat(status): show turns remaining in ralphai status output
ba13b44 feat(config): add turns as a config file key with env var and --show-config support
57a9bd4 feat(init): add turns, mode, autoCommit, maxStuck wizard questions
```