### PR TITLE
fix: restrict batch task count regex to heading lines only

### DIFF
--- a/runner/lib/receipt.sh
+++ b/runner/lib/receipt.sh
@@ -113,7 +113,7 @@ update_receipt_tasks() {
     if [[ -n "$start_num" && -n "$end_num" && "$end_num" -gt "$start_num" ]]; then
       count=$((count + end_num - start_num + 1))
     fi
-  done < <(grep -i 'tasks\?[[:space:]]\+[0-9]\+[[:space:]]*[–-][[:space:]]*[0-9]\+' "$PROGRESS_FILE" 2>/dev/null || true)
+  done < <(grep -i '^### .*tasks\?[[:space:]]\+[0-9]\+[[:space:]]*[–-][[:space:]]*[0-9]\+' "$PROGRESS_FILE" 2>/dev/null || true)
 
   # Update or append tasks_completed in the receipt
   if grep -q '^tasks_completed=' "$RECEIPT_FILE"; then

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -4073,4 +4073,77 @@ build_continuous_pr_body
       expect(output).toContain("prd-search.md");
     });
   });
+
+  describe.skipIf(process.platform === "win32")(
+    "update_receipt_tasks batch counting",
+    () => {
+      const receiptShPath = join(
+        __dirname,
+        "..",
+        "runner",
+        "lib",
+        "receipt.sh",
+      );
+
+      /** Helper: run update_receipt_tasks with given progress content and return tasks_completed */
+      function countTasks(progressContent: string): number {
+        const progressFile = join(testDir, "progress.md");
+        const receiptFile = join(testDir, "receipt.txt");
+        writeFileSync(progressFile, progressContent);
+        writeFileSync(receiptFile, "tasks_completed=0\n");
+
+        execSync(
+          `bash -c 'export RECEIPT_FILE=${JSON.stringify(receiptFile)}; export PROGRESS_FILE=${JSON.stringify(progressFile)}; source ${JSON.stringify(receiptShPath)}; update_receipt_tasks'`,
+          { cwd: testDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+        );
+
+        const receipt = readFileSync(receiptFile, "utf-8");
+        const match = receipt.match(/^tasks_completed=(\d+)/m);
+        return match ? parseInt(match[1]!, 10) : -1;
+      }
+
+      it("counts individual Status Complete markers", () => {
+        expect(
+          countTasks(
+            "## Progress\n\n### Task 1: A\n**Status:** Complete\n\n### Task 2: B\n**Status:** Complete\n",
+          ),
+        ).toBe(2);
+      });
+
+      it("counts batch heading Tasks X-Y", () => {
+        expect(
+          countTasks(
+            "## Progress\n\n### Tasks 1-3: Batch\n**Status:** Complete\n",
+          ),
+        ).toBe(4); // 3 from batch (1-3) + 1 from Status Complete
+      });
+
+      it("does not count Tasks X-Y in prose body text", () => {
+        // Regression: prose mentioning "Tasks 3-4" was incorrectly counted as batch tasks
+        expect(
+          countTasks(
+            [
+              "## Progress",
+              "",
+              "### Task 1: Refactor",
+              "**Status:** Complete",
+              "",
+              "Refactored validation. CLI parsing moves in Tasks 3-4.",
+              "",
+              "### Task 2: Extract",
+              "**Status:** Complete",
+              "",
+              "Remaining size includes show-config which moves in Tasks 3-4.",
+            ].join("\n"),
+          ),
+        ).toBe(2); // Only 2 individual completions, prose mentions should be ignored
+      });
+
+      it("counts batch heading with en-dash Tasks X–Y", () => {
+        expect(
+          countTasks("## Progress\n\n### Tasks 5\u20138: Later batch\n"),
+        ).toBe(4); // 8 - 5 + 1 = 4 from batch, no Status Complete
+      });
+    },
+  );
 });

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1576,8 +1576,10 @@ function countCompletedTasks(progressPath: string): number {
   const completeMatches = content.match(/\*\*Status:\*\*\s*Complete/gi);
   let count = completeMatches ? completeMatches.length : 0;
 
-  // Count batch entries: `Tasks X–Y` or `Tasks X-Y`
-  const batchMatches = content.matchAll(/Tasks?\s+(\d+)\s*[–-]\s*(\d+)/gi);
+  // Count batch entries: `### ... Tasks X–Y` or `### ... Tasks X-Y` headings only
+  const batchMatches = content.matchAll(
+    /^### .*Tasks?\s+(\d+)\s*[–-]\s*(\d+)/gim,
+  );
   for (const match of batchMatches) {
     const start = parseInt(match[1]!, 10);
     const end = parseInt(match[2]!, 10);


### PR DESCRIPTION
## Summary

- **Bug:** `ralphai status` displayed "6 of 5 tasks" because the batch task counting regex (`Tasks X-Y`) matched prose body text in progress files, not just heading lines
- **Fix:** Restrict the batch regex in both `runner/lib/receipt.sh` (`update_receipt_tasks`) and `src/ralphai.ts` (`countCompletedTasks`) to only match lines starting with `###` (H3 markdown headings)
- **Tests:** Added 4 new tests for `update_receipt_tasks` covering individual markers, batch headings, en-dash variants, and the regression case (prose text containing "Tasks 3-4" no longer inflates the count)

## Root Cause

The progress file for `refactor-config-sh` contained two prose lines referencing "Tasks 3-4":

```
Refactored validation. CLI parsing moves in Tasks 3-4.
...remaining size includes show-config which move in Tasks 3-4
```

The loose grep/regex matched these as batch task completions, each contributing `4 - 3 + 1 = 2` phantom tasks. Combined with 2 real `**Status:** Complete` markers, the receipt got `tasks_completed=6` instead of `2`.