### PR TITLE
refactor: remove fallback agent rotation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ npx ralphai uninstall && npm install -g ralphai@latest
 - **Worktree subcommand** — `ralphai worktree` runs a plan in an isolated git worktree with `list` and `clean` management commands (#41)
 - **Worktree-aware runner** — auto-detects git worktrees and adapts branch strategy, PR creation, and CLI suggestions accordingly (#39)
 - **Continuous single-branch mode** — replaced group mode with a simpler continuous + PR single-branch workflow (#38)
-- **Fallback agent rotation** — automatically rotates to a fallback agent when stuck, with per-plan agent override support (#35)
+- **~~Fallback agent rotation~~** — removed; stuck detection now aborts cleanly instead of rotating agents
 - **Real-time streaming output** — runner streams agent output in real time on Unix (#36)
 - **Self-update command** — `ralphai update` with background update notifications (#30)
 - **Direct mode safety guard** — shows copy-pasteable `git checkout` command when direct mode blocks on main/master (#33)

--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ Run:
   --continuous                      Keep processing backlog plans after the first completes
   --max-stuck=<n>                   Stuck threshold before abort (default: 3)
   --turn-timeout=<seconds>          Timeout per agent invocation (default: 0 = no timeout)
-  --fallback-agents=<list>          Comma-separated fallback agent commands (tried when stuck)
   --auto-commit                     Auto-commit agent changes between turns
   --no-auto-commit                  Disable auto-commit (default)
   --prompt-mode=<mode>              Prompt format: 'auto', 'at-path', or 'inline' (default: auto)
@@ -285,7 +284,6 @@ Settings resolve in this order: **CLI flags > env vars > `ralphai.json` > defaul
 | `RALPHAI_TURNS`                   | `turns`                |
 | `RALPHAI_PROMPT_MODE`             | `promptMode`           |
 | `RALPHAI_CONTINUOUS`              | `continuous`           |
-| `RALPHAI_FALLBACK_AGENTS`         | `fallbackAgents`       |
 | `RALPHAI_MAX_STUCK`               | `maxStuck`             |
 | `RALPHAI_TURN_TIMEOUT`            | `turnTimeout`          |
 | `RALPHAI_NO_UPDATE_CHECK`         | _(none)_               |

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -103,37 +103,6 @@ When a run is aborted due to stuck detection, the plan and progress files stay
 in `.ralphai/pipeline/in-progress/`. You can resume with `ralphai run` after
 investigating what went wrong — or adjust the plan and try again.
 
-## Fallback Agents
-
-When stuck detection fires, Ralphai doesn't have to give up — it can try a
-different agent. Fallback agents are an ordered list of alternative agent
-commands that Ralphai rotates through when the primary agent gets stuck.
-
-**How it works:**
-
-1. The primary agent hits the stuck threshold (no new commits for N
-   consecutive turns).
-2. Instead of aborting, Ralphai switches to the first fallback agent command
-   and **resets the stuck counter to zero**, giving the new agent a fresh
-   budget of N turns to make progress.
-3. If the first fallback also gets stuck, Ralphai moves to the next one in
-   the list.
-4. If all fallback agents are exhausted and the last one also gets stuck,
-   the run aborts — plan files stay in `in-progress/` for manual inspection.
-
-Each switch is logged in `progress.md` with a timestamp. The turn counter
-is **not** reset — fallback agents share the remaining turn budget.
-
-**Configuration:**
-
-- **Config file:** `"fallbackAgents": ["claude -p", "codex exec"]` in
-  `ralphai.json` (JSON array of strings, or a comma-separated string)
-- **Env var:** `RALPHAI_FALLBACK_AGENTS="claude -p,codex exec"`
-- **CLI flag:** `--fallback-agents='claude -p,codex exec'`
-
-Default: no fallback agents (empty). Ralphai aborts after the primary agent
-gets stuck.
-
 ## Continuous Mode
 
 By default, Ralphai stops after completing one plan. Continuous mode keeps
@@ -153,7 +122,7 @@ current branch. In **PR mode**, Ralphai creates a single **draft PR** after
 the first plan completes, updates it after each subsequent plan, and marks
 it as "ready for review" when the backlog is drained.
 
-If a plan fails mid-session (runs out of turns or all agents get stuck),
+If a plan fails mid-session (runs out of turns or the agent gets stuck),
 Ralphai pushes any partial work and exits — it does not skip ahead to the
 next plan.
 
@@ -181,8 +150,7 @@ prevents a single agent call from running indefinitely.
 4. The turn still counts toward the turn budget. The stuck counter
    increments (since a killed agent typically produces no commits).
 5. If the agent keeps timing out with no commits, stuck detection
-   eventually fires — which either rotates to a fallback agent or aborts
-   the run.
+   eventually fires — which aborts the run.
 
 A timed-out turn is not fatal on its own. Ralphai continues to the next
 turn, giving the agent another chance to make progress.

--- a/ralphai.json
+++ b/ralphai.json
@@ -1,10 +1,6 @@
 {
   "agentCommand": "claude -p",
-  "feedbackCommands": [
-    "pnpm build",
-    "pnpm test",
-    "pnpm type-check"
-  ],
+  "feedbackCommands": ["pnpm build", "pnpm test", "pnpm type-check"],
   "baseBranch": "main",
   "turns": 5,
   "mode": "pr",
@@ -13,7 +9,6 @@
   "turnTimeout": 0,
   "promptMode": "auto",
   "continuous": false,
-  "fallbackAgents": "",
   "issueSource": "none",
   "issueLabel": "ralphai",
   "issueInProgressLabel": "ralphai:in-progress",

--- a/runner/lib/cli.sh
+++ b/runner/lib/cli.sh
@@ -1,5 +1,5 @@
 # cli.sh — CLI argument parsing, config precedence orchestration,
-# fallback chain setup, and agent command validation.
+# and agent command validation.
 # Sourced by ralphai.sh after config.sh. Runs at source-time.
 # Depends on: defaults.sh (DEFAULT_* vars), validate.sh (validate_* helpers),
 #             config.sh (load_config, apply_config, apply_env_overrides)
@@ -27,7 +27,6 @@ print_usage() {
   echo "  --continuous                     Keep processing backlog plans after the first completes"
   echo "  --max-stuck=<n>                  Override stuck threshold (default: $DEFAULT_MAX_STUCK)"
   echo "  --turn-timeout=<seconds>         Timeout per agent invocation (default: 0 = no timeout)"
-  echo "  --fallback-agents=<list>         Comma-separated fallback agent commands (tried when stuck)"
   echo "  --auto-commit                    Enable auto-commit of agent changes (per-turn and resume recovery)"
   echo "  --no-auto-commit                 Disable auto-commit (default; only meaningful in patch mode)"
   echo "  --prompt-mode=<mode>             Prompt file ref format: 'auto', 'at-path', or 'inline' (default: auto)"
@@ -43,7 +42,7 @@ print_usage() {
   echo "Config file: $CONFIG_FILE (optional, JSON format)"
   echo "  Supported keys: agentCommand, feedbackCommands, baseBranch, maxStuck,"
   echo "                  mode, continuous, autoCommit, turns, turnTimeout, promptMode,"
-  echo "                  fallbackAgents, issueSource, issueLabel,"
+  echo "                  issueSource, issueLabel,"
   echo "                  issueInProgressLabel, issueRepo,"
   echo "                  issueCloseOnComplete, issueCommentProgress"
   echo ""
@@ -51,7 +50,7 @@ print_usage() {
   echo "                   RALPHAI_BASE_BRANCH, RALPHAI_MAX_STUCK,"
   echo "                   RALPHAI_MODE, RALPHAI_CONTINUOUS,"
   echo "                   RALPHAI_AUTO_COMMIT, RALPHAI_TURNS,"
-  echo "                   RALPHAI_TURN_TIMEOUT, RALPHAI_FALLBACK_AGENTS,"
+  echo "                   RALPHAI_TURN_TIMEOUT,"
   echo "                   RALPHAI_PROMPT_MODE,"
   echo "                   RALPHAI_ISSUE_SOURCE,"
   echo "                   RALPHAI_ISSUE_LABEL, RALPHAI_ISSUE_IN_PROGRESS_LABEL,"
@@ -180,13 +179,6 @@ for arg in "$@"; do
       CLI_ISSUE_COMMENT_PROGRESS="${arg#--issue-comment-progress=}"
       validate_boolean "$CLI_ISSUE_COMMENT_PROGRESS" "--issue-comment-progress"
       ;;
-    --fallback-agents=*)
-      CLI_FALLBACK_AGENTS="${arg#--fallback-agents=}"
-      # Empty value is valid (disables fallback); validate entries if non-empty
-      if [[ -n "$CLI_FALLBACK_AGENTS" ]]; then
-        validate_comma_list "$CLI_FALLBACK_AGENTS" "--fallback-agents"
-      fi
-      ;;
     *)
       echo "ERROR: Unrecognized argument: $arg"
       print_usage
@@ -256,23 +248,9 @@ fi
 if [[ -n "$CLI_PROMPT_MODE" ]]; then
   PROMPT_MODE="$CLI_PROMPT_MODE"
 fi
-if [[ -n "$CLI_FALLBACK_AGENTS" ]]; then
-  FALLBACK_AGENTS="$CLI_FALLBACK_AGENTS"
-fi
 if [[ -n "$CLI_AUTO_COMMIT" ]]; then
   AUTO_COMMIT="$CLI_AUTO_COMMIT"
 fi
-
-# --- Parse fallback chain into array ---
-FALLBACK_CHAIN=()
-if [[ -n "$FALLBACK_AGENTS" ]]; then
-  IFS=',' read -ra FALLBACK_CHAIN <<< "$FALLBACK_AGENTS"
-  # Trim whitespace from each entry
-  for i in "${!FALLBACK_CHAIN[@]}"; do
-    FALLBACK_CHAIN[$i]=$(echo "${FALLBACK_CHAIN[$i]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-  done
-fi
-FALLBACK_INDEX=0
 
 # --- Validate agentCommand is set ---
 if [[ -z "$AGENT_COMMAND" ]]; then

--- a/runner/lib/config.sh
+++ b/runner/lib/config.sh
@@ -31,7 +31,7 @@ load_config() {
 
   # Check for unknown keys
   local unknown_keys
-  unknown_keys=$(jq -r 'keys[] | select(. as $k | ["agentCommand","feedbackCommands","baseBranch","maxStuck","mode","issueCloseOnComplete","issueSource","issueLabel","issueInProgressLabel","issueRepo","issueCommentProgress","turnTimeout","promptMode","continuous","fallbackAgents","autoCommit","turns"] | index($k) | not)' "$config_path")
+  unknown_keys=$(jq -r 'keys[] | select(. as $k | ["agentCommand","feedbackCommands","baseBranch","maxStuck","mode","issueCloseOnComplete","issueSource","issueLabel","issueInProgressLabel","issueRepo","issueCommentProgress","turnTimeout","promptMode","continuous","autoCommit","turns"] | index($k) | not)' "$config_path")
   if [[ -n "$unknown_keys" ]]; then
     local first_unknown
     first_unknown=$(echo "$unknown_keys" | head -1)
@@ -179,22 +179,6 @@ load_config() {
     CONFIG_CONTINUOUS="$value"
   fi
 
-  # --- fallbackAgents (array of strings or comma-separated string) ---
-  if _json_has "fallbackAgents"; then
-    local fa_type
-    fa_type=$(jq -r '.fallbackAgents | type' "$config_path")
-    if [[ "$fa_type" == "array" ]]; then
-      value=$(jq -r '.fallbackAgents | join(",")' "$config_path")
-      validate_comma_list "$value" "$config_path: 'fallbackAgents' array"
-    elif [[ "$fa_type" == "string" ]]; then
-      value=$(_json_str "fallbackAgents")
-      validate_comma_list "$value" "$config_path: 'fallbackAgents'"
-    else
-      echo "ERROR: $config_path: 'fallbackAgents' must be an array of strings or a comma-separated string, got $fa_type"
-      exit 1
-    fi
-    CONFIG_FALLBACK_AGENTS="$value"
-  fi
 
   # --- autoCommit (boolean) ---
   if _json_has "autoCommit"; then
@@ -255,9 +239,6 @@ apply_config() {
   fi
   if [[ -n "${CONFIG_CONTINUOUS:-}" ]]; then
     CONTINUOUS="$CONFIG_CONTINUOUS"
-  fi
-  if [[ -n "${CONFIG_FALLBACK_AGENTS:-}" ]]; then
-    FALLBACK_AGENTS="$CONFIG_FALLBACK_AGENTS"
   fi
   if [[ -n "${CONFIG_AUTO_COMMIT:-}" ]]; then
     AUTO_COMMIT="$CONFIG_AUTO_COMMIT"
@@ -323,10 +304,6 @@ apply_env_overrides() {
   if [[ -n "${RALPHAI_CONTINUOUS:-}" ]]; then
     validate_boolean "$RALPHAI_CONTINUOUS" "RALPHAI_CONTINUOUS"
     CONTINUOUS="$RALPHAI_CONTINUOUS"
-  fi
-  if [[ -n "${RALPHAI_FALLBACK_AGENTS:-}" ]]; then
-    validate_comma_list "$RALPHAI_FALLBACK_AGENTS" "RALPHAI_FALLBACK_AGENTS"
-    FALLBACK_AGENTS="$RALPHAI_FALLBACK_AGENTS"
   fi
   if [[ -n "${RALPHAI_AUTO_COMMIT:-}" ]]; then
     validate_boolean "$RALPHAI_AUTO_COMMIT" "RALPHAI_AUTO_COMMIT"

--- a/runner/lib/defaults.sh
+++ b/runner/lib/defaults.sh
@@ -16,7 +16,6 @@ DEFAULT_ISSUE_COMMENT_PROGRESS="true"    # comment on issue during run
 DEFAULT_TURN_TIMEOUT=0                   # 0 = no timeout (seconds per agent invocation)
 DEFAULT_PROMPT_MODE="auto"               # "auto", "at-path", or "inline"
 DEFAULT_CONTINUOUS="false"               # "true" to keep draining backlog after first plan
-DEFAULT_FALLBACK_AGENTS=""               # comma-separated fallback agent commands
 DEFAULT_AUTO_COMMIT="false"              # "true" to auto-commit after turns / on resume (patch mode)
 
 # --- Resolved settings (will be overridden by config/env/CLI) ---
@@ -34,7 +33,6 @@ ISSUE_CLOSE_ON_COMPLETE="$DEFAULT_ISSUE_CLOSE_ON_COMPLETE"
 ISSUE_COMMENT_PROGRESS="$DEFAULT_ISSUE_COMMENT_PROGRESS"
 TURN_TIMEOUT="$DEFAULT_TURN_TIMEOUT"
 PROMPT_MODE="$DEFAULT_PROMPT_MODE"
-FALLBACK_AGENTS="$DEFAULT_FALLBACK_AGENTS"
 AUTO_COMMIT="$DEFAULT_AUTO_COMMIT"
 
 WIP_DIR=".ralphai/pipeline/in-progress"
@@ -97,7 +95,6 @@ CLI_ISSUE_REPO=""
 CLI_ISSUE_CLOSE_ON_COMPLETE=""
 CLI_ISSUE_COMMENT_PROGRESS=""
 CLI_PROMPT_MODE=""
-CLI_FALLBACK_AGENTS=""
 CLI_AUTO_COMMIT=""
 CLI_TURNS=""
 SHOW_CONFIG=false

--- a/runner/lib/show_config.sh
+++ b/runner/lib/show_config.sh
@@ -64,7 +64,6 @@ if [[ "$SHOW_CONFIG" == true ]]; then
   issue_close_source=$(_setting_source "$CLI_ISSUE_CLOSE_ON_COMPLETE" "RALPHAI_ISSUE_CLOSE_ON_COMPLETE" "${CONFIG_ISSUE_CLOSE_ON_COMPLETE:-}" "--issue-close-on-complete=$CLI_ISSUE_CLOSE_ON_COMPLETE")
   issue_comment_source=$(_setting_source "$CLI_ISSUE_COMMENT_PROGRESS" "RALPHAI_ISSUE_COMMENT_PROGRESS" "${CONFIG_ISSUE_COMMENT_PROGRESS:-}" "--issue-comment-progress=$CLI_ISSUE_COMMENT_PROGRESS")
   prompt_mode_source=$(_setting_source "$CLI_PROMPT_MODE" "RALPHAI_PROMPT_MODE" "${CONFIG_PROMPT_MODE:-}" "--prompt-mode=$CLI_PROMPT_MODE")
-  fallback_agents_source=$(_setting_source "$CLI_FALLBACK_AGENTS" "RALPHAI_FALLBACK_AGENTS" "${CONFIG_FALLBACK_AGENTS:-}" "--fallback-agents=$CLI_FALLBACK_AGENTS" "none")
 
   # auto_commit: special-case --no-auto-commit vs --auto-commit CLI label
   if [[ -n "$CLI_AUTO_COMMIT" ]]; then
@@ -101,7 +100,6 @@ if [[ "$SHOW_CONFIG" == true ]]; then
     echo "  turnTimeout        = off  ($timeout_source)"
   fi
   echo "  promptMode         = $PROMPT_MODE  ($prompt_mode_source)"
-  echo "  fallbackAgents     = ${FALLBACK_AGENTS:-<none>}  ($fallback_agents_source)"
   echo "  issueSource        = $ISSUE_SOURCE  ($issue_source_source)"
   if [[ "$ISSUE_SOURCE" != "none" ]]; then
     echo "  issueLabel         = $ISSUE_LABEL  ($issue_label_source)"

--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -153,13 +153,6 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "[dry-run] Would initialize: $PROGRESS_FILE"
   fi
 
-  if [[ ${#FALLBACK_CHAIN[@]} -gt 0 ]]; then
-    echo "[dry-run] Fallback chain (${#FALLBACK_CHAIN[@]} agent(s)):"
-    for fi_idx in "${!FALLBACK_CHAIN[@]}"; do
-      echo "[dry-run]   $((fi_idx + 1)). ${FALLBACK_CHAIN[$fi_idx]}"
-    done
-  fi
-
   echo "[dry-run] No files moved, no branches created, no agent run executed."
   exit 0
 fi
@@ -311,7 +304,7 @@ while true; do
   fi
 
   # --- Per-plan agent override ---
-  GLOBAL_AGENT_COMMAND="$AGENT_COMMAND"
+  SAVED_AGENT_COMMAND="$AGENT_COMMAND"
   plan_agent=$(extract_plan_agent "${WIP_FILES[0]}" 2>/dev/null || true)
   if [[ -n "$plan_agent" ]]; then
     AGENT_COMMAND="$plan_agent"
@@ -406,38 +399,15 @@ The <learnings> block is mandatory in every response. Ralphai will parse it and 
       stuck_count=$((stuck_count + 1))
       echo "WARNING: No new commits this turn ($stuck_count/$MAX_STUCK)."
       if [[ $stuck_count -ge $MAX_STUCK ]]; then
-        # --- Fallback agent rotation ---
-        if [[ $FALLBACK_INDEX -lt ${#FALLBACK_CHAIN[@]} ]]; then
-          next_agent="${FALLBACK_CHAIN[$FALLBACK_INDEX]}"
-          FALLBACK_INDEX=$((FALLBACK_INDEX + 1))
-          echo ""
-          echo "Agent stuck after $MAX_STUCK iterations with no progress."
-          echo "Switching to fallback agent: $next_agent"
-          AGENT_COMMAND="$next_agent"
-          detect_agent_type
-          resolve_prompt_mode
-          stuck_count=0
-          # Log switch to progress file
-          if [[ -n "${PROGRESS_FILE:-}" && -f "$PROGRESS_FILE" ]]; then
-            echo "" >> "$PROGRESS_FILE"
-            echo "--- Agent switch (stuck after $MAX_STUCK iterations) ---" >> "$PROGRESS_FILE"
-            echo "Switched to fallback agent: $next_agent" >> "$PROGRESS_FILE"
-            echo "Timestamp: $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$PROGRESS_FILE"
-          fi
-        else
-          echo "ERROR: $MAX_STUCK consecutive turns with no progress. All fallback agents exhausted."
-          echo "Branch: $branch"
-          echo "Plan files remain in $WIP_DIR/ — resume with another run."
-          # In continuous+PR mode, push partial work
-          if [[ "$CONTINUOUS" == "true" && "$MODE" == "pr" && -n "$CONTINUOUS_BRANCH" ]]; then
-            echo "Pushing partial work to continuous branch..."
-            git push origin "$branch" 2>&1 || true
-          fi
-          AGENT_COMMAND="$GLOBAL_AGENT_COMMAND"
-          detect_agent_type
-          resolve_prompt_mode
-          exit 1
+        echo "ERROR: $MAX_STUCK consecutive turns with no progress. Aborting."
+        echo "Branch: $branch"
+        echo "Plan files remain in $WIP_DIR/ — resume with another run."
+        # In continuous+PR mode, push partial work
+        if [[ "$CONTINUOUS" == "true" && "$MODE" == "pr" && -n "$CONTINUOUS_BRANCH" ]]; then
+          echo "Pushing partial work to continuous branch..."
+          git push origin "$branch" 2>&1 || true
         fi
+        exit 1
       fi
     else
       stuck_count=0
@@ -490,8 +460,8 @@ The <learnings> block is mandatory in every response. Ralphai will parse it and 
     fi
   done
 
-  # --- Restore global agent command after plan completes ---
-  AGENT_COMMAND="$GLOBAL_AGENT_COMMAND"
+  # --- Restore agent command after plan completes ---
+  AGENT_COMMAND="$SAVED_AGENT_COMMAND"
   detect_agent_type
   resolve_prompt_mode
 

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -114,8 +114,8 @@ describe("ralphai command", () => {
     const config = readFileSync(join(testDir, "ralphai.json"), "utf-8");
     const parsed = JSON.parse(config);
 
-    // Verify exactly 17 keys are present
-    expect(Object.keys(parsed)).toHaveLength(17);
+    // Verify exactly 16 keys are present
+    expect(Object.keys(parsed)).toHaveLength(16);
 
     // Core settings from wizard
     expect(parsed.agentCommand).toBe("opencode run --agent build");
@@ -132,7 +132,6 @@ describe("ralphai command", () => {
     expect(parsed.turnTimeout).toBe(0);
     expect(parsed.promptMode).toBe("auto");
     expect(parsed.continuous).toBe(false);
-    expect(parsed.fallbackAgents).toBe("");
 
     // Issue tracking defaults
     expect(parsed.issueSource).toBe("none");
@@ -150,7 +149,7 @@ describe("ralphai command", () => {
     const parsed = JSON.parse(config);
     expect(parsed.agentCommand).toBe("claude -p");
     // Other keys should still get defaults
-    expect(Object.keys(parsed)).toHaveLength(17);
+    expect(Object.keys(parsed)).toHaveLength(16);
     expect(parsed.turns).toBe(5);
     expect(parsed.mode).toBe("branch");
     expect(parsed.autoCommit).toBe(false);

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -676,7 +676,6 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
     turnTimeout: 0,
     promptMode: "auto",
     continuous: false,
-    fallbackAgents: "",
     issueSource: answers.issueSource ?? "none",
     issueLabel: "ralphai",
     issueInProgressLabel: "ralphai:in-progress",

--- a/templates/ralphai/README.md
+++ b/templates/ralphai/README.md
@@ -244,25 +244,24 @@ A standard JSON file.
 
 Supported keys:
 
-| Key                    | Description                                                                 | Default               | Validation                     |
-| ---------------------- | --------------------------------------------------------------------------- | --------------------- | ------------------------------ |
-| `agentCommand`         | Full CLI invocation prefix for the AI agent                                 | _(none)_              | Non-empty                      |
-| `feedbackCommands`     | Shell commands to run after each change (JSON array or comma-separated)     | _(none)_              | Array of non-empty strings     |
-| `baseBranch`           | Branch to create work branches from                                         | `main`                | Non-empty, single token        |
-| `mode`                 | Run mode: `direct` (commit on current branch) or `pr` (create branch + PR)  | `direct`              | `pr` or `direct`               |
-| `autoCommit`           | Auto-commit dirty state after each turn (ignored in PR mode)                | `false`               | `true` or `false`              |
-| `turns`                | Number of turns per plan (0 = unlimited)                                    | `5`                   | Non-negative integer           |
-| `maxStuck`             | Consecutive no-progress turns before aborting                               | `3`                   | Positive integer               |
-| `turnTimeout`          | Seconds before killing a hung agent invocation                              | `0` (off)             | Non-negative integer           |
-| `promptMode`           | How file refs are passed to the agent: `auto`, `at-path`, or `inline`       | `auto`                | `auto`, `at-path`, or `inline` |
-| `continuous`           | Keep processing backlog plans after the first completes                     | `false`               | `true` or `false`              |
-| `fallbackAgents`       | Alternative agent commands tried when stuck (comma-separated or JSON array) | _(none)_              | Array of non-empty strings     |
-| `issueSource`          | Issue source to pull from (`none` or `github`)                              | `none`                | `none` or `github`             |
-| `issueLabel`           | Label to filter GitHub issues by                                            | `ralphai`             | Non-empty                      |
-| `issueInProgressLabel` | Label applied when an issue is picked up                                    | `ralphai:in-progress` | Non-empty                      |
-| `issueRepo`            | `owner/repo` override (auto-detected from remote)                           | _(auto-detect)_       | Any value                      |
-| `issueCloseOnComplete` | Close the issue when the plan completes                                     | `true`                | `true` or `false`              |
-| `issueCommentProgress` | Comment on the issue during the run                                         | `true`                | `true` or `false`              |
+| Key                    | Description                                                                | Default               | Validation                     |
+| ---------------------- | -------------------------------------------------------------------------- | --------------------- | ------------------------------ |
+| `agentCommand`         | Full CLI invocation prefix for the AI agent                                | _(none)_              | Non-empty                      |
+| `feedbackCommands`     | Shell commands to run after each change (JSON array or comma-separated)    | _(none)_              | Array of non-empty strings     |
+| `baseBranch`           | Branch to create work branches from                                        | `main`                | Non-empty, single token        |
+| `mode`                 | Run mode: `direct` (commit on current branch) or `pr` (create branch + PR) | `direct`              | `pr` or `direct`               |
+| `autoCommit`           | Auto-commit dirty state after each turn (ignored in PR mode)               | `false`               | `true` or `false`              |
+| `turns`                | Number of turns per plan (0 = unlimited)                                   | `5`                   | Non-negative integer           |
+| `maxStuck`             | Consecutive no-progress turns before aborting                              | `3`                   | Positive integer               |
+| `turnTimeout`          | Seconds before killing a hung agent invocation                             | `0` (off)             | Non-negative integer           |
+| `promptMode`           | How file refs are passed to the agent: `auto`, `at-path`, or `inline`      | `auto`                | `auto`, `at-path`, or `inline` |
+| `continuous`           | Keep processing backlog plans after the first completes                    | `false`               | `true` or `false`              |
+| `issueSource`          | Issue source to pull from (`none` or `github`)                             | `none`                | `none` or `github`             |
+| `issueLabel`           | Label to filter GitHub issues by                                           | `ralphai`             | Non-empty                      |
+| `issueInProgressLabel` | Label applied when an issue is picked up                                   | `ralphai:in-progress` | Non-empty                      |
+| `issueRepo`            | `owner/repo` override (auto-detected from remote)                          | _(auto-detect)_       | Any value                      |
+| `issueCloseOnComplete` | Close the issue when the plan completes                                    | `true`                | `true` or `false`              |
+| `issueCommentProgress` | Comment on the issue during the run                                        | `true`                | `true` or `false`              |
 
 The `agentCommand` is the full CLI invocation prefix — Ralphai appends the prompt as a quoted argument. Examples:
 
@@ -301,7 +300,6 @@ Environment variables override config file values:
 | `RALPHAI_TURN_TIMEOUT`            | `turnTimeout`          |
 | `RALPHAI_PROMPT_MODE`             | `promptMode`           |
 | `RALPHAI_CONTINUOUS`              | `continuous`           |
-| `RALPHAI_FALLBACK_AGENTS`         | `fallbackAgents`       |
 | `RALPHAI_ISSUE_SOURCE`            | `issueSource`          |
 | `RALPHAI_ISSUE_LABEL`             | `issueLabel`           |
 | `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | `issueInProgressLabel` |
@@ -331,7 +329,6 @@ CLI flags have the highest priority:
 | `--turn-timeout=<seconds>`          | `turnTimeout`               |
 | `--prompt-mode=<mode>`              | `promptMode`                |
 | `--continuous`                      | `continuous` (sets `true`)  |
-| `--fallback-agents=<list>`          | `fallbackAgents`            |
 | `--issue-source=<source>`           | `issueSource`               |
 | `--issue-label=<label>`             | `issueLabel`                |
 | `--issue-in-progress-label=<label>` | `issueInProgressLabel`      |


### PR DESCRIPTION
## Summary

- Remove the fallback agent rotation feature entirely — it was overdesigned and unused
- Stuck detection now aborts cleanly with exit 1 instead of rotating to alternative agents
- Per-plan agent overrides (`extract_plan_agent`) continue to work as before

## Changes

**Shell runner** (`runner/`):
- `defaults.sh`: removed `DEFAULT_FALLBACK_AGENTS`, `FALLBACK_AGENTS`, `CLI_FALLBACK_AGENTS`
- `config.sh`: removed `fallbackAgents` config parsing, `RALPHAI_FALLBACK_AGENTS` env var, `--fallback-agents` CLI flag, `FALLBACK_CHAIN`/`FALLBACK_INDEX` construction, and show-config output
- `ralphai.sh`: replaced fallback rotation logic with simple abort; replaced `GLOBAL_AGENT_COMMAND` with `SAVED_AGENT_COMMAND` for per-plan agent save/restore

**Node.js** (`src/`):
- `ralphai.ts`: removed `fallbackAgents: ""` from init wizard config
- `ralphai.test.ts`: removed `fallbackAgents` assertion, updated config key count (17 → 16)

**Config**: removed `"fallbackAgents": ""` from `ralphai.json`

**Docs**: removed Fallback Agents section from `docs/how-ralphai-works.md`, cleaned cross-references in turn timeout section, removed from CLI/env/config tables in `README.md` and `templates/ralphai/README.md`, updated `CHANGELOG.md`

## Verification

- All 230 tests pass
- Build and type-check pass
- `grep -r` confirms no fallback agent references remain (excluding unrelated uses of "fallback")