### PR TITLE
docs: streamline docs — 57% line reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,193 +2,90 @@
 
 Put your AI coding agent on autopilot.
 
-Ralphai takes [plan files](#1-write-plans) (markdown) from its backlog and drives any CLI-based coding agent to implement them, with branch isolation, feedback loops, and stuck detection built in. Each plan contains tasks — like a todo list for the agent to work through. You write the plans (or have your agent write them). Ralphai does the rest.
+Ralphai takes [plan files](#1-write-plans) (markdown) from its backlog and drives any CLI-based coding agent to implement them, with branch isolation, feedback loops, and stuck detection built in. You write the plans (or have your agent write them). Ralphai does the rest.
 
 ## Why Ralphai?
 
-AI coding agents get worse the longer they run. Every model can only "see" a limited amount of text at once (its context window). As the conversation grows, the model quietly drops or summarizes older messages. It forgets what it already tried, repeats mistakes, or contradicts earlier work. [More on this →](docs/how-ralphai-works.md#context-rot)
+AI coding agents get worse the longer they run. As the conversation grows, the model drops older context — it forgets what it tried, repeats mistakes, and drifts.
 
 Ralphai avoids this by starting each **turn** with a **fresh session**: just the plan and a progress log. No conversation history to lose, no drift.
 
-- **No context rot** — turn 50 is as sharp as turn 1
+- **No context rot** — turn 10 is as sharp as turn 1
 - **Fresh feedback** — real build output every cycle, never recalled from memory
 - **Stuck detection** — stops burning tokens when progress stalls
-- **Unattended** — write plans, walk away
+
+[How it works →](docs/how-ralphai-works.md)
 
 ## Install
 
-**Global** (recommended for individual use):
-
 ```bash
-npm install -g ralphai
-```
-
-**Local dev dependency** (pins the version in package.json):
-
-```bash
-npm install -D ralphai
-```
-
-**npx** (no install, runs latest):
-
-```bash
-npx ralphai
+npm install -g ralphai       # global (recommended)
+npm install -D ralphai       # local dev dependency
+npx ralphai                  # no install, runs latest
 ```
 
 ## Get Started
 
-In your project directory:
-
 ```bash
-ralphai init
+ralphai init                 # scaffold .ralphai/ and ralphai.json
 ```
 
-Ralphai scaffolds a `.ralphai/` directory into your project with docs and a plan pipeline, and creates a `ralphai.json` config file at the repo root. It detects your package manager and build scripts automatically.
-
-> Use `ralphai init --yes` to skip prompts and accept defaults.
+Ralphai detects your package manager and build scripts automatically. Use `--yes` to skip prompts.
 
 ## Workflow
 
 ### 1. Write plans
 
-Ask your coding agent to create plan files in `.ralphai/pipeline/backlog/`. Point it at `.ralphai/PLANNING.md` for structure and examples, or roll your own format. Ralphai just needs markdown files with clear [**acceptance criteria**](templates/ralphai/PLANNING.md).
-
-> Plan files are **gitignored** — they're local-only state, not tracked by git.
+Ask your coding agent to create plan files in `.ralphai/pipeline/backlog/`. Point it at `.ralphai/PLANNING.md` for structure and examples.
 
 ```
 Create a plan in the ralphai backlog for adding dark mode support.
 Use PLANNING.md as a guide.
 ```
 
+> Plan files are **gitignored** — local-only state.
+
 ### 2. Run
 
-Ralphai commits on your **current branch** by default. It refuses to run on `main`/`master` — create or switch to a feature branch first.
+Ralphai commits on your **current branch** by default. It refuses to run on `main`/`master` — switch to a feature branch first.
 
 ```bash
 git checkout -b my-feature
 ralphai run
 ```
 
-Ralphai picks a plan from the backlog, hands it to your agent, and loops. Each turn, the agent works on one task, then ralphai runs build, test, and lint. When all the tasks in a plan is done, it commits the changes on your current branch.
-
-```
-    ┌─────────────────────────────────────┐
-    │            Fresh session            │
-    │   plan + progress log + learnings   │
-    └──────────────────┬──────────────────┘
-                       ▼
-               ┌───────────────┐
-               │  Agent works  │
-               │ on next task  │
-               └───────┬───────┘
-                       ▼
-               ┌───────────────┐
-               │  Agent runs   │
-               │  build/test/  │◄──┐
-               │     lint      │   │
-               └───────┬───────┘   │
-                       ▼           │
-                 ┌───────────┐     │
-                 │  Errors?  │─yes─┘
-                 └─────┬─────┘
-                       │ no
-                       ▼
-                 ┌───────────┐
-                 │  Commit   │
-                 └─────┬─────┘
-                       ▼
-                   Next turn
-                (fresh session)
-```
-
-Common options:
+Each turn: the agent reads the plan, implements the next task, runs build/test/lint, fixes errors, and commits. Then a fresh session starts for the next turn.
 
 ```bash
 ralphai run --turns=3    # 3 turns per plan (default: 5)
-ralphai run --turns=0    # unlimited turns — runs until all work is done
-ralphai run --pr         # create a ralphai/* branch and open a PR instead
-ralphai run --dry-run    # preview what ralphai would do without changing anything
+ralphai run --turns=0    # unlimited turns
+ralphai run --pr         # create a ralphai/* branch and open a PR
+ralphai run --dry-run    # preview without changing anything
 ```
 
-> A single turn can take several minutes (agent invocation + feedback commands). Don't expect `progress.md` to update every few seconds — it updates between turns when there's something to report.
-
-### 2b. Run in a worktree
-
-For non-disruptive parallel work, use `ralphai worktree` to run a plan in an isolated [git worktree](https://git-scm.com/docs/git-worktree). This lets you keep working in your main checkout while Ralphai runs in a separate directory.
+For parallel work, run in a [git worktree](docs/worktrees.md):
 
 ```bash
-ralphai worktree                          # auto-pick next backlog plan
-ralphai worktree --turns=3                # run with 3 turns per plan
-ralphai worktree --plan=dark-mode.md      # target a specific plan
+ralphai worktree                    # auto-pick next backlog plan
+ralphai worktree list               # show active worktrees
+ralphai worktree clean              # remove completed worktrees
 ```
-
-The lifecycle: create worktree → run plan → create PR → clean up. If the agent gets stuck or times out, the worktree is preserved. Re-run `ralphai worktree` from the main repo to reuse it, or `cd` into the worktree and run `ralphai run --resume` directly.
-
-```bash
-ralphai worktree list    # show active ralphai-managed worktrees
-ralphai worktree clean   # remove completed/orphaned worktrees
-```
-
-> `ralphai worktree` must be run from the **main repository**, not from inside a worktree. All runner options (`--turns`, `--agent-command`, `--feedback-commands`, etc.) are forwarded automatically.
 
 ### 3. Steer
 
-Plans flow through three directories: `backlog/ → in-progress/ → out/`. Not ready for Ralphai to pick something up? Park it in `wip/` — Ralphai ignores that folder.
-
-```
-pipeline/backlog/       ← queued, ralphai picks from here
-pipeline/in-progress/   ← ralphai is working on it
-pipeline/out/           ← done, archived
-pipeline/wip/           ← parked, ralphai ignores
-```
+Plans flow through `backlog/` → `in-progress/` → `out/`. Park unready plans in `wip/` — Ralphai ignores that folder.
 
 ### 4. Pause and resume
 
-Stop mid-run any time. Work stays in `in-progress/`. Resume by running `ralphai run` again — it auto-detects in-progress work. For worktree runs, re-run `ralphai worktree` from the main repo to reuse the existing managed worktree, or resume inside the worktree with `ralphai run --resume`.
-
-Use `ralphai status` to see what's in the backlog, what's in progress (with task counts), active worktrees, and any problems.
+Stop mid-run any time. Work stays in `in-progress/`. Resume with `ralphai run` — it auto-detects in-progress work. Use `ralphai status` to see what's queued, in progress, and any problems.
 
 ### 5. Close the learnings loop
 
-Ralphai logs mistakes to `.ralphai/LEARNINGS.md` (gitignored) during runs. After a run, review those entries and promote durable lessons to `AGENTS.md` or skill docs. [How the learnings system works →](docs/how-ralphai-works.md#learnings-system)
-
-### After you're set up
-
-1. **Commit `ralphai.json` to git.** It's the shared config for your team.
-
-2. **Review `ralphai.json`** and adjust settings (agent command,
-   feedback commands, base branch, etc.).
-
-<details>
-<summary><strong>Advanced: Git Worktrees</strong></summary>
-
-For worktree internals, agent compatibility, and manual worktree setup, see
-[Worktrees](docs/worktrees.md).
-
-</details>
-
-## How Ralphai Works
-
-- **Direct mode by default** — commits on your current branch, no branch creation or PR
-- **`--pr` mode** — creates a `ralphai/<plan-name>` branch and opens a PR via `gh`
-- **Feedback loops** — build, test, and lint run after each turn (auto-detected or configured)
-- **Stuck detection** — if N turns produce no commits, Ralphai aborts (default: 3)
-- **Plan dependencies** — plans can declare `depends-on` for ordering across a backlog
-- **GitHub Issues** — Ralphai can pull labeled issues when the backlog is empty
-
-See [How Ralphai Works](docs/how-ralphai-works.md) for the full picture.
-
-## Docs
-
-After `ralphai init`, pipeline docs live in `.ralphai/` (local-only, gitignored):
-
-- `.ralphai/README.md` — full operational docs (lifecycle, config)
-- `.ralphai/PLANNING.md` — guide for writing plan files (give this to your agent)
-- [Worktrees](docs/worktrees.md) — worktree usage, agent compatibility, and manual setup
+Ralphai logs mistakes to `.ralphai/LEARNINGS.md` (gitignored) during runs. After a run, review entries and promote durable lessons to `AGENTS.md` or skill docs. [More →](docs/how-ralphai-works.md#learnings-system)
 
 ## Supported Agents
 
-Ralphai works with any CLI agent that accepts a prompt argument. **Claude Code** and **OpenCode** are actively tested. The other presets are included for convenience but have not been validated end-to-end — they should work, but your mileage may vary.
+Ralphai works with any CLI agent that accepts a prompt argument. **Claude Code** and **OpenCode** are actively tested.
 
 <details>
 <summary>Agent commands</summary>
@@ -206,100 +103,17 @@ Ralphai works with any CLI agent that accepts a prompt argument. **Claude Code**
 
 </details>
 
-## CLI Reference
+## Reference
 
-<details>
-<summary>Commands and options</summary>
-
-```
-ralphai <command> [options]
-
-Commands:
-  init        Set up Ralphai in your project
-  run         Start the Ralphai task runner
-  worktree    Run in an isolated git worktree
-  status      Show pipeline and worktree status
-  reset       Move in-progress plans back to backlog and clean up
-  update      Update ralphai to the latest (or specified) version
-  uninstall   Remove Ralphai from your project
-
-Options:
-  --help, -h     Show help
-  --version, -v  Show version
-
-Init:
-  --yes, -y              Skip prompts, use defaults
-  --force                Re-scaffold from scratch
-  --agent-command=CMD    Set the agent command
-
-Run:
-  --turns=<n>                       Turns per plan (default: 5, 0 = unlimited)
-  --dry-run, -n                     Preview what would happen without changing anything
-  --resume, -r                      Auto-commit dirty state and continue
-  --agent-command=<command>         Override agent CLI command
-  --feedback-commands=<list>        Comma-separated feedback commands
-  --base-branch=<branch>            Override base branch (default: main)
-  --direct                          Direct mode (default): commit on current branch, no PR
-  --pr                              PR mode: create branch, push, and open PR
-  --continuous                      Keep processing backlog plans after the first completes
-  --max-stuck=<n>                   Stuck threshold before abort (default: 3)
-  --turn-timeout=<seconds>          Timeout per agent invocation (default: 0 = no timeout)
-  --auto-commit                     Auto-commit agent changes between turns
-  --no-auto-commit                  Disable auto-commit (default)
-  --prompt-mode=<mode>              Prompt format: 'auto', 'at-path', or 'inline' (default: auto)
-  --show-config                     Print resolved settings and exit
-  --issue-source=<source>           Issue source: 'none' or 'github' (default: none)
-  --issue-label=<label>             Label to filter issues (default: ralphai)
-  --issue-in-progress-label=<label> Label applied when issue is picked up
-  --issue-repo=<owner/repo>         Override repo for issue operations (default: auto-detect)
-  --issue-close-on-complete=<bool>  Close issue on plan completion (default: true)
-  --issue-comment-progress=<bool>   Comment on issue during run (default: true)
-
-Worktree:
-  --plan=<file>     Target a specific backlog plan (default: auto-detect)
-  --dir=<path>      Worktree directory (default: ../.ralphai-worktrees/<slug>)
-  worktree list     Show active ralphai-managed worktrees
-  worktree clean    Remove completed/orphaned worktrees
-
-Reset:
-  --yes, -y         Skip confirmation prompt
-```
-
-</details>
-
-## Configuration
-
-Settings resolve in this order: **CLI flags > env vars > `ralphai.json` > defaults**.
-
-<details>
-<summary>Environment variables</summary>
-
-| Env Var                           | Config Key             |
-| --------------------------------- | ---------------------- |
-| `RALPHAI_AGENT_COMMAND`           | `agentCommand`         |
-| `RALPHAI_FEEDBACK_COMMANDS`       | `feedbackCommands`     |
-| `RALPHAI_BASE_BRANCH`             | `baseBranch`           |
-| `RALPHAI_MODE`                    | `mode`                 |
-| `RALPHAI_AUTO_COMMIT`             | `autoCommit`           |
-| `RALPHAI_TURNS`                   | `turns`                |
-| `RALPHAI_PROMPT_MODE`             | `promptMode`           |
-| `RALPHAI_CONTINUOUS`              | `continuous`           |
-| `RALPHAI_MAX_STUCK`               | `maxStuck`             |
-| `RALPHAI_TURN_TIMEOUT`            | `turnTimeout`          |
-| `RALPHAI_NO_UPDATE_CHECK`         | _(none)_               |
-| `RALPHAI_ISSUE_SOURCE`            | `issueSource`          |
-| `RALPHAI_ISSUE_LABEL`             | `issueLabel`           |
-| `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | `issueInProgressLabel` |
-| `RALPHAI_ISSUE_REPO`              | `issueRepo`            |
-| `RALPHAI_ISSUE_CLOSE_ON_COMPLETE` | `issueCloseOnComplete` |
-| `RALPHAI_ISSUE_COMMENT_PROGRESS`  | `issueCommentProgress` |
-
-</details>
+- [CLI Reference](docs/cli-reference.md) — all commands, flags, and configuration
+- [How Ralphai Works](docs/how-ralphai-works.md) — context rot, feedback loops, stuck detection
+- [Worktrees](docs/worktrees.md) — parallel runs in isolated directories
 
 ## Acknowledgements
 
-- [Ralph](https://ghuntley.com/ralph/) by Geoffrey Huntley — the technique behind the loop
-- [Vercel CLI](https://github.com/vercel/vercel) — CLI DX inspiration
+- [Ralph](https://ghuntley.com/ralph/) by Geoffrey Huntley — creator of the technique behind the loop
+- [Getting Started With Ralph](https://www.aihero.dev/getting-started-with-ralph) by Matt Pocock
+- [Vercel CLI](https://github.com/vercel/vercel) for CLI DX inspiration
 
 ## License
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,100 @@
+# CLI Reference
+
+```
+ralphai <command> [options]
+```
+
+## Commands
+
+| Command          | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `init`           | Set up Ralphai in your project                      |
+| `run`            | Start the Ralphai task runner                       |
+| `worktree`       | Run in an isolated git worktree                     |
+| `status`         | Show pipeline and worktree status                   |
+| `reset`          | Move in-progress plans back to backlog and clean up |
+| `update [tag]`   | Update ralphai to the latest (or specified) version |
+| `uninstall`      | Remove Ralphai from your project                    |
+
+## Global Options
+
+```
+--help, -h        Show help
+--version, -v     Show version
+```
+
+## Init
+
+```
+--yes, -y              Skip prompts, use defaults
+--force                Re-scaffold from scratch
+--agent-command=CMD    Set the agent command
+```
+
+## Run
+
+```
+--turns=<n>                       Turns per plan (default: 5, 0 = unlimited)
+--dry-run, -n                     Preview what would happen without changing anything
+--resume, -r                      Auto-commit dirty state and continue
+--agent-command=<command>         Override agent CLI command
+--feedback-commands=<list>        Comma-separated feedback commands
+--base-branch=<branch>            Override base branch (default: main)
+--branch                          Branch mode (default): create isolated branch, commit, no PR
+--pr                              PR mode: create branch, push, and open PR
+--patch                           Patch mode: leave changes uncommitted in working tree
+--continuous                      Keep processing backlog plans after the first completes
+--max-stuck=<n>                   Stuck threshold before abort (default: 3)
+--turn-timeout=<seconds>          Timeout per agent invocation (default: 0 = no timeout)
+--auto-commit                     Enable auto-commit of agent changes (per-turn and resume recovery)
+--no-auto-commit                  Disable auto-commit (default)
+--prompt-mode=<mode>              Prompt format: 'auto', 'at-path', or 'inline' (default: auto)
+--show-config                     Print resolved settings and exit
+--issue-source=<source>           Issue source: 'none' or 'github' (default: none)
+--issue-label=<label>             Label to filter issues (default: ralphai)
+--issue-in-progress-label=<label> Label applied when issue is picked up (default: ralphai:in-progress)
+--issue-repo=<owner/repo>         Override repo for issue operations (default: auto-detect)
+--issue-close-on-complete=<bool>  Close issue on plan completion (default: true)
+--issue-comment-progress=<bool>   Comment on issue during run (default: true)
+```
+
+## Worktree
+
+```
+--plan=<file>     Target a specific backlog plan (default: auto-detect)
+--dir=<path>      Worktree directory (default: ../.ralphai-worktrees/<slug>)
+worktree list     Show active ralphai-managed worktrees
+worktree clean    Remove completed/orphaned worktrees
+```
+
+## Reset
+
+```
+--yes, -y         Skip confirmation prompt
+```
+
+## Configuration
+
+Settings resolve in this order: **CLI flags > env vars > `ralphai.json` > defaults**.
+
+### Environment Variables
+
+| Env Var                           | Config Key             |
+| --------------------------------- | ---------------------- |
+| `RALPHAI_AGENT_COMMAND`           | `agentCommand`         |
+| `RALPHAI_FEEDBACK_COMMANDS`       | `feedbackCommands`     |
+| `RALPHAI_BASE_BRANCH`            | `baseBranch`           |
+| `RALPHAI_MODE`                    | `mode`                 |
+| `RALPHAI_AUTO_COMMIT`             | `autoCommit`           |
+| `RALPHAI_TURNS`                   | `turns`                |
+| `RALPHAI_PROMPT_MODE`             | `promptMode`           |
+| `RALPHAI_CONTINUOUS`              | `continuous`           |
+| `RALPHAI_MAX_STUCK`               | `maxStuck`             |
+| `RALPHAI_TURN_TIMEOUT`            | `turnTimeout`          |
+| `RALPHAI_NO_UPDATE_CHECK`         | _(none)_               |
+| `RALPHAI_ISSUE_SOURCE`            | `issueSource`          |
+| `RALPHAI_ISSUE_LABEL`             | `issueLabel`           |
+| `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | `issueInProgressLabel` |
+| `RALPHAI_ISSUE_REPO`              | `issueRepo`            |
+| `RALPHAI_ISSUE_CLOSE_ON_COMPLETE` | `issueCloseOnComplete` |
+| `RALPHAI_ISSUE_COMMENT_PROGRESS`  | `issueCommentProgress` |

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -1,44 +1,29 @@
-# How ralphai Works
+# How Ralphai Works
 
 Ralphai is a loop that drives your AI coding agent one plan at a time, with
-real build/test/lint feedback every cycle. This page explains the mechanics
-behind that loop.
+real build/test/lint feedback every cycle.
 
 Back to the [README](../README.md) for setup and quickstart.
 
 ## Context Rot
 
-When you use an AI coding agent in a long session, the conversation history
-grows. Every model has a fixed-size "context window" — the amount of text it
-can consider at once. Once the conversation exceeds that window, the agent may
-apply **context compression** by automatically summarizing or condensing
-older messages to free up space for new ones. Unlike simple truncation,
-compression actively rewrites your earlier conversation into shorter summaries.
-Nuance gets lost. Specific decisions become vague references. Code you
-discussed in detail gets reduced to a one-line note.
+Long AI coding sessions degrade. The model's context window fills up, older
+messages get compressed or dropped, and the agent forgets what it already
+tried — repeating mistakes and drifting from the goal.
 
-The result: the model forgets what it already tried, repeats mistakes, or
-invents things that contradict earlier work.
-
-This is **context rot**. The longer a session runs, the less reliable the agent
-becomes — not because the model is bad, but because its view of the
-conversation has been quietly rewritten underneath it.
-
-Ralphai avoids context rot by design. Each turn starts a **fresh agent
-session** with only the information that matters:
+Ralphai avoids this by starting each turn with a **fresh agent session**
+containing only what matters:
 
 - The [plan file](../templates/ralphai/PLANNING.md) (what to build)
 - A progress log (what was already done)
 - Learnings from past mistakes (if any)
 
-Turn 50 gets exactly the same quality of context as turn 1. No
-accumulated history, no summarization artifacts, no drift.
+Turn 50 gets exactly the same quality of context as turn 1.
 
 ## Feedback Loop
 
-Each turn, Ralphai instructs the agent to run your project's real build, test,
-and lint commands — not cached results, not model-generated guesses. The agent
-runs these commands itself and fixes any failures before committing.
+Each turn, the agent runs your project's real build, test, and lint
+commands — not cached results, not model-generated guesses.
 
 ```
     ┌─────────────────────────────────────┐
@@ -70,161 +55,61 @@ runs these commands itself and fixes any failures before committing.
                 (fresh session)
 ```
 
-1. Agent reads the plan and progress log
-2. Agent implements the next task
-3. Agent runs the configured feedback commands (e.g. `npm run build`, `npm test`)
-4. Agent fixes any errors and commits
-
-This loop keeps the agent grounded. Instead of drifting based on stale
-assumptions, it reacts to actual project state every cycle.
-
-Feedback commands are auto-detected during `ralphai init` or can be configured
-manually via `feedbackCommands` in `ralphai.json`. When configured, the
-agent prompt includes the specific commands. When absent, the prompt uses a
-generic fallback: "Run your project's build, test, and lint commands."
+Feedback commands are auto-detected during `ralphai init` or configured
+via `feedbackCommands` in `ralphai.json`.
 
 ## Stuck Detection
 
-Sometimes an agent gets stuck — making changes that don't compile, going in
-circles, or producing empty commits. Ralphai watches for this.
+If **N consecutive turns** produce no new commits, Ralphai aborts. Default
+threshold is 3. Configurable via `maxStuck` in `ralphai.json`,
+`RALPHAI_MAX_STUCK`, or `--max-stuck`.
 
-If **N consecutive turns** produce no new commits, Ralphai aborts the run.
-The default threshold is 3, meaning: if the agent fails to commit anything
-useful three times in a row, Ralphai stops burning tokens and leaves the work
-in `in-progress/` for you to inspect.
-
-The threshold is configurable:
-
-- **Config file:** `"maxStuck": 5` in `ralphai.json`
-- **Env var:** `RALPHAI_MAX_STUCK=5`
-- **CLI flag:** `--max-stuck=5`
-
-When a run is aborted due to stuck detection, the plan and progress files stay
-in `.ralphai/pipeline/in-progress/`. You can resume with `ralphai run` after
-investigating what went wrong — or adjust the plan and try again.
+The plan stays in `in-progress/` so you can inspect and resume.
 
 ## Continuous Mode
 
-By default, Ralphai stops after completing one plan. Continuous mode keeps
-draining the backlog — after a plan completes, Ralphai picks the next
-dependency-ready plan and starts a fresh turn loop for it.
+By default, Ralphai stops after one plan. With `--continuous`, it keeps
+draining the backlog — picking the next dependency-ready plan after each
+completion.
 
-**How it works:**
-
-1. A plan completes (the agent signals `COMPLETE`).
-2. Ralphai checks the backlog for more dependency-ready plans.
-3. If a plan is found, a new turn loop begins with a fresh turn counter,
-   fresh stuck counter, and a fresh agent session.
-4. This repeats until the backlog is empty or a plan fails.
-
-In **direct mode**, continuous processing simply keeps committing on the
-current branch. In **PR mode**, Ralphai creates a single **draft PR** after
-the first plan completes, updates it after each subsequent plan, and marks
-it as "ready for review" when the backlog is drained.
-
-If a plan fails mid-session (runs out of turns or the agent gets stuck),
-Ralphai pushes any partial work and exits — it does not skip ahead to the
-next plan.
-
-**Configuration:**
-
-- **Config file:** `"continuous": true` in `ralphai.json`
-- **Env var:** `RALPHAI_CONTINUOUS=true`
-- **CLI flag:** `--continuous`
-
-Default: `false` (stop after one plan).
+In **PR mode** (`--continuous --pr`), a single draft PR is created after the
+first plan. Each subsequent plan updates the PR body. The PR is marked ready
+for review when the backlog is drained. If a plan fails mid-session, Ralphai
+pushes partial work and exits.
 
 ## Turn Timeout
 
-Turn timeout sets a maximum duration for each individual agent invocation.
-If the agent exceeds the limit, it is killed and the turn ends. This
-prevents a single agent call from running indefinitely.
-
-**How it works:**
-
-1. When `turnTimeout` is set to a value greater than 0, each agent command
-   is wrapped with the Unix `timeout` command.
-2. If the agent exceeds the limit, it receives a SIGTERM signal and the
-   process is killed.
-3. A warning is printed: `"Agent command timed out after Ns."`.
-4. The turn still counts toward the turn budget. The stuck counter
-   increments (since a killed agent typically produces no commits).
-5. If the agent keeps timing out with no commits, stuck detection
-   eventually fires — which aborts the run.
-
-A timed-out turn is not fatal on its own. Ralphai continues to the next
-turn, giving the agent another chance to make progress.
-
-**Configuration:**
-
-- **Config file:** `"turnTimeout": 300` in `ralphai.json` (value in seconds)
-- **Env var:** `RALPHAI_TURN_TIMEOUT=300`
-- **CLI flag:** `--turn-timeout=300`
-
-Default: `0` (no timeout — the agent runs until it exits on its own).
+Optional per-invocation timeout (`turnTimeout` in seconds, or
+`--turn-timeout`). If the agent exceeds the limit, it's killed via SIGTERM
+and the turn counts toward the stuck budget. Default: 0 (no timeout).
 
 ## Branch Isolation
 
-Ralphai supports two branching strategies:
+Two modes:
 
-- **Direct mode** (default, `--direct`): Ralphai commits on your current
-  branch. No branch creation, no PR. You must be on a feature branch —
-  Ralphai refuses to run on `main` or `master`.
-- **PR mode** (`--pr`): Ralphai creates an isolated `ralphai/*` branch from the
-  configured base branch, does all work there, and opens a PR on completion
-  via the `gh` CLI (validated at startup before any agent work begins).
+- **Branch mode** (default): commits on your current branch. No branch
+  creation, no PR. Refuses to run on `main`/`master`.
+- **PR mode** (`--pr`): creates a `ralphai/<plan-slug>` branch from the base
+  branch, does all work there, and opens a PR on completion via `gh`.
 
-**Branch naming (PR mode only):** The branch name is derived from the plan
-filename (minus the `.md` suffix). `add-dark-mode.md` becomes
-`ralphai/add-dark-mode`. The `ralphai/` prefix keeps automated work visually
-separate from human branches.
-
-**Collision detection (PR mode only):** Before creating a branch, Ralphai
-checks whether it already exists locally, on the remote, or has an open PR. If
-a collision is found, the plan is skipped and Ralphai moves to the next one.
-
-**Feature branch workflow:** For large features spanning multiple plans,
-use direct mode on a feature branch (`git checkout -b feature/big-thing`
-then `ralphai run --turns=5`). When all plans are done, you
-manually open a PR from the feature branch to `main`.
-
-**Safety guards:**
-
-- Ralphai blocks on dirty working state by default; `--resume` auto-commits
-  dirty changes on any non-base branch (not just `ralphai/*` branches)
-- `--resume` refuses to auto-commit on the configured base branch (defaults to
-  `main`; configurable via `baseBranch`)
-- Direct mode (`--direct`) refuses to run on `main` or `master`
-- Dry-run mode (`--dry-run`) is completely read-only — no file moves, branch
-  creation, or agent execution
+PR mode checks for branch collisions (local, remote, open PR) before
+starting — collisions skip to the next plan.
 
 ## Plan Lifecycle
 
-Plans flow through four directories inside `.ralphai/`:
-
 ```
-wip/        (work in progress — Ralphai ignores these)
-backlog/    --> in-progress/ --> out/
+wip/       (parked — Ralphai ignores)
+backlog/  →  in-progress/  →  out/
 ```
 
-1. **`wip/`** (work in progress) — Plans that aren't ready yet. Ralphai never looks here. Use it
-   for ideas that need more thought, external prerequisites, or human review.
-   Move to `backlog/` when ready.
+- **`backlog/`** — the queue. Ralphai picks dependency-ready plans
+  (LLM-selected when multiple are ready).
+- **`in-progress/`** — active work. Plan + `progress.md` live here. Files
+  stay on interruption for resumption.
+- **`out/`** — archive. Moved here when the agent signals completion.
 
-2. **`backlog/`** — The queue. Ralphai picks dependency-ready plans automatically.
-   When multiple plans are ready, an LLM call selects the best one based on
-   dependencies, risk, and value. The chosen plan is moved to `in-progress/`.
-
-3. **`in-progress/`** — Active work. The plan file and `progress.md` live here
-   while Ralphai is working. If a run is interrupted or exhausts its turns,
-   files stay here so work can be resumed.
-
-4. **`out/`** — Archive. Plans and progress logs are moved here only when the
-   agent signals completion.
-
-**Plan dependencies:** Plans can declare `depends-on` in their YAML
-frontmatter. A plan is only runnable when all its dependencies are archived in
-`out/`. Plans without `depends-on` are always considered ready.
+Plans can declare `depends-on` in YAML frontmatter. A plan runs only when
+all dependencies are in `out/`.
 
 ```md
 ---
@@ -232,35 +117,10 @@ depends-on: [foundation.md, wiring.md]
 ---
 ```
 
-**GitHub Issues integration:** When the backlog is empty and `issueSource=github`
-is configured, Ralphai can pull labeled GitHub issues and convert them into plan
-files automatically. See the [operational docs](../templates/ralphai/README.md) for
-details.
-
-**File tracking:** Plan files in `backlog/`, `in-progress/`, and `out/` are
-gitignored (local-only state). The entire `.ralphai/` directory is gitignored.
-Moving files between lifecycle stages requires no git commits.
-
 ## Learnings System
 
-Ralphai logs mistakes and lessons to `.ralphai/LEARNINGS.md` during autonomous
-runs. This file is **gitignored** (local-only, never committed). Ralphai reads
-it at the start of each turn so it doesn't repeat past errors.
+Ralphai logs mistakes to `.ralphai/LEARNINGS.md` (gitignored) during runs
+and reads it each turn to avoid repeating errors.
 
-**Review workflow after runs:**
-
-1. Check `.ralphai/LEARNINGS.md` for new entries
-2. Compact findings — merge duplicates, drop one-off noise
-3. Promote durable guidance to the appropriate place:
-   - `AGENTS.md` (or equivalent) for immediate repo-specific agent behavior
-   - Skill/reusable docs for stable patterns worth reusing across tasks or repos
-
-Keeping learnings gitignored prevents auto-written entries from interfering
-with stuck detection (which counts commits).
-
-## Worktrees
-
-`ralphai worktree` runs a plan in an isolated git worktree, letting you keep
-working in your main checkout while Ralphai runs in a separate directory.
-
-See [Worktrees](worktrees.md) for usage, agent compatibility, and manual setup.
+**After runs:** review entries, merge duplicates, and promote durable
+lessons to `AGENTS.md` or skill docs.

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -1,133 +1,53 @@
 # Worktrees
 
-Git worktrees let you run plans in parallel without stashing or switching
-branches. Each worktree is a separate directory with its own working tree and
-branch, sharing the same git history.
+Git worktrees let you run plans in parallel without switching branches.
+Each worktree is a separate directory with its own working tree, sharing
+the same git history.
 
 Back to the [README](../README.md) for setup and quickstart.
 
 ## When to use worktrees
 
-- Running multiple plans concurrently (each in its own worktree)
-- Keeping your main checkout clean while Ralphai works in an isolated directory
-- Avoiding branch-switching interruptions during autonomous runs
+- Running multiple plans concurrently
+- Keeping your main checkout clean while Ralphai works
+- Avoiding branch-switching interruptions
 
 ## Commands
 
-### Run a plan in a worktree
-
 ```bash
 ralphai worktree                          # auto-pick next backlog plan
-ralphai worktree --turns=3                # run with 3 turns per plan
+ralphai worktree --turns=3                # limit turns
 ralphai worktree --plan=dark-mode.md      # target a specific plan
+ralphai worktree list                     # show active worktrees
+ralphai worktree clean                    # remove completed worktrees
 ```
 
-The lifecycle: create worktree → run plan (in PR mode) → create PR → clean up.
-If the agent gets stuck or times out, the worktree is preserved. Re-run
-`ralphai worktree` from the main repo to reuse it, or resume inside the
-worktree with `ralphai run --resume`.
+The lifecycle: create worktree → run plan → create PR → clean up. If the
+agent gets stuck, the worktree is preserved — re-run `ralphai worktree`
+to reuse it, or resume inside with `ralphai run --resume`.
 
-`ralphai worktree` must be run from the **main repository**, not from inside a
-worktree. All runner options (`--turns`, `--agent-command`, `--feedback-commands`, etc.)
-are forwarded automatically.
-
-Options:
-
-- `--plan=<file>` — Target a specific backlog plan (default: auto-detect)
-- `--dir=<path>` — Worktree directory (default: `../.ralphai-worktrees/<slug>`)
-
-### List active worktrees
-
-```bash
-ralphai worktree list
-```
-
-Shows all git worktrees on `ralphai/*` branches.
-
-### Clean up worktrees
-
-```bash
-ralphai worktree clean
-```
-
-Removes worktrees whose plans are no longer in `in-progress/`. Worktrees with
-active plans are preserved.
+`ralphai worktree` must be run from the **main repository**, not from inside
+a worktree. All runner options are forwarded automatically.
 
 ## How it works
 
-1. `ralphai worktree` creates a git worktree (a separate working directory
-   sharing the same `.git` history) and a new `ralphai/<plan-slug>` branch.
-   If that plan is already in progress, it reuses the existing managed
-   worktree instead of creating a second one.
-2. A **symlink** is created from the worktree's `.ralphai/` to the main repo's
-   `.ralphai/` directory. Since `.ralphai/` is fully gitignored, it won't exist
-   in the worktree after `git worktree add` — the symlink is simply created.
-3. The runner is spawned with the worktree as its working directory.
-4. When the runner detects the symlink, it uses **relative paths** (e.g.,
-   `.ralphai/pipeline/in-progress/`) in the prompt sent to the agent.
-5. Config (`ralphai.json`) lives at the repo root and is tracked by git, so
-   `git worktree add` checks it out automatically — no special handling needed.
-
-Pipeline state (`.ralphai/pipeline/`) lives in the main worktree and is shared
-across all worktrees via the symlink.
-
-## The sandbox problem
-
-Most AI coding agents enforce **directory sandboxing** — they restrict file
-access to the agent's working directory (the worktree). Without the symlink,
-pipeline files live at absolute paths in the main repo
-(e.g., `/home/user/project/.ralphai/pipeline/in-progress/`), which the agent
-rejects as "external directory" access.
-
-The symlink makes `.ralphai/` appear local to the worktree, so the agent can
-read and write pipeline files through relative paths.
+1. Creates a git worktree with a `ralphai/<plan-slug>` branch.
+   Reuses existing worktrees for in-progress plans.
+2. Symlinks the worktree's `.ralphai/` to the main repo's `.ralphai/`
+   so the agent can access pipeline files through relative paths
+   (bypassing agent directory sandboxing).
+3. Spawns the runner in the worktree directory.
+4. Config (`ralphai.json`) is tracked by git and checked out automatically.
 
 ## Agent compatibility
 
 | Agent       | Worktree support | Notes                                                       |
 | ----------- | ---------------- | ----------------------------------------------------------- |
-| OpenCode    | Yes              | Tested — follows symlinks within working directory          |
 | Claude Code | Yes              | Tested — follows symlinks within project directory          |
-| Gemini CLI  | Likely           | Untested — no known sandbox restrictions                    |
-| Aider       | Likely           | Untested — no directory sandbox                             |
-| Goose       | Likely           | Untested                                                    |
-| Amp         | Likely           | Untested                                                    |
-| Kiro        | Likely           | Untested                                                    |
+| OpenCode    | Yes              | Tested — follows symlinks within working directory          |
 | Codex       | No               | Container sandbox may not follow symlinks outside the mount |
-
-> Only **Claude Code** and **OpenCode** have been tested end-to-end with Ralphai. The other agents are expected to work but are unverified.
+| Others      | Likely           | Untested — no known restrictions                            |
 
 **Workaround for unsupported agents:** Set `"promptMode": "inline"` in
-`ralphai.json`. This causes the runner (bash) to read pipeline files
-and embed their contents directly in the prompt, bypassing the agent's need to
-access external paths. This increases prompt size but works with all agents.
-
-## Manual worktrees
-
-You can also create worktrees manually instead of using `ralphai worktree`:
-
-```bash
-# Create the worktree
-git worktree add ../feature-x -b ralphai/feature-x main
-
-# Add the symlink so the agent can access pipeline files
-cd ../feature-x
-ln -s /path/to/main-repo/.ralphai .ralphai
-
-# Run ralphai
-ralphai run --pr
-```
-
-Without the symlink, the runner falls back to absolute paths pointing to the
-main repo. This works for the runner's own bash operations, but agents with
-directory sandboxing will reject reads/writes to those paths.
-
-Ralphai auto-detects worktrees — no extra flags needed. Use
-`ralphai run --show-config` inside a worktree to verify detection
-(`worktree = true`).
-
-**Important:**
-
-- `ralphai init` must be run in the **main repository**, not inside a
-  worktree.
-- `ralphai run` works in both the main repo and any worktree.
+`ralphai.json` to embed pipeline file contents directly in the prompt,
+bypassing the agent's need to access external paths.

--- a/src/ralphai.test.ts
+++ b/src/ralphai.test.ts
@@ -160,7 +160,7 @@ describe("ralphai command", () => {
     const output = stripLogo(runCliOutput(["init", "--yes"], testDir));
 
     expect(output).toContain("Ralphai initialized");
-    expect(output).toContain("dry-run");
+    expect(output).toContain("feature branch");
     expect(output).toContain("ralphai.json");
     expect(output).toContain("PLANNING.md");
     expect(output).toContain("LEARNINGS.md");
@@ -193,7 +193,7 @@ describe("ralphai command", () => {
     const output = stripLogo(runCliOutput(["init", "--yes"], testDir));
 
     expect(output).toContain("Ralphai initialized");
-    expect(output).toContain("ralphai run --dry-run");
+    expect(output).toContain("ralphai run");
   });
 
   it("init --yes <target-dir> scaffolds into the target directory, not cwd", () => {

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -752,7 +752,7 @@ Each entry should include:
     `  ralphai.json               ${DIM}Configuration (edit to customize)${RESET}`,
   );
   console.log(`  .ralphai/README.md         ${DIM}Operational docs${RESET}`);
-  console.log(`  .ralphai/PLANNING.md   ${DIM}How to write plans${RESET}`);
+  console.log(`  .ralphai/PLANNING.md       ${DIM}How to write plans${RESET}`);
   console.log(
     `  .ralphai/LEARNINGS.md      ${DIM}Ralphai-specific learnings${RESET}`,
   );
@@ -763,7 +763,7 @@ Each entry should include:
   if (labelResult) {
     if (labelResult.success) {
       console.log(
-        `  GitHub labels            ${DIM}Created "ralphai" and "ralphai:in-progress" labels${RESET}`,
+        `  GitHub labels              ${DIM}Created "ralphai" and "ralphai:in-progress" labels${RESET}`,
       );
     } else {
       console.log();
@@ -772,15 +772,11 @@ Each entry should include:
   }
   console.log();
   console.log(`${DIM}Next steps:${RESET}`);
-  console.log(`  1. Review ${TEXT}ralphai.json${RESET} and adjust settings`);
   console.log(
-    `  2. Read ${TEXT}.ralphai/PLANNING.md${RESET} for how to write plans`,
+    `  1. Write a plan in ${TEXT}.ralphai/pipeline/backlog/${RESET} (see ${TEXT}PLANNING.md${RESET})`,
   );
-  console.log(
-    `  3. Create your first plan in ${TEXT}.ralphai/pipeline/backlog/${RESET}`,
-  );
-  console.log(`  4. Preview:  ${TEXT}ralphai run --dry-run${RESET}`);
-  console.log(`  5. Run:      ${TEXT}ralphai run${RESET}`);
+  console.log(`  2. Switch to a feature branch`);
+  console.log(`  3. ${TEXT}ralphai run${RESET}`);
   if (answers.issueSource === "github") {
     console.log();
     console.log(

--- a/templates/ralphai/PLANNING.md
+++ b/templates/ralphai/PLANNING.md
@@ -1,48 +1,33 @@
 # Writing Ralphai Plan Files
 
-Guide for writing plan files that Ralphai consumes. Plans go in `.ralphai/pipeline/backlog/` and are picked automatically by `ralphai run`.
+Guide for writing plan files that Ralphai consumes. Plans go in `.ralphai/pipeline/backlog/`.
 
-Plans that aren't ready for execution (waiting on external prerequisites, need human review, or are still being drafted) go in `.ralphai/pipeline/wip/`. `ralphai run` does not scan `wip/` — move plans to `pipeline/backlog/` when they're ready to be picked up.
+Plans not ready for execution go in `.ralphai/pipeline/wip/` — Ralphai ignores that directory.
 
 ## Core Principles
 
-1. **Define the end state, not the journey.** Ralphai picks tasks and figures out how. You specify what "done" looks like via acceptance criteria.
-2. **Small steps.** Each task should be one logical commit. If a task feels too large, break it into subtasks. Context rot degrades quality on long tasks.
-3. **Vertical slices first.** Structure tasks so the first task delivers a minimal but working end-to-end slice through the user's project — the "skateboard." Subsequent tasks widen the slice: add edge cases, improve UX, harden error handling, extend to more inputs. This ensures every intermediate state is demonstrably useful and testable, not just a pile of disconnected foundations. A working thin path through the system beats a perfect layer that nothing uses yet.
-4. **Risky work first.** Architectural decisions, integration points, and unknowns go at the top. Polish and docs go last. Ralphai will pick easy wins if you let it.
-5. **Explicit acceptance criteria.** Use checkboxes. Without them, ralphai declares victory early or skips edge cases.
-6. **Feedback loops are guardrails.** Every task must pass your configured feedback commands (build, test, lint) before committing. The ralphai prompt enforces this, but the plan should assume it.
+1. **Define the end state, not the journey.** Specify what "done" looks like via acceptance criteria. Ralphai figures out how.
+2. **Small steps.** Each task should be one logical commit. If a task feels too large, break it down.
+3. **Vertical slices first.** The first task should deliver a minimal but working end-to-end path — the "skateboard." Subsequent tasks widen the slice.
+4. **Risky work first.** Architectural decisions, integration points, and unknowns go at the top. Polish and docs go last.
+5. **Explicit acceptance criteria.** Use `- [ ]` checkboxes. Without them, Ralphai declares victory early or skips edge cases.
+6. **Feedback loops are guardrails.** Every task must pass build, test, and lint before committing. The prompt enforces this.
 
-## Plan Types
+## Plan Template
 
-### Feature PRD (build something new)
-
-For new capabilities that span multiple files and require design decisions.
-
-**Use when:** Adding a new capability, a new CLI command, a new integration, a new module.
-
-**Structure:**
-
-```markdown
+```md
 # Plan: <Title>
 
 > <TL;DR — what this adds, what pattern it follows, why it matters. 2-4 sentences.>
 
 ## Background
 
-<Current state of the codebase relevant to this work. What exists, what doesn't.
-Link to existing files and prior plans. Be specific — ralphai explores the repo
-but specific pointers save tokens and reduce wrong turns.>
+<Current state of the codebase. What exists, what doesn't. Link to existing
+files, line numbers, prior plans. Be specific — every pointer saves tokens.>
 
 ## References
 
-- <Link to specs, prior PRDs, deferred items docs>
-- <Link to upstream patterns this mirrors>
-
-## <Domain-Specific Context> (optional)
-
-<Support matrices, canonical format specs, agent output tables — whatever
-ralphai needs to make correct decisions without exploring the codebase.>
+- <Link to specs, prior plans, upstream patterns>
 
 ## Acceptance Criteria
 
@@ -50,23 +35,22 @@ ralphai needs to make correct decisions without exploring the codebase.>
 - [ ] <Another observable behavior>
 - [ ] All existing tests continue to pass
 - [ ] New tests cover the new functionality
-- [ ] AGENTS.md updated if work created knowledge future agents need and can't easily infer
+- [ ] AGENTS.md updated if work created knowledge future agents need
 - [ ] README.md updated if user-facing behavior changed
 
 ## Implementation Tasks
 
 List tasks in dependency order — each task should leave a green build.
-Foundations first, wiring second, tests third, docs last.
 
 ### Task 1: <Title>
 
 **File:** `src/<file>.ts`
 
 **What:** <Describe the change. Name specific functions, interfaces, line
-numbers. The more precise, the fewer tokens ralphai spends exploring.>
+numbers. The more precise, the fewer tokens spent exploring.>
 
-**Key insight:** <Call out non-obvious things — existing code that already
-handles this, functions that need renaming, integration points.>
+**Key insight:** <Non-obvious things — existing code that handles part of this,
+functions that need renaming, integration points.>
 
 ### Task 2: <Title>
 
@@ -74,179 +58,48 @@ handles this, functions that need renaming, integration points.>
 
 ## Verification
 
-<Final end-to-end checks after all tasks are done.>
+- Build, test, lint all pass
+- <End-to-end command that exercises the new feature>
+- <Specific behavioral checks>
 ```
 
-### Wiring PRD (connect existing pieces)
-
-For work where the infrastructure exists but isn't exposed to users.
-
-**Use when:** Adding a CLI flag for existing functionality, extending an existing command to handle a new type, connecting modules that already work independently.
-
-**Structure:** Same as Feature PRD but with a shorter Background that emphasizes what's already built and what's missing. Tasks are typically smaller since they're wiring, not building.
-
-**Key difference:** Background section should explicitly list what's done vs what's missing, with file paths and line numbers. This prevents ralphai from rebuilding existing infrastructure.
-
-### Bug Fix PRD (fix broken behavior)
-
-For fixing incorrect behavior where the expected outcome is clear.
-
-**Use when:** A command produces wrong output, a parser crashes on valid input, an edge case is mishandled.
-
-**Structure:**
-
-```markdown
-# Plan: Fix <Title>
-
-> <What's broken, what the correct behavior should be. 1-2 sentences.>
-
-## Reproduction
-
-**Input:** <Exact command, input file, or function call that triggers the bug>
-
-**Expected:** <What should happen>
-
-**Actual:** <What happens instead>
-
-## Root Cause (hypothesis)
-
-<Best guess at why this happens. Name specific files, functions, line numbers.
-If uncertain, say so — ralphai will investigate.>
-
-## References
-
-- <Link to issue, error log, or related code>
-
-## Acceptance Criteria
-
-- [ ] Failing test reproduces the bug before the fix
-- [ ] Fix makes the test pass
-- [ ] No regressions — all existing tests continue to pass
-- [ ] AGENTS.md updated if fix created knowledge future agents need and can't easily infer
-- [ ] README.md updated if the fix changes documented behavior
-
-## Tasks
-
-### Task 1: Write failing test
-
-**File:** `src/<file>.test.ts` or `tests/<file>.test.ts`
-
-**What:** <Test that asserts the expected behavior and fails with the current code.
-Use the reproduction case above as the basis.>
-
-### Task 2: Fix the bug
-
-**File:** `src/<file>.ts`
-
-**What:** <Describe the fix. Be specific about which function/branch to change.>
-
-## Verification
-
-<Run the reproduction case manually and confirm correct behavior.>
-```
-
-**Key difference from other templates:** Task 1 is always "write failing test." The ralphai prompt enforces test-first for bug fixes, and this template structure matches that expectation.
-
-### Structural PRD (refactor, cleanup, migration)
-
-For work that changes organization without adding features.
-
-**Use when:** Renaming modules, extracting shared code, migrating patterns, cleaning up dead code, improving test coverage.
-
-**Structure:**
-
-```markdown
-# Plan: <Title>
-
-> <What's being restructured and why. What stays the same from the user's perspective.>
-
-## Current State
-
-<Describe the problem: duplication, inconsistency, tech debt. Link to specific
-files and line numbers.>
-
-## Target State
-
-<Describe what the code should look like after. Be concrete about file names,
-module boundaries, export surfaces.>
-
-## Constraints
-
-- No user-facing behavior changes (unless explicitly noted)
-- All existing tests must continue to pass without modification
-- <Other invariants>
-
-## Acceptance Criteria
-
-- [ ] <Structural outcome — e.g. "X lives in its own module">
-- [ ] <Another structural outcome>
-- [ ] All existing tests pass without modification
-- [ ] Build, test, and lint all pass
-- [ ] AGENTS.md updated if restructuring created knowledge future agents need and can't easily infer
-
-## Tasks
-
-### Task 1: <Title>
-
-...
-
-## Verification
-
-- Build passes
-- Tests pass (same count, no skips)
-- Lint passes
-- <Specific behavioral invariants to verify>
-```
-
-### Implementation Plan (reference doc, not a ralphai plan)
-
-For repeatable processes that different developers (or ralphai runs) will follow multiple times. These are human reference docs, not plans ralphai consumes directly.
-
-**Use when:** Documenting a cookbook process like adding a new module, onboarding a new integration, or any step-by-step guide.
-
-**Not for ralphai:** If you want ralphai to execute a cookbook process, write a Feature or Wiring PRD that references the implementation plan.
-
-**Structure:**
-
-```markdown
-# <Process Name>
-
-<When to use this plan. Prerequisites.>
-
-## Goal
-
-<What success looks like.>
-
-## Scope Decision (Step 0)
-
-<Decisions that must be made before starting.>
-
-## Phase 1 — <Name>
-
-### Step 1: <Action>
-
-<What to do, where, expected outcome.>
-
-### Step 2: <Action>
-
-...
-
-## Phase 2 — <Name>
-
-...
-```
+### Adapting the template
+
+- **Bug fixes:** Task 1 should always be "write failing test." Include reproduction case (input, expected, actual) so Ralphai can translate it directly into a test.
+- **Refactors:** Add a Constraints section noting "no user-facing behavior changes" and rely on existing tests as the safety net.
+- **Wiring work:** Background should explicitly list what's already built vs what's missing, with file paths and line numbers, to prevent rebuilding existing infrastructure.
 
 ## Writing Guidelines
 
-### Frontmatter keys that are NOT supported
+### Be specific about locations
 
-`promptMode` is a global/per-run setting (configured via CLI flag `--prompt-mode`, env var `RALPHAI_PROMPT_MODE`, or config key `promptMode`). It cannot be set per-plan in frontmatter — it controls how `ralphai run` formats file references in prompts for the current agent, which applies uniformly to the entire run.
+Bad: "Update the types file to add prompt support."
+
+Good: "Add `'prompt'` to the `ConfigType` union in `src/types.ts` (line 106)."
+
+### State what already works
+
+Ralphai rebuilds things that already exist if you don't tell it. List existing infrastructure explicitly:
+
+```
+The install pipeline (`src/installer.ts`) already handles this case —
+it checks `item.type === 'foo'` at line 104. No changes needed here.
+```
+
+### One task = one commit
+
+Each task should result in exactly one commit. Multiple file changes are fine — but it should be one logical unit.
+
+### Order tasks for a green build
+
+1. Thin vertical slice first — types + function + wiring + test for one path
+2. Widen — additional cases, inputs, error handling
+3. Harden — edge cases, validation
+4. Docs last
 
 ### Optional `depends-on` frontmatter
 
-For cross-plan ordering, you can declare dependencies in plan frontmatter. `ralphai run` only considers a plan runnable when all dependencies are complete (archived in `.ralphai/pipeline/out/`).
-
-Use basename references (not full paths):
+For cross-plan ordering:
 
 ```md
 ---
@@ -254,21 +107,9 @@ depends-on: [foundation.md, wiring.md]
 ---
 ```
 
-or
-
-```md
----
-depends-on:
-	- foundation.md
-	- wiring.md
----
-```
-
-If omitted, the plan is treated as having no dependencies.
+A plan is runnable only when all dependencies are archived in `out/`.
 
 ### Optional `source` frontmatter (issue linking)
-
-Link a plan to an external issue tracker. When the plan completes, Ralphai automatically comments on and closes the linked issue.
 
 ```md
 ---
@@ -278,122 +119,15 @@ issue-url: https://github.com/owner/repo/issues/42
 ---
 ```
 
-Supported sources: `github`. Requires `gh` CLI to be installed and authenticated (`gh auth login`).
-
-Fields:
-
-- `source` — tracker type (currently only `github`)
-- `issue` — issue number
-- `issue-url` — full URL to the issue (used for repo detection and human reference)
-
-If `gh` is not available, the hooks are silently skipped. To disable automatic issue closing while keeping comments, set `"issueCloseOnComplete": false` in `ralphai.json`.
-
-### Be specific about locations
-
-Bad: "Update the types file to add prompt support."
-
-Good: "Add `'prompt'` to the `ConfigType` union in `src/types.ts` (line 106)."
-
-Ralphai spends tokens exploring. Every line number, function name, and file path you provide is tokens saved and wrong turns avoided.
-
-### State what already works
-
-Ralphai will rebuild things that already exist if you don't tell it they're done. List existing infrastructure explicitly:
-
-```
-The install pipeline (`src/installer.ts`) already handles this case —
-it checks `item.type === 'foo'` at line 104 and routes correctly.
-No changes needed here.
-```
-
-### One task = one commit
-
-Each task should result in exactly one commit. If a task requires changes across 5 files, that's fine — but it should be one logical unit. If you need two logical units, make two tasks.
-
-### Use conventional commits
-
-All commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>[optional scope]: <description>
-```
-
-Common types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`. Use a scope when it adds clarity (e.g. `feat(transpiler): ...`). The ralphai prompt enforces this, but plan tasks should assume it when describing expected commits.
-
-Examples:
-
-- `feat(parser): add support for new config format`
-- `fix(cli): handle missing arguments gracefully`
-- `refactor: extract shared validation logic`
-- `test(agent): add coverage for edge cases`
-- `docs: update README with new CLI command`
-
-### Testing strategy by task type
-
-The ralphai prompt enforces different testing approaches depending on the nature of the task. Plan authors should be aware of this when writing tasks:
-
-- **Bug fixes**: Ralphai writes a failing test first, then fixes the code. Plans should describe the buggy behavior clearly enough for ralphai to reproduce it in a test.
-- **New features**: Ralphai implements first, then adds tests. Plans should include test expectations in the acceptance criteria so ralphai knows what to cover.
-- **Refactoring**: Ralphai relies on existing tests as the safety net. Plans should note if coverage gaps exist that need new tests.
-- **Docs/chore tasks**: No tests expected.
-
-When writing bug fix tasks, include the reproduction case (input, expected output, actual output) so ralphai can translate it directly into a failing test. Without this, ralphai may write a test that asserts the wrong thing.
-
-### Order tasks for a green build
-
-Every task should leave the build and tests passing. This means:
-
-1. **Thin vertical slice first** — types + function + wiring + test for one end-to-end path. The narrowest version that proves the architecture works.
-2. **Widen the slice** — additional cases, inputs, error handling. Each task extends the working path.
-3. **Harden** — edge cases, validation, error messages.
-4. **Docs last** — describes the final state.
-
-Avoid building complete layers (all types, then all functions, then all wiring). Layer-first ordering means nothing works until the last task, and you can't catch design mistakes early.
-
-### Include acceptance criteria with checkboxes
-
-Ralphai uses these to determine when it's done. Without them, it guesses. Use `- [ ]` checkboxes — they're both human-readable and machine-parseable.
-
-### Always include doc updates
-
-Every plan that changes user-facing behavior should include tasks for:
-
-- **AGENTS.md** — only when the work created knowledge that future coding agents need and cannot easily infer from the code (e.g. new CLI commands, non-obvious architectural constraints, changed dev workflows). Routine bug fixes, internal refactors, and new tests do not warrant an AGENTS.md update.
-- **README.md** — commands, options, examples, support matrices
-- **Learnings** — when the work reveals recurring mistakes or durable operational patterns, review `.ralphai/LEARNINGS.md` and promote findings appropriately:
-  - `AGENTS.md` for immediate repo-specific behavior
-  - skill/reusable docs for stable patterns worth reusing across tasks/repos
-
-### Standard verification block
-
-Include at the bottom of every plan:
-
-```markdown
-## Verification
-
-After each task:
-
-- Build passes
-- Tests pass
-- Lint passes
-
-Final verification:
-
-- <end-to-end command that exercises the new feature>
-- <specific behavioral checks>
-```
+On completion, Ralphai comments on and closes the linked GitHub issue.
 
 ## Turn Sizing
 
-| Plan complexity                        | Recommended turns (`ralphai run`) |
-| -------------------------------------- | --------------------------------- |
-| 3-5 small tasks                        | 5                                 |
-| 6-10 tasks with wiring                 | 10-15                             |
-| Large feature (10+ tasks, new modules) | 15-25                             |
-| Structural refactor                    | 10-15                             |
+| Plan complexity                        | Recommended turns |
+| -------------------------------------- | ----------------- |
+| 3-5 small tasks                        | 5                 |
+| 6-10 tasks with wiring                 | 10-15             |
+| Large feature (10+ tasks, new modules) | 15-25             |
+| Structural refactor                    | 10-15             |
 
-Pass `--turns=0` for unlimited turns — Ralphai keeps going until all tasks are complete or stuck detection triggers. This is useful when you don't want to estimate a turn budget up front.
-
-Use `ralphai run --dry-run` to verify selection/readiness before launching long autonomous runs.
-
-If a run is interrupted and leaves a dirty tree, use `ralphai run --turns=<n> --resume` on the current branch to auto-commit recovery state and continue.
+Pass `--turns=0` for unlimited turns.

--- a/templates/ralphai/README.md
+++ b/templates/ralphai/README.md
@@ -1,124 +1,59 @@
 # .ralphai/ — Autonomous Task Runner
 
-Ralphai is an autonomous task runner that drives an AI coding agent to implement tasks from plan files.
+Ralphai drives an AI coding agent to implement tasks from plan files.
 
 ## Quick Start
 
 ```bash
 ralphai run              # run with defaults (5 turns per plan)
 ralphai run --turns=3    # 3 turns per plan
-ralphai run --turns=0    # unlimited turns — runs until all work is done
-ralphai run --dry-run    # preview what ralphai would do
+ralphai run --turns=0    # unlimited turns
+ralphai run --dry-run    # preview what would happen
 ralphai run --resume     # recover dirty state and continue
-ralphai run --pr         # create a ralphai/* branch and open a PR
+ralphai run --pr         # create ralphai/* branch and open a PR
 ralphai run --help       # show all options
 ```
-
-Arguments after `run` are forwarded directly to the task runner.
 
 ## Lifecycle
 
 Plans flow through four directories:
 
 ```
-wip/ (work in progress)  backlog/  -->  in-progress/  -->  out/
+wip/ (parked)    backlog/  →  in-progress/  →  out/
 ```
 
-1. **`wip/`** (work in progress) — Parked plans not ready for execution. Ralphai does **not** scan this directory. Use it for plans that need further thought, external prerequisites, or human review before they're queued. Move to `backlog/` when ready.
-2. **`backlog/`** — Queue incoming plans here. Ralphai picks dependency-ready plans automatically (LLM-selected when multiple are ready) and moves them to `in-progress/`.
-3. **`in-progress/`** — Active work. Plan files and `progress.md` live here while ralphai is working. If a run is interrupted or exhausts its turns, files stay here so work can be resumed.
-4. **`out/`** — Archive. Plans and progress logs are moved here only when the agent signals `COMPLETE`.
+1. **`wip/`** — Not ready. Ralphai ignores this directory.
+2. **`backlog/`** — Queued plans. Ralphai picks dependency-ready plans automatically.
+3. **`in-progress/`** — Active work. Plan + `progress.md` live here. Files stay on interruption for resumption.
+4. **`out/`** — Archive. Moved here when the agent signals completion.
 
-Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are **gitignored** (local-only state). The entire `.ralphai/` directory is gitignored. This means moving files between lifecycle stages requires no git commits.
-
-## Task Runner
-
-### `ralphai run [options]`
-
-Looped autonomous runner. Auto-detects what to work on, runs up to N turns per plan, with stuck detection. Pass `--turns=0` for unlimited turns — Ralphai keeps going until all tasks are complete or stuck detection triggers. You can also set turns in `ralphai.json` (e.g. `"turns": 10`) or via the `RALPHAI_TURNS` environment variable.
-
-```bash
-ralphai run --turns=5
-
-# Preview selection and readiness without moving files or creating branches
-ralphai run --dry-run
-
-# Recover dirty state and continue
-ralphai run --turns=5 --resume
-
-# Override agent command, base branch, or stuck threshold
-ralphai run --turns=5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
-
-# Override via env vars
-RALPHAI_AGENT_COMMAND='codex exec' ralphai run --turns=5
-
-# Direct mode: commit on current branch, no PR
-ralphai run --turns=5 --direct
-```
-
-No file arguments needed. The script auto-detects:
-
-1. **In-progress work** — If `.ralphai/pipeline/in-progress/` has plan files, resumes on the current branch (your feature branch in direct mode, or the `ralphai/*` branch in PR mode).
-2. **Backlog selection** — If no in-progress work, picks from dependency-ready plans in `.ralphai/pipeline/backlog/`. When multiple ready plans exist, an LLM call selects the best one based on dependencies, risk, and value. The chosen plan is moved to `in-progress/` (and in PR mode, a new `ralphai/*` branch is created).
-3. **Nothing to do** — If both are empty and no GitHub issues are available, exits.
-
-The turn budget (N) resets for each new plan. With `--continuous`, the script automatically picks the next plan from the backlog after completing one, continuing until the backlog is empty. Without `--continuous`, the script exits after completing one plan.
-
-Aborts if N consecutive turns produce no commits (stuck detection). The threshold defaults to 3 and can be configured via `maxStuck` in `ralphai.json`, `RALPHAI_MAX_STUCK` env var, or `--max-stuck=<n>` CLI flag.
-
-`--dry-run` mode previews:
-
-- whether there is runnable work
-- which plan would be selected
-- whether run would resume or create a branch
-- the current mode (PR or direct)
-
-Dry run makes no mutations (no file moves, branch creation, or agent execution).
-
-`--resume` mode:
-
-- auto-commits dirty tracked/untracked changes on any non-base branch (when `autoCommit` is `true` or in PR mode)
-- when `autoCommit` is `false` in direct mode, skips the recovery commit and preserves dirty state
-- then continues normal execution
-- refuses to auto-commit on the configured base branch (defaults to `main`)
-
-**Two modes:**
-
-- **Direct mode** (default): Commits on the current branch — no branch creation, no PR. Refuses to run on `main`/`master`. Use this when you're already on a feature branch.
-- **PR mode** (`--pr`): On completion, pushes the `ralphai/*` branch and creates a PR via `gh` CLI (with plan content + commit log in the PR body). With `--continuous`, loops back to pick the next backlog item.
-
-- **On turn exhaustion or stuck abort**: leaves files in `in-progress/` so you can resume with another run on the same branch.
-
-## Files
-
-| File / Directory | Purpose                                                    |
-| ---------------- | ---------------------------------------------------------- |
-| `README.md`      | This file — operational docs for the `.ralphai/` directory |
-| `PLANNING.md`    | Guide for writing plan files                               |
-| `LEARNINGS.md`   | Ralphai-written learnings — local-only                     |
-| `wip/`           | Work-in-progress plans — not scanned by ralphai            |
-| `backlog/`       | Incoming plans queued for ralphai to pick up               |
-| `in-progress/`   | Active plans and progress.md — work in flight              |
-| `out/`           | Archived PRD files and progress logs from completed runs   |
+All pipeline files are **gitignored** (local-only state).
 
 ## How It Works
 
-1. Ralphai loads `ralphai.json` (if present), applies env var overrides, then CLI flag overrides to resolve settings (agent command, feedback commands, base branch, mode, stuck threshold)
-2. It scans `in-progress/` for existing plan files; if found, it resumes. Otherwise it picks from `backlog/` (LLM-selected when multiple ready plans exist) and moves the chosen plan to `in-progress/`, initializing `progress.md`
-3. In PR mode, a `ralphai/<plan-slug>` branch is created from the base branch (e.g. `ralphai/add-dark-mode` from `add-dark-mode.md`; current branch reused on resume). If the branch already exists (local, remote, or has an open PR), the plan is skipped and the next one is tried. In direct mode, work continues on the current branch.
-4. The agent receives a prompt with `@file` references to the plan files + `progress.md`
-5. The agent reads the plan, picks the next task, implements it, runs the configured feedback commands, and commits
-6. `progress.md` is updated with what was done
-7. On completion (`COMPLETE` signal): plan + progress archived to `pipeline/out/`, then in PR mode the branch is pushed and a PR is created via `gh`. In direct mode, work is simply committed on the current branch. With `--continuous`, the script then loops back to pick the next backlog item; otherwise it exits.
-8. On incomplete run: files stay in `pipeline/in-progress/` for resumption
+1. Loads config: `ralphai.json` → env vars → CLI flags (highest priority wins)
+2. Resumes in-progress work, or picks from backlog (LLM-selected when multiple plans are ready)
+3. In PR mode, creates a `ralphai/<plan-slug>` branch. In branch mode (default), works on current branch.
+4. Agent receives plan + progress log, implements next task, runs feedback commands, commits
+5. Repeats until done or stuck. On completion, archives to `out/` and (in PR mode) opens a PR.
 
-**Turn pacing:** A single turn can take several minutes — the agent invocation itself plus all configured feedback commands (build, test, lint) run sequentially. Don't expect `progress.md` to update every few seconds. It updates between turns when there is something to report.
+**No file arguments needed.** Ralphai auto-detects what to work on.
 
-## Optional plan dependencies (`depends-on`)
+**Stuck detection:** Aborts after N consecutive turns with no commits (default: 3).
 
-`ralphai` supports optional `depends-on` metadata in plan frontmatter. A plan is runnable only when **all** dependencies are archived in `.ralphai/pipeline/out/`.
+**Modes:**
 
-Supported forms:
+- **Branch mode** (default): commits on current branch, refuses `main`/`master`
+- **PR mode** (`--pr`): creates `ralphai/*` branch, pushes, opens PR via `gh`
+- **Patch mode** (`--patch`): leaves changes uncommitted
+
+**`--resume`:** Auto-commits dirty state on non-base branches and continues. Refuses to auto-commit on the base branch.
+
+**`--dry-run`:** Read-only preview — no file moves, no branches, no agent execution.
+
+## Plan Dependencies
+
+Plans can declare `depends-on` in YAML frontmatter. A plan is runnable only when all dependencies are in `out/`.
 
 ```md
 ---
@@ -126,23 +61,9 @@ depends-on: [foundation.md, wiring.md]
 ---
 ```
 
-```md
----
-depends-on:
-	- foundation.md
-	- wiring.md
----
-```
+## Issue Linking
 
-Notes:
-
-- Dependencies are referenced by plan basename (e.g. `foundation.md`).
-- Missing or still-pending dependencies block the plan.
-- Plans with no `depends-on` are treated as ready (backward compatible).
-
-## Issue Linking (`source` frontmatter)
-
-Plans can link to a GitHub issue via `source` frontmatter. When a linked plan completes, Ralphai automatically comments on and closes the originating issue.
+Link a plan to a GitHub issue. On completion, Ralphai comments and closes the issue.
 
 ```md
 ---
@@ -152,123 +73,80 @@ issue-url: https://github.com/owner/repo/issues/42
 ---
 ```
 
-- `source` — tracker type (currently only `github`)
-- `issue` — issue number
-- `issue-url` — full URL to the issue (used for repo detection and human reference)
+Requires `gh` CLI. If `gh` is unavailable, hooks are silently skipped. Set `issueCloseOnComplete: false` to disable auto-closing.
 
-**What happens on completion:**
+## Files
 
-1. **`archive_run()`** — posts a "completed" comment on the linked issue
-2. **`create_pr()`** — closes the issue with a comment referencing the branch and PR
-
-**Requirements:**
-
-- `gh` CLI must be installed and authenticated (`gh auth login`). If `gh` is not available, hooks are silently skipped — no error.
-- To disable automatic issue closing while keeping completion comments, set `issueCloseOnComplete` to `false` in `ralphai.json`.
-
-Plans without `source` frontmatter behave exactly as before.
+| File / Directory       | Purpose                             |
+| ---------------------- | ----------------------------------- |
+| `README.md`            | This file                           |
+| `PLANNING.md`          | Guide for writing plan files        |
+| `LEARNINGS.md`         | Auto-written learnings (local-only) |
+| `pipeline/wip/`        | Parked plans                        |
+| `pipeline/backlog/`    | Queued plans                        |
+| `pipeline/in-progress/`| Active plans + progress.md          |
+| `pipeline/out/`        | Completed plans archive             |
 
 ## Conventions
 
-### Branch Naming (PR mode)
-
-In PR mode, branches are derived from the plan filename (minus the `.md` suffix): `add-dark-mode.md` → `ralphai/add-dark-mode`. Plans can be named freely — `dark-mode.md`, `gh-42-search.md`, `prd-auth.md` all work. If the branch already exists (locally, on the remote, or has an open PR), the plan is **skipped** and Ralphai tries the next dependency-ready plan. The `ralphai/` prefix is always used for isolation. In direct mode, no branches are created — work happens on the current branch.
-
 ### Commit Messages
 
-All commits use [Conventional Commits](https://www.conventionalcommits.org/). The agent prompt enforces this. Examples:
-
-- `feat(transpiler): add Windsurf prompt support`
-- `fix(parser): handle empty frontmatter gracefully`
-- `refactor: extract shared validation logic`
-- `test: add coverage for collision detection`
-- `docs: update AGENTS.md with new CLI command`
-- `chore(ralphai): archive completed run`
+[Conventional Commits](https://www.conventionalcommits.org/): `feat(scope): description`, `fix: ...`, `refactor: ...`, `test: ...`, `docs: ...`, `chore: ...`
 
 ### AGENTS.md Updates
 
-Only update `AGENTS.md` when a task produces knowledge that future coding agents need and cannot easily infer from the code itself — e.g. new CLI commands, non-obvious architectural constraints, or changed development workflows. Routine code changes (bug fixes, internal refactors, new tests) do not warrant an `AGENTS.md` update.
+Only update `AGENTS.md` when a task produces knowledge that future agents need and cannot easily infer from code — e.g. new CLI commands, non-obvious constraints, changed workflows.
 
 ### CHANGELOG.md
 
-Do **not** edit `CHANGELOG.md` unless explicitly asked. Changelog entries are maintained by humans.
+Do **not** edit `CHANGELOG.md` unless explicitly asked.
 
 ## Learnings
 
-Ralphai logs mistakes and lessons to `.ralphai/LEARNINGS.md` during autonomous runs. This file is **gitignored** (local-only, never committed). Ralphai reads it at the start of each turn to avoid repeating past mistakes.
+Ralphai logs mistakes to `LEARNINGS.md` (gitignored) during runs and reads it each turn to avoid repeating errors.
 
-Use a lightweight review loop after runs:
-
-1. Review `.ralphai/LEARNINGS.md` entries from the run.
-2. Compact findings by merging duplicates and removing one-off noise.
-3. Promote durable guidance to the appropriate place:
-
-- `AGENTS.md` (or equivalent agent-instruction docs) for immediate repo-specific behavior
-- Skill/reusable docs for stable patterns that should be reused across tasks/repos
-
-Keeping learnings gitignored prevents auto-written entries from interfering with stuck detection (which counts commits).
-
-## Safety Guards
-
-- **Dirty state**: Ralphai blocks by default; `--resume` auto-commits dirty state on any non-base branch (dry-run is read-only)
-- **Auto-commit control**: Per-turn safety-net commits and resume recovery commits are controlled by `autoCommit` (default `false`). When `autoCommit` is `false` in direct mode, dirty state is preserved with a warning. In PR mode, auto-commits always happen regardless of this setting.
-- **Branch isolation**: All work happens on `ralphai/*` branches (PR mode) or your current feature branch (direct mode), never directly on `main`
-- **Direct mode by default**: Ralphai commits on your current branch with no branch creation or PR. Refuses to run on `main`/`master`.
-- **Direct mode safety**: `--direct` refuses to run on `main`/`master` — you must be on a feature branch.
-- **Collision detection**: Before creating a new branch, Ralphai checks for existing local/remote branches and open PRs. If a collision is found, the plan is skipped and the next one is tried.
-- **Plan files gitignored**: The entire `.ralphai/` directory is gitignored. Plan files in `wip/`, `backlog/`, `in-progress/`, and `out/` are local-only state.
-- **Stuck detection**: Ralphai aborts after N turns with no new commits (default 3, configurable)
-- **Turn timeout**: Optional per-invocation timeout (`turnTimeout` in seconds). When set, the agent command is killed if it exceeds the limit. Default is 0 (no timeout).
-- **Completion signal**: Agent outputs `<promise>COMPLETE</promise>` when all tasks are done
+After runs: review entries, merge duplicates, promote durable lessons to `AGENTS.md` or skill docs.
 
 ## Configuration
 
-Ralphai supports an optional config file at `ralphai.json` (repo root) for repo-level defaults. Settings follow a strict precedence order:
-
-```
-CLI flags  >  env vars  >  config file  >  built-in defaults
-```
-
-### Config File (`ralphai.json`)
-
-A standard JSON file.
+Settings resolve: **CLI flags > env vars > `ralphai.json` > defaults**.
 
 ```json
 {
-  "agentCommand": "opencode run --agent build",
+  "agentCommand": "claude -p",
   "feedbackCommands": ["npm run build", "npm test", "npm run lint"],
   "baseBranch": "main",
   "maxStuck": 3
 }
 ```
 
-Supported keys:
+| Key                    | Default               | Description                              |
+| ---------------------- | --------------------- | ---------------------------------------- |
+| `agentCommand`         | _(none)_              | CLI prefix for the AI agent              |
+| `feedbackCommands`     | _(none)_              | Commands to run after each change        |
+| `baseBranch`           | `main`                | Branch to create work branches from      |
+| `mode`                 | `direct`              | `direct`, `pr`, or `patch`               |
+| `autoCommit`           | `false`               | Auto-commit after each turn              |
+| `turns`                | `5`                   | Turns per plan (0 = unlimited)           |
+| `maxStuck`             | `3`                   | No-progress turns before aborting        |
+| `turnTimeout`          | `0`                   | Seconds before killing agent (0 = off)   |
+| `promptMode`           | `auto`                | `auto`, `at-path`, or `inline`           |
+| `continuous`           | `false`               | Keep processing after first plan         |
+| `issueSource`          | `none`                | `none` or `github`                       |
+| `issueLabel`           | `ralphai`             | Label to filter issues                   |
+| `issueInProgressLabel` | `ralphai:in-progress` | Label when issue is picked up            |
+| `issueRepo`            | _(auto-detect)_       | `owner/repo` override                    |
+| `issueCloseOnComplete` | `true`                | Close issue on completion                |
+| `issueCommentProgress` | `true`                | Comment on issue during run              |
 
-| Key                    | Description                                                                | Default               | Validation                     |
-| ---------------------- | -------------------------------------------------------------------------- | --------------------- | ------------------------------ |
-| `agentCommand`         | Full CLI invocation prefix for the AI agent                                | _(none)_              | Non-empty                      |
-| `feedbackCommands`     | Shell commands to run after each change (JSON array or comma-separated)    | _(none)_              | Array of non-empty strings     |
-| `baseBranch`           | Branch to create work branches from                                        | `main`                | Non-empty, single token        |
-| `mode`                 | Run mode: `direct` (commit on current branch) or `pr` (create branch + PR) | `direct`              | `pr` or `direct`               |
-| `autoCommit`           | Auto-commit dirty state after each turn (ignored in PR mode)               | `false`               | `true` or `false`              |
-| `turns`                | Number of turns per plan (0 = unlimited)                                   | `5`                   | Non-negative integer           |
-| `maxStuck`             | Consecutive no-progress turns before aborting                              | `3`                   | Positive integer               |
-| `turnTimeout`          | Seconds before killing a hung agent invocation                             | `0` (off)             | Non-negative integer           |
-| `promptMode`           | How file refs are passed to the agent: `auto`, `at-path`, or `inline`      | `auto`                | `auto`, `at-path`, or `inline` |
-| `continuous`           | Keep processing backlog plans after the first completes                    | `false`               | `true` or `false`              |
-| `issueSource`          | Issue source to pull from (`none` or `github`)                             | `none`                | `none` or `github`             |
-| `issueLabel`           | Label to filter GitHub issues by                                           | `ralphai`             | Non-empty                      |
-| `issueInProgressLabel` | Label applied when an issue is picked up                                   | `ralphai:in-progress` | Non-empty                      |
-| `issueRepo`            | `owner/repo` override (auto-detected from remote)                          | _(auto-detect)_       | Any value                      |
-| `issueCloseOnComplete` | Close the issue when the plan completes                                    | `true`                | `true` or `false`              |
-| `issueCommentProgress` | Comment on the issue during the run                                        | `true`                | `true` or `false`              |
+All keys have corresponding `RALPHAI_*` env vars and CLI flags. Run `ralphai run --help` for the full list.
 
-The `agentCommand` is the full CLI invocation prefix — Ralphai appends the prompt as a quoted argument. Examples:
+### Agent Commands
 
-| Agent CLI   | `agentCommand` value             |
+| Agent       | `agentCommand`                   |
 | ----------- | -------------------------------- |
-| OpenCode    | `opencode run --agent build`     |
 | Claude Code | `claude -p`                      |
+| OpenCode    | `opencode run --agent build`     |
 | Codex       | `codex exec`                     |
 | Gemini CLI  | `gemini -p`                      |
 | Aider       | `aider --message`                |
@@ -276,245 +154,4 @@ The `agentCommand` is the full CLI invocation prefix — Ralphai appends the pro
 | Kiro        | `kiro-cli chat --no-interactive` |
 | Amp         | `amp -x`                         |
 
-> **Tested agents:** Only **Claude Code** and **OpenCode** have been validated end-to-end. The other presets are included for convenience and should work, but are untested.
-
-When `feedbackCommands` is configured, the agent prompt includes the specific commands (e.g. "Run all feedback loops: npm run build, npm test, npm run lint"). When absent, the prompt uses a generic fallback: "Run your project's build, test, and lint commands."
-
-Unknown keys are logged as a warning and ignored. Invalid values for known keys cause an immediate error with a description of the problem.
-
-The config file is optional. When absent, built-in defaults are used.
-
-### Env Var Overrides
-
-Environment variables override config file values:
-
-| Env Var                           | Overrides              |
-| --------------------------------- | ---------------------- |
-| `RALPHAI_AGENT_COMMAND`           | `agentCommand`         |
-| `RALPHAI_FEEDBACK_COMMANDS`       | `feedbackCommands`     |
-| `RALPHAI_BASE_BRANCH`             | `baseBranch`           |
-| `RALPHAI_MODE`                    | `mode`                 |
-| `RALPHAI_AUTO_COMMIT`             | `autoCommit`           |
-| `RALPHAI_TURNS`                   | `turns`                |
-| `RALPHAI_MAX_STUCK`               | `maxStuck`             |
-| `RALPHAI_TURN_TIMEOUT`            | `turnTimeout`          |
-| `RALPHAI_PROMPT_MODE`             | `promptMode`           |
-| `RALPHAI_CONTINUOUS`              | `continuous`           |
-| `RALPHAI_ISSUE_SOURCE`            | `issueSource`          |
-| `RALPHAI_ISSUE_LABEL`             | `issueLabel`           |
-| `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | `issueInProgressLabel` |
-| `RALPHAI_ISSUE_REPO`              | `issueRepo`            |
-| `RALPHAI_ISSUE_CLOSE_ON_COMPLETE` | `issueCloseOnComplete` |
-| `RALPHAI_ISSUE_COMMENT_PROGRESS`  | `issueCommentProgress` |
-
-```bash
-RALPHAI_AGENT_COMMAND='claude -p' RALPHAI_MAX_STUCK=5 ralphai run --turns=5
-```
-
-### CLI Flag Overrides
-
-CLI flags have the highest priority:
-
-| Flag                                | Overrides                   |
-| ----------------------------------- | --------------------------- |
-| `--agent-command=<command>`         | `agentCommand`              |
-| `--feedback-commands=<list>`        | `feedbackCommands`          |
-| `--base-branch=<branch>`            | `baseBranch`                |
-| `--turns=<n>`                       | `turns`                     |
-| `--direct`                          | `mode` (sets `direct`)      |
-| `--pr`                              | `mode` (sets `pr`)          |
-| `--auto-commit`                     | `autoCommit` (sets `true`)  |
-| `--no-auto-commit`                  | `autoCommit` (sets `false`) |
-| `--max-stuck=<n>`                   | `maxStuck`                  |
-| `--turn-timeout=<seconds>`          | `turnTimeout`               |
-| `--prompt-mode=<mode>`              | `promptMode`                |
-| `--continuous`                      | `continuous` (sets `true`)  |
-| `--issue-source=<source>`           | `issueSource`               |
-| `--issue-label=<label>`             | `issueLabel`                |
-| `--issue-in-progress-label=<label>` | `issueInProgressLabel`      |
-| `--issue-repo=<owner/repo>`         | `issueRepo`                 |
-| `--issue-close-on-complete=<bool>`  | `issueCloseOnComplete`      |
-| `--issue-comment-progress=<bool>`   | `issueCommentProgress`      |
-
-```bash
-ralphai run --turns=5 --agent-command='claude -p' --base-branch=develop --max-stuck=5
-```
-
-### Verifying Config (`--show-config`)
-
-Use `--show-config` to inspect resolved settings and their sources without running anything:
-
-```bash
-ralphai run --show-config
-```
-
-Output shows each setting's resolved value and where it came from (default, config file, env var, or CLI flag). This is useful for debugging precedence issues.
-
-```bash
-# Verify env var overrides config file
-RALPHAI_AGENT_COMMAND='codex exec' ralphai run --show-config
-
-# Verify CLI overrides everything
-RALPHAI_AGENT_COMMAND='codex exec' ralphai run --show-config --agent-command='claude -p'
-```
-
-### Feature Branch Workflow
-
-Ralphai supports working on a feature branch using direct mode. This is useful for large features that require multiple plans/sub-tasks before they're ready for `main`.
-
-**Setup:**
-
-1. Create your feature branch manually: `git checkout -b feature/big-thing main`
-2. Run Ralphai in direct mode on the feature branch:
-
-```bash
-ralphai run --turns=5 --direct
-```
-
-Or via `ralphai.json`:
-
-```json
-{
-  "baseBranch": "feature/big-thing",
-  "mode": "direct"
-}
-```
-
-**What happens:**
-
-1. Ralphai commits directly on `feature/big-thing` (no sub-branches)
-2. When all plans are done, you manually open a PR from `feature/big-thing` to `main`
-
-Alternatively, use PR mode with `--pr --base-branch=feature/big-thing` to create `ralphai/*` sub-branches that open PRs against the feature branch.
-
-### Continuous PR Mode (`--continuous --pr`)
-
-When `--continuous` and `--pr` are both active, all backlog plans run on a single branch and produce a single PR — no special plan-level metadata needed.
-
-**How it works:**
-
-1. **First plan completes** — branch is pushed, draft PR created via `gh pr create --draft`
-2. **Each subsequent plan completes** — PR body updated with cumulative progress (completed/remaining plans, commit log)
-3. **Last plan completes** — PR marked ready for review via `gh pr ready`
-
-The branch name uses the first plan's slug (e.g. `ralphai/add-dark-mode`). The PR body shows completed plans as checked items and remaining plans as unchecked.
-
-**When to use:**
-
-- Feature work that naturally splits into sequential phases
-- When you want a single reviewable PR but small, focused plans for the AI agent
-- When you want to AFK while multiple plans are completed
-
-**Failure handling:**
-
-- If a plan gets stuck or exhausts its turns, partial work is pushed and the PR is updated
-- Files stay in `in-progress/` so `--resume` can recover
-
-```bash
-ralphai run --turns=10 --continuous --pr
-```
-
-### GitHub Issues Integration
-
-Ralphai can automatically pull work from GitHub Issues when the backlog is empty. Issues labeled with a configurable label are converted to plan files, executed, and then closed on completion.
-
-**Prerequisites:** The [`gh` CLI](https://cli.github.com/) must be installed and authenticated (`gh auth login`). If `gh` is not available, Ralphai silently skips issue pulling and continues normally.
-
-**Enable it** by setting `issueSource` to `"github"` in `ralphai.json`:
-
-```json
-{
-  "issueSource": "github"
-}
-```
-
-Or via env var or CLI flag:
-
-```bash
-RALPHAI_ISSUE_SOURCE=github ralphai run --turns=5
-ralphai run --turns=5 --issue-source=github
-```
-
-**How it works:**
-
-1. When `detect_plan()` finds an empty backlog and `issueSource=github`, it calls `pull_github_issues()`
-2. The oldest open issue with the configured label (default: `ralphai`) is fetched via `gh issue list`
-3. A plan file is created in `backlog/` named `gh-<number>-<slugified-title>.md` with YAML frontmatter linking back to the issue:
-   ```yaml
-   ---
-   source: github
-   issue: 42
-   issue-url: https://github.com/owner/repo/issues/42
-   ---
-   ```
-4. The issue's label is changed from `ralphai` to `ralphai:in-progress`
-5. A progress comment is posted on the issue (if `issueCommentProgress=true`)
-6. `detect_plan()` re-scans the backlog and picks up the new plan file normally
-7. On completion, a comment is posted on the issue and it is closed (if `issueCloseOnComplete=true`)
-
-**Label workflow:**
-
-```
-Issue created with label "ralphai"
-  → Ralphai picks it up → label changed to "ralphai:in-progress"
-    → Ralphai completes the plan → issue closed with summary comment
-```
-
-**Config keys:**
-
-| Key                    | Description                                       | Default               | Validation         |
-| ---------------------- | ------------------------------------------------- | --------------------- | ------------------ |
-| `issueSource`          | Issue source to pull from (`none` or `github`)    | `none`                | `none` or `github` |
-| `issueLabel`           | Label to filter issues by                         | `ralphai`             | Non-empty          |
-| `issueInProgressLabel` | Label applied when an issue is picked up          | `ralphai:in-progress` | Non-empty          |
-| `issueRepo`            | `owner/repo` override (auto-detected from remote) | _(auto-detect)_       | Any value          |
-| `issueCloseOnComplete` | Close the issue when the plan completes           | `true`                | `true` or `false`  |
-| `issueCommentProgress` | Comment on the issue during the run               | `true`                | `true` or `false`  |
-
-**Env var overrides:**
-
-| Env Var                           | Overrides              |
-| --------------------------------- | ---------------------- |
-| `RALPHAI_ISSUE_SOURCE`            | `issueSource`          |
-| `RALPHAI_ISSUE_LABEL`             | `issueLabel`           |
-| `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | `issueInProgressLabel` |
-| `RALPHAI_ISSUE_REPO`              | `issueRepo`            |
-| `RALPHAI_ISSUE_CLOSE_ON_COMPLETE` | `issueCloseOnComplete` |
-| `RALPHAI_ISSUE_COMMENT_PROGRESS`  | `issueCommentProgress` |
-
-**CLI flag overrides:**
-
-| Flag                                | Overrides              |
-| ----------------------------------- | ---------------------- |
-| `--issue-source=<source>`           | `issueSource`          |
-| `--issue-label=<label>`             | `issueLabel`           |
-| `--issue-in-progress-label=<label>` | `issueInProgressLabel` |
-| `--issue-repo=<owner/repo>`         | `issueRepo`            |
-| `--issue-close-on-complete=<bool>`  | `issueCloseOnComplete` |
-| `--issue-comment-progress=<bool>`   | `issueCommentProgress` |
-
-**Repo detection:** When `issueRepo` is empty (default), Ralphai auto-detects the `owner/repo` from the `origin` git remote URL. Both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) formats are supported. Set `issueRepo` explicitly if the remote doesn't point to the correct repository.
-
-### Smoke Checks
-
-Use these checks to verify config behavior after changes to `ralphai.json`:
-
-1. **No config** — Remove or rename `ralphai.json`. Run `--show-config` and confirm all settings show `(default)`.
-
-2. **Config file only** — Create `ralphai.json` with custom values (e.g. `{"agentCommand": "claude -p"}`). Run `--show-config` and confirm settings show `(config)`.
-
-3. **Env var override** — Set an env var (e.g. `RALPHAI_AGENT_COMMAND='codex exec'`) with a config file present. Run `--show-config` and confirm the env var wins over the config file value.
-
-4. **CLI flag override** — Pass a CLI flag (e.g. `--agent-command='gemini -p'`) with both env var and config file set. Run `--show-config` and confirm the CLI flag wins.
-
-5. **Syntax check** — Run `bash -n $(npm root -g)/ralphai/runner/ralphai.sh` to verify the runner script has no syntax errors (or `bash -n $(node -e "console.log(require.resolve('ralphai/runner/ralphai.sh'))")`).
-
-### Troubleshooting
-
-**"Ralphai is not set up. Run ralphai init first."** inside a worktree
-
-`ralphai init` must be run in the **main repository**, not inside a git worktree. The `.ralphai/` directory only exists in the main repo — worktrees resolve it automatically via `git rev-parse --git-common-dir`. Run `git worktree list` to find the main worktree path, then run `ralphai init` there.
-
-**"Cannot initialize ralphai inside a git worktree"**
-
-Navigate to the main repository and run `ralphai init` there. Ralphai detects that you're in a worktree and refuses to initialize because `.ralphai/` must live in the main repo to be shared across all worktrees. Use `git worktree list` to find the main repo path (the first entry in the list).
+> Only **Claude Code** and **OpenCode** have been validated end-to-end.


### PR DESCRIPTION
Cuts total doc lines from ~1,595 to 689 (57% reduction) while preserving all vital information.

**Changes:**
- **README** (213→120): collapse install blocks, cut duplicated flow diagram and How Ralphai Works section, consolidate doc links
- **how-ralphai-works** (232→126): tighten context rot to 1 paragraph, trim all sections
- **worktrees** (120→53): cut manual worktrees, fold sandbox problem, consolidate agent compat table
- **templates/README** (530→157): cut Feature Branch, Continuous PR, GitHub Issues, Smoke Checks, Safety Guards, Troubleshooting; replace 3 override tables with 1 config table
- **templates/PLANNING** (420→133): consolidate 4 plan templates into 1 + adapting section
- **ralphai.ts**: fix init output alignment, reduce next steps from 5 to 3
- **cli-reference** (new, 100 lines): extracted from README to its own doc (was inline)