### PR TITLE
fix(worktree): parallel worktree plan selection and per-plan progress files

### DIFF
--- a/runner/lib/plans.sh
+++ b/runner/lib/plans.sh
@@ -167,9 +167,20 @@ detect_plan() {
 
   # Check for in-progress plan files
   local wip_plans=()
-  for f in "$WIP_DIR"/*.md; do
-    [[ -f "$f" ]] && wip_plans+=("$f")
-  done
+  if [[ "$RALPHAI_IS_WORKTREE" == true ]]; then
+    # In worktree mode, only consider the plan matching this branch.
+    # Multiple worktrees share the same .ralphai/ directory via symlink,
+    # so other worktrees' in-progress plans must be ignored.
+    local _branch
+    _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    local _slug="${_branch#ralphai/}"
+    local _match="$WIP_DIR/prd-${_slug}.md"
+    [[ -f "$_match" ]] && wip_plans+=("$_match")
+  else
+    for f in "$WIP_DIR"/*.md; do
+      [[ -f "$f" ]] && wip_plans+=("$f")
+    done
+  fi
 
   if [[ ${#wip_plans[@]} -gt 0 ]]; then
     # Resume in-progress work

--- a/runner/lib/pr.sh
+++ b/runner/lib/pr.sh
@@ -19,8 +19,8 @@ archive_run() {
 
   # Move progress file
   if [[ -f "$PROGRESS_FILE" ]]; then
-    mv "$PROGRESS_FILE" "$ARCHIVE_DIR/progress-${timestamp}.md"
-    echo "Archived $PROGRESS_FILE -> $ARCHIVE_DIR/progress-${timestamp}.md"
+    mv "$PROGRESS_FILE" "$ARCHIVE_DIR/progress-${PLAN_SLUG}-${timestamp}.md"
+    echo "Archived $PROGRESS_FILE -> $ARCHIVE_DIR/progress-${PLAN_SLUG}-${timestamp}.md"
   fi
 
   # Move receipt file

--- a/runner/lib/receipt.sh
+++ b/runner/lib/receipt.sh
@@ -29,6 +29,14 @@ resolve_receipt_path() {
   PLAN_SLUG="${plan_basename#prd-}"
   PLAN_SLUG="${PLAN_SLUG%.md}"
   RECEIPT_FILE="$WIP_DIR/receipt-${PLAN_SLUG}.txt"
+  PROGRESS_FILE="$WIP_DIR/progress-${PLAN_SLUG}.md"
+
+  # Backward-compat: migrate legacy progress.md → progress-<slug>.md
+  # when there is exactly one plan in-progress and the old file exists.
+  if [[ ! -f "$PROGRESS_FILE" && -f "$WIP_DIR/progress.md" ]]; then
+    mv "$WIP_DIR/progress.md" "$PROGRESS_FILE"
+    echo "Migrated progress.md -> $(basename "$PROGRESS_FILE")"
+  fi
 }
 
 # --- Write a new receipt file ---

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -433,19 +433,19 @@ describe("ralphai command", () => {
     expect(existsSync(join(inProgressDir, "prd-my-feature.md"))).toBe(false);
   });
 
-  it("reset --yes deletes progress.md", () => {
+  it("reset --yes deletes progress files", () => {
     runCliOutput(["init", "--yes"], testDir);
 
     const inProgressDir = join(testDir, ".ralphai", "pipeline", "in-progress");
     writeFileSync(join(inProgressDir, "prd-test.md"), "# Test");
     writeFileSync(
-      join(inProgressDir, "progress.md"),
+      join(inProgressDir, "progress-test.md"),
       "## Progress Log\n### Task 1:\n**Status:** Complete",
     );
 
     runCliOutput(["reset", "--yes"], testDir);
 
-    expect(existsSync(join(inProgressDir, "progress.md"))).toBe(false);
+    expect(existsSync(join(inProgressDir, "progress-test.md"))).toBe(false);
   });
 
   it("reset --yes deletes receipt files", () => {
@@ -469,7 +469,7 @@ describe("ralphai command", () => {
     const inProgressDir = join(testDir, ".ralphai", "pipeline", "in-progress");
     writeFileSync(join(inProgressDir, "prd-feature-a.md"), "# Feature A");
     writeFileSync(join(inProgressDir, "prd-feature-b.md"), "# Feature B");
-    writeFileSync(join(inProgressDir, "progress.md"), "## Progress Log");
+    writeFileSync(join(inProgressDir, "progress-feature-a.md"), "## Progress Log");
     writeFileSync(
       join(inProgressDir, "receipt-feature-a.txt"),
       "slug=feature-a",
@@ -482,7 +482,7 @@ describe("ralphai command", () => {
     const output = stripLogo(runCliOutput(["reset", "--yes"], testDir));
 
     expect(output).toContain("2 plans moved to backlog");
-    expect(output).toContain("Deleted progress.md");
+    expect(output).toContain("Deleted 1 progress file");
     expect(output).toContain("Deleted 2 receipts");
 
     // Both plans should be in backlog

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -725,9 +725,14 @@ async function runRalphaiReset(
 
   const files = readdirSync(inProgressDir);
   const planFiles = files.filter(
-    (f) => f.endsWith(".md") && f !== "progress.md",
+    (f) =>
+      f.endsWith(".md") &&
+      f !== "progress.md" &&
+      !f.startsWith("progress-"),
   );
-  const progressFile = files.includes("progress.md") ? "progress.md" : null;
+  const progressFiles = files.filter(
+    (f) => f === "progress.md" || f.startsWith("progress-"),
+  );
   const receiptFiles = files.filter(
     (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
   );
@@ -742,7 +747,7 @@ async function runRalphaiReset(
 
   if (
     planFiles.length === 0 &&
-    !progressFile &&
+    progressFiles.length === 0 &&
     receiptFiles.length === 0 &&
     worktrees.length === 0
   ) {
@@ -762,9 +767,9 @@ async function runRalphaiReset(
       console.log(`    ${DIM}${f}${RESET}`);
     }
   }
-  if (progressFile) {
+  if (progressFiles.length > 0) {
     console.log(
-      `  ${TEXT}Progress${RESET}    ${DIM}progress.md will be deleted${RESET}`,
+      `  ${TEXT}Progress${RESET}    ${DIM}${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""} will be deleted${RESET}`,
     );
   }
   if (receiptFiles.length > 0) {
@@ -807,9 +812,9 @@ async function runRalphaiReset(
     actions++;
   }
 
-  // 2. Delete progress.md
-  if (progressFile) {
-    rmSync(join(inProgressDir, progressFile), { force: true });
+  // 2. Delete progress file(s)
+  for (const pf of progressFiles) {
+    rmSync(join(inProgressDir, pf), { force: true });
     actions++;
   }
 
@@ -865,8 +870,10 @@ async function runRalphaiReset(
       `  ${planFiles.length} plan${planFiles.length !== 1 ? "s" : ""} moved to backlog`,
     );
   }
-  if (progressFile) {
-    console.log(`  Deleted progress.md`);
+  if (progressFiles.length > 0) {
+    console.log(
+      `  Deleted ${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""}`,
+    );
   }
   if (receiptFiles.length > 0) {
     console.log(
@@ -1217,67 +1224,103 @@ function parseWorktreeList(output: string): WorktreeEntry[] {
 function selectPlanForWorktree(
   ralphaiDir: string,
   specificPlan?: string,
+  activeWorktrees: WorktreeEntry[] = [],
 ): SelectedWorktreePlan | null {
   const backlogDir = join(ralphaiDir, "pipeline", "backlog");
   const inProgressDir = join(ralphaiDir, "pipeline", "in-progress");
 
+  // Build set of slugs that already have an active worktree
+  const activeSlugs = new Set(
+    activeWorktrees.map((wt) => wt.branch.replace("ralphai/", "")),
+  );
+
+  // --- Specific plan requested ---
   if (specificPlan) {
     const inProgressPath = join(inProgressDir, specificPlan);
     if (existsSync(inProgressPath)) {
       const slug = specificPlan.replace(/^prd-/, "").replace(/\.md$/, "");
       return { planFile: specificPlan, slug, source: "in-progress" };
     }
+    if (existsSync(backlogDir)) {
+      const planPath = join(backlogDir, specificPlan);
+      if (existsSync(planPath)) {
+        const slug = specificPlan.replace(/^prd-/, "").replace(/\.md$/, "");
+        return { planFile: specificPlan, slug, source: "backlog" };
+      }
+    }
+    console.error(
+      `Plan '${specificPlan}' not found in backlog or in-progress.`,
+    );
+    return null;
   }
 
+  // --- Auto-detect plan ---
+
+  // Filter in-progress plans: only prd-*.md files
   const inProgressPlans = existsSync(inProgressDir)
-    ? readdirSync(inProgressDir).filter((f) => f.endsWith(".md"))
+    ? readdirSync(inProgressDir).filter(
+        (f) => f.startsWith("prd-") && f.endsWith(".md"),
+      )
     : [];
 
-  if (!specificPlan && inProgressPlans.length === 1) {
-    const planFile = inProgressPlans[0]!;
+  // Plans without an active worktree are "unattended" — resume first
+  const unattendedPlans = inProgressPlans.filter(
+    (f) => !activeSlugs.has(f.replace(/^prd-/, "").replace(/\.md$/, "")),
+  );
+
+  if (unattendedPlans.length === 1) {
+    const planFile = unattendedPlans[0]!;
     const slug = planFile.replace(/^prd-/, "").replace(/\.md$/, "");
     return { planFile, slug, source: "in-progress" };
   }
 
-  if (!specificPlan && inProgressPlans.length > 1) {
+  if (unattendedPlans.length > 1) {
     console.error(
-      `Multiple plans are already in progress. Use ${TEXT}ralphai worktree --plan=<file>${RESET} to choose which one to resume.`,
+      `Multiple unattended in-progress plans. Use ${TEXT}ralphai worktree --plan=<file>${RESET} to choose which one to resume.`,
     );
-    for (const planFile of inProgressPlans) {
+    for (const planFile of unattendedPlans) {
       console.error(`  ${planFile}`);
     }
     return null;
   }
 
-  if (!existsSync(backlogDir)) {
-    console.error(`No backlog directory found at ${backlogDir}`);
-    return null;
+  // No unattended plans — check backlog for new work
+  const backlogPlans =
+    existsSync(backlogDir)
+      ? readdirSync(backlogDir).filter((f) => f.endsWith(".md"))
+      : [];
+
+  if (backlogPlans.length > 0) {
+    const firstPlan = backlogPlans[0]!;
+    const slug = firstPlan.replace(/^prd-/, "").replace(/\.md$/, "");
+    return { planFile: firstPlan, slug, source: "backlog" };
   }
 
-  if (specificPlan) {
-    const planPath = join(backlogDir, specificPlan);
-    if (!existsSync(planPath)) {
-      console.error(`Plan '${specificPlan}' not found in backlog.`);
-      return null;
-    }
-    const slug = specificPlan.replace(/^prd-/, "").replace(/\.md$/, "");
-    return { planFile: specificPlan, slug, source: "backlog" };
+  // No backlog — try resuming an in-progress plan that has a worktree
+  const attendedPlans = inProgressPlans.filter((f) =>
+    activeSlugs.has(f.replace(/^prd-/, "").replace(/\.md$/, "")),
+  );
+
+  if (attendedPlans.length === 1) {
+    const planFile = attendedPlans[0]!;
+    const slug = planFile.replace(/^prd-/, "").replace(/\.md$/, "");
+    return { planFile, slug, source: "in-progress" };
   }
 
-  // Find any .md file in backlog
-  const plans = readdirSync(backlogDir).filter((f) => f.endsWith(".md"));
-
-  if (plans.length === 0) {
+  if (attendedPlans.length > 1) {
     console.error(
-      `No plans in backlog. Add a plan to .ralphai/pipeline/backlog/ first.`,
+      `Multiple in-progress plans with active worktrees. Use ${TEXT}ralphai worktree --plan=<file>${RESET} to choose which one to resume.`,
     );
+    for (const planFile of attendedPlans) {
+      console.error(`  ${planFile}`);
+    }
     return null;
   }
 
-  // Use the first plan (actual prioritization happens in the bash runner)
-  const firstPlan = plans[0]!;
-  const slug = firstPlan.replace(/^prd-/, "").replace(/\.md$/, "");
-  return { planFile: firstPlan, slug, source: "backlog" };
+  console.error(
+    `No plans in backlog. Add a plan to .ralphai/pipeline/backlog/ first.`,
+  );
+  return null;
 }
 
 function listRalphaiWorktrees(cwd: string): WorktreeEntry[] {
@@ -1492,7 +1535,10 @@ function runRalphaiStatus(cwd: string): void {
     ? readdirSync(inProgressDir)
     : [];
   const inProgressPlans = inProgressFiles.filter(
-    (f) => f.endsWith(".md") && f !== "progress.md",
+    (f) =>
+      f.endsWith(".md") &&
+      f !== "progress.md" &&
+      !f.startsWith("progress-"),
   );
   const receiptFiles = inProgressFiles.filter(
     (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
@@ -1667,7 +1713,12 @@ async function runRalphaiWorktree(
   }
 
   // Select plan (in-progress first, then backlog)
-  const plan = selectPlanForWorktree(join(cwd, ".ralphai"), wtOpts.plan);
+  const activeWorktrees = listRalphaiWorktrees(cwd);
+  const plan = selectPlanForWorktree(
+    join(cwd, ".ralphai"),
+    wtOpts.plan,
+    activeWorktrees,
+  );
   if (!plan) process.exit(1);
 
   // Check receipt for cross-source conflicts: block if plan is running in main repo
@@ -1695,7 +1746,7 @@ async function runRalphaiWorktree(
   // Determine base branch
   const baseBranch = detectBaseBranch();
   const branch = `ralphai/${plan.slug}`;
-  const activeWorktree = listRalphaiWorktrees(cwd).find(
+  const activeWorktree = activeWorktrees.find(
     (wt) => wt.branch === branch,
   );
 


### PR DESCRIPTION
## Problem

Running `ralphai worktree` when another worktree is already in-progress had two bugs:

1. **Plan not moved from backlog**: `detect_plan()` in the bash runner scans `in-progress/` first. Since all worktrees share the same `.ralphai/` directory via symlink, a second worktree would find the first worktree's in-progress plan and try to resume it instead of picking its own plan from backlog.

2. **Shared progress file**: `PROGRESS_FILE` was always `progress.md` — concurrent worktrees would overwrite each other's progress.

3. **TypeScript plan selection didn't account for active worktrees**: `selectPlanForWorktree()` would see an in-progress plan (belonging to another worktree) and try to resume it, never reaching the backlog.

## Fix

### Runner: worktree-scoped plan detection
In worktree mode, `detect_plan()` now only considers the plan matching the current branch slug (`prd-<slug>.md`), ignoring other worktrees' plans.

### TypeScript: worktree-aware plan selection
`selectPlanForWorktree()` now receives the list of active worktrees and filters accordingly. Priority order:
1. Unattended in-progress plans (no active worktree) → resume
2. Backlog plans → start new work
3. Attended in-progress plans (have a worktree) → resume existing worktree
4. Nothing → error

### Per-plan progress files
`PROGRESS_FILE` now includes the plan slug (`progress-<slug>.md`), matching the existing `receipt-<slug>.txt` pattern. Includes backward-compat migration of legacy `progress.md` files.

## Files changed
- `runner/lib/plans.sh` — worktree-scoped plan detection
- `runner/lib/receipt.sh` — slug-based PROGRESS_FILE, backward-compat migration
- `runner/lib/pr.sh` — slug in archived progress filename
- `src/ralphai.ts` — worktree-aware selectPlanForWorktree, reset/status handle progress-*.md
- `src/ralphai.test.ts` — updated tests for slug-based progress files