### PR TITLE
docs: restructure AGENTS.md with dogfooding section and learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,24 @@
 
 Project-specific guidance for AI coding agents working in this codebase.
 
-## Testing child process output capture
+## Dogfooding Ralphai
+
+Ralphai is an autonomous task runner for AI coding agents.
+
+Plan files go in `.ralphai/pipeline/backlog/`. See `.ralphai/PLANNING.md` for the
+plan writing guide. Plans not ready for execution go in
+`.ralphai/pipeline/wip/`.
+
+## Learnings
+
+### Testing child process output capture
 
 `spawnSync` with `stdio: "inherit"` sends output directly to the parent's file descriptors, bypassing any pipe that a grandparent test harness sets up via `execFileSync`. Use `stdio: ["inherit", "pipe", "pipe"]` and manually write `result.stdout`/`result.stderr` to `process.stdout`/`process.stderr` when the CLI output needs to be capturable by tests.
 
-## Windows CI has no bash
+### Windows CI has no bash
 
 Tests that spawn bash scripts (e.g. the task runner via `RALPHAI_RUNNER_SCRIPT`) must be skipped on Windows. Use `describe.skipIf(process.platform === "win32")` — same pattern as the existing executable-permission tests.
+
+### Batch task counting regexes must be anchored to headings
+
+The `update_receipt_tasks()` function in `runner/lib/receipt.sh` and `countCompletedTasks()` in `src/ralphai.ts` count batch task completions by matching `Tasks X-Y` patterns. These regexes must be anchored to `^### ` (H3 markdown headings) to avoid false matches on prose body text that references task ranges (e.g. "CLI parsing moves in Tasks 3-4").


### PR DESCRIPTION
## Summary

- Adds a "Dogfooding Ralphai" section pointing to backlog and planning docs
- Reorganizes existing learnings under a "Learnings" heading with proper H3 sub-sections
- Adds a new learning about anchoring batch task counting regexes to headings