### PR TITLE
Rename 'uninstall' command to 'teardown'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,10 @@
 
 ## 0.4.0
 
-**Breaking** — This release includes structural changes. If upgrading from an earlier version, uninstall first:
+**Breaking** — This release includes structural changes. If upgrading from an earlier version, teardown first:
 
 ```sh
-npx ralphai uninstall && npm install -g ralphai@latest
+npx ralphai teardown && npm install -g ralphai@latest
 ```
 
 ### Features
@@ -65,10 +65,10 @@ npx ralphai uninstall && npm install -g ralphai@latest
 
 ## 0.3.0
 
-**Breaking** — This release includes structural changes. If upgrading from an earlier version, uninstall first:
+**Breaking** — This release includes structural changes. If upgrading from an earlier version, teardown first:
 
 ```sh
-npx ralphai uninstall && npm install -g ralphai@latest
+npx ralphai teardown && npm install -g ralphai@latest
 ```
 
 ### Features
@@ -152,4 +152,4 @@ Ralph takes plan files from a backlog and drives any CLI-based coding agent to i
 - **GitHub Issues integration** — optionally pulls labeled issues when the backlog is empty
 - **Plan dependencies** — `depends-on` field for ordering across a backlog
 - **Learnings loop** — two-tier system for logging and curating lessons across runs
-- **Update, sync & uninstall** — `ralphai update` self-updates the CLI; `ralphai sync` refreshes templates; `ralphai uninstall` cleans up
+- **Update, sync & teardown** — `ralphai update` self-updates the CLI; `ralphai sync` refreshes templates; `ralphai teardown` cleans up

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -14,7 +14,7 @@ ralphai <command> [options]
 | `status`       | Show pipeline and worktree status                   |
 | `reset`        | Move in-progress plans back to backlog and clean up |
 | `update [tag]` | Update ralphai to the latest (or specified) version |
-| `uninstall`    | Remove Ralphai from your project                    |
+| `teardown`     | Remove Ralphai from your project                    |
 
 ## Global Options
 

--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -17,7 +17,7 @@ describe("CLI help and flags", () => {
     expect(output).toContain("init");
     expect(output).toContain("run");
     expect(output).toContain("update");
-    expect(output).toContain("uninstall");
+    expect(output).toContain("teardown");
     expect(output).toContain("reset");
   });
 
@@ -46,7 +46,7 @@ describe("CLI help and flags", () => {
     expect(result.stdout).toContain("init");
     expect(result.stdout).toContain("run");
     expect(result.stdout).toContain("update");
-    expect(result.stdout).toContain("uninstall");
+    expect(result.stdout).toContain("teardown");
   });
 
   // -------------------------------------------------------------------------
@@ -82,10 +82,10 @@ describe("CLI help and flags", () => {
     expect(result.stdout).toContain("update");
   });
 
-  it("uninstall --help shows uninstall usage and flags", () => {
-    const result = runCli(["uninstall", "--help"]);
+  it("teardown --help shows teardown usage and flags", () => {
+    const result = runCli(["teardown", "--help"]);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("uninstall");
+    expect(result.stdout).toContain("teardown");
     expect(result.stdout).toContain("--yes");
   });
 
@@ -126,8 +126,8 @@ describe("CLI help and flags", () => {
     expect(result.stderr).toContain("Unknown flag");
   });
 
-  it("uninstall --wrong exits with error", () => {
-    const result = runCli(["uninstall", "--wrong"], ctx.dir);
+  it("teardown --wrong exits with error", () => {
+    const result = runCli(["teardown", "--wrong"], ctx.dir);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Unknown flag");
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ ${BOLD}Commands:${RESET}
   status         Show pipeline and worktree status
   reset          Move in-progress plans back to backlog and clean up
   update [tag]   Update ralphai to the latest (or specified) version
-  uninstall      Remove Ralphai from your project
+  teardown       Remove Ralphai from your project
   doctor         Check your ralphai setup for problems
 
 ${BOLD}Options:${RESET}
@@ -77,7 +77,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} ralphai reset --yes            ${DIM}# reset without confirmation${RESET}
   ${DIM}$${RESET} ralphai update                 ${DIM}# update ralphai to latest${RESET}
   ${DIM}$${RESET} ralphai update beta            ${DIM}# install beta version${RESET}
-  ${DIM}$${RESET} ralphai uninstall --yes        ${DIM}# remove ralphai${RESET}
+  ${DIM}$${RESET} ralphai teardown --yes         ${DIM}# remove ralphai from project${RESET}
 `);
 }
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -24,7 +24,7 @@ type RalphaiSubcommand =
   | "init"
   | "update"
   | "run"
-  | "uninstall"
+  | "teardown"
   | "worktree"
   | "status"
   | "reset"
@@ -85,7 +85,7 @@ const SUBCOMMANDS = new Set<RalphaiSubcommand>([
   "init",
   "update",
   "run",
-  "uninstall",
+  "teardown",
   "worktree",
   "status",
   "reset",
@@ -588,10 +588,10 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
 }
 
 // ---------------------------------------------------------------------------
-// Uninstall logic
+// Teardown logic
 // ---------------------------------------------------------------------------
 
-async function uninstallRalphai(
+async function teardownRalphai(
   options: RalphaiOptions,
   cwd: string,
 ): Promise<void> {
@@ -605,7 +605,7 @@ async function uninstallRalphai(
   }
 
   if (!options.yes) {
-    clack.intro("Uninstalling Ralphai");
+    clack.intro("Tearing down Ralphai");
     const confirmed = await clack.confirm({
       message:
         "This will permanently delete .ralphai/. " +
@@ -613,7 +613,7 @@ async function uninstallRalphai(
     });
 
     if (clack.isCancel(confirmed) || !confirmed) {
-      clack.cancel("Uninstall cancelled.");
+      clack.cancel("Teardown cancelled.");
       return;
     }
   }
@@ -621,7 +621,7 @@ async function uninstallRalphai(
   // Remove .ralphai/ directory
   rmSync(ralphaiDir, { recursive: true, force: true });
 
-  console.log(`${TEXT}Ralphai uninstalled.${RESET}`);
+  console.log(`${TEXT}Ralphai torn down.${RESET}`);
   console.log();
   console.log(`${DIM}Removed:${RESET}`);
   console.log(`  .ralphai/                  ${DIM}Entire directory${RESET}`);
@@ -1130,7 +1130,7 @@ function showRalphaiHelp(): void {
     `  ${TEXT}update${RESET}      ${DIM}Update ralphai to the latest (or specified) version${RESET}`,
   );
   console.log(
-    `  ${TEXT}uninstall${RESET}   ${DIM}Remove Ralphai from your project${RESET}`,
+    `  ${TEXT}teardown${RESET}    ${DIM}Remove Ralphai from your project${RESET}`,
   );
   console.log(
     `  ${TEXT}doctor${RESET}      ${DIM}Check your ralphai setup for problems${RESET}`,
@@ -1156,7 +1156,7 @@ export async function runRalphai(args: string[]): Promise<void> {
     "status",
     "reset",
     "update",
-    "uninstall",
+    "teardown",
     "doctor",
   ]);
   if (
@@ -1190,12 +1190,12 @@ export async function runRalphai(args: string[]): Promise<void> {
         tag: options.targetDir, // first positional arg after "update" is parsed as targetDir
       });
       break;
-    case "uninstall":
+    case "teardown":
       if (helpRequested) {
-        showUninstallHelp();
+        showTeardownHelp();
         return;
       }
-      await uninstallRalphai(options, cwd);
+      await teardownRalphai(options, cwd);
       break;
     case "run":
       await runRalphaiRunner(options, cwd);
@@ -1721,8 +1721,8 @@ function showUpdateHelp(): void {
   );
 }
 
-function showUninstallHelp(): void {
-  console.log(`${TEXT}Usage:${RESET} ralphai uninstall [options]`);
+function showTeardownHelp(): void {
+  console.log(`${TEXT}Usage:${RESET} ralphai teardown [options]`);
   console.log();
   console.log(`${DIM}Remove Ralphai from your project.${RESET}`);
   console.log();

--- a/src/teardown-reset.test.ts
+++ b/src/teardown-reset.test.ts
@@ -10,32 +10,32 @@ import {
   useTempGitDir,
 } from "./test-utils.ts";
 
-describe("uninstall command", () => {
+describe("teardown command", () => {
   const ctx = useTempGitDir();
 
-  it("uninstall --yes removes .ralphai/ dir", () => {
+  it("teardown --yes removes .ralphai/ dir", () => {
     // First, set up ralphai
     runCliOutput(["init", "--yes"], ctx.dir);
     expect(existsSync(join(ctx.dir, ".ralphai"))).toBe(true);
 
-    // Now uninstall
-    const output = stripLogo(runCliOutput(["uninstall", "--yes"], ctx.dir));
+    // Now tear down
+    const output = stripLogo(runCliOutput(["teardown", "--yes"], ctx.dir));
 
-    expect(output).toContain("Ralphai uninstalled");
+    expect(output).toContain("Ralphai torn down");
     expect(existsSync(join(ctx.dir, ".ralphai"))).toBe(false);
   });
 
-  it("uninstall --yes prints not set up when .ralphai/ does not exist", () => {
-    const output = stripLogo(runCliOutput(["uninstall", "--yes"], ctx.dir));
+  it("teardown --yes prints not set up when .ralphai/ does not exist", () => {
+    const output = stripLogo(runCliOutput(["teardown", "--yes"], ctx.dir));
 
     expect(output).toContain("not set up");
     expect(output).toContain(".ralphai/ does not exist");
   });
 
-  it("uninstall --yes <target-dir> uninstalls from target directory", () => {
+  it("teardown --yes <target-dir> tears down from target directory", () => {
     const targetDir = join(
       tmpdir(),
-      `ralphai-uninstall-target-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      `ralphai-teardown-target-${Date.now()}-${Math.random().toString(36).slice(2)}`,
     );
     mkdirSync(targetDir, { recursive: true });
     execSync("git init", { cwd: targetDir, stdio: "ignore" });
@@ -45,12 +45,12 @@ describe("uninstall command", () => {
       runCliOutput(["init", "--yes", targetDir], ctx.dir);
       expect(existsSync(join(targetDir, ".ralphai"))).toBe(true);
 
-      // Uninstall from target
+      // Tear down from target
       const output = stripLogo(
-        runCliOutput(["uninstall", "--yes", targetDir], ctx.dir),
+        runCliOutput(["teardown", "--yes", targetDir], ctx.dir),
       );
 
-      expect(output).toContain("Ralphai uninstalled");
+      expect(output).toContain("Ralphai torn down");
       expect(existsSync(join(targetDir, ".ralphai"))).toBe(false);
     } finally {
       if (existsSync(targetDir)) {


### PR DESCRIPTION
## Summary

- Renames `ralphai uninstall` → `ralphai teardown` across the entire codebase
- "uninstall" implied removing the tool itself (like `npm uninstall`), but the command only deletes the `.ralphai/` directory — the CLI stays installed globally
- "teardown" is the natural inverse of `init` and clearly signals project-level cleanup

## Changes

- `src/ralphai.ts` — type union, subcommand set, function names, switch case, help text, user-facing strings
- `src/cli.ts` — help listing and example
- `src/uninstall-reset.test.ts` → `src/teardown-reset.test.ts` — renamed file and updated all test content
- `src/cli-help.test.ts` — updated assertions and test names
- `docs/cli-reference.md` — command table
- `CHANGELOG.md` — upgrade instructions and feature descriptions