### PR TITLE
Add purge command to delete archived pipeline artifacts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ ${BOLD}Commands:${RESET}
   worktree       Create or reuse an isolated git worktree
   status         Show pipeline and worktree status
   reset          Move in-progress plans back to backlog and clean up
+  purge          Delete archived artifacts from pipeline/out/
   update [tag]   Update ralphai to the latest (or specified) version
   teardown       Remove Ralphai from your project
   doctor         Check your ralphai setup for problems
@@ -61,6 +62,9 @@ ${BOLD}Worktree Options:${RESET}
 ${BOLD}Reset Options:${RESET}
   --yes, -y         Skip confirmation prompt
 
+${BOLD}Purge Options:${RESET}
+  --yes, -y         Skip confirmation prompt
+
 ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} ralphai init                  ${DIM}# interactive setup${RESET}
   ${DIM}$${RESET} ralphai init --yes             ${DIM}# setup with defaults${RESET}
@@ -75,6 +79,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} ralphai status                 ${DIM}# show pipeline and worktree status${RESET}
   ${DIM}$${RESET} ralphai reset                  ${DIM}# move in-progress plans back to backlog${RESET}
   ${DIM}$${RESET} ralphai reset --yes            ${DIM}# reset without confirmation${RESET}
+  ${DIM}$${RESET} ralphai purge --yes            ${DIM}# delete all archived artifacts${RESET}
   ${DIM}$${RESET} ralphai update                 ${DIM}# update ralphai to latest${RESET}
   ${DIM}$${RESET} ralphai update beta            ${DIM}# install beta version${RESET}
   ${DIM}$${RESET} ralphai teardown --yes         ${DIM}# remove ralphai from project${RESET}

--- a/src/purge.test.ts
+++ b/src/purge.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, writeFileSync, mkdirSync, readdirSync } from "fs";
+import { join } from "path";
+import {
+  runCli,
+  runCliOutput,
+  stripLogo,
+  useTempGitDir,
+} from "./test-utils.ts";
+
+describe("purge command", () => {
+  const ctx = useTempGitDir();
+
+  it("purge --yes deletes all files in pipeline/out/", () => {
+    runCliOutput(["init", "--yes"], ctx.dir);
+
+    const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(
+      join(outDir, "my-feature-20260101-120000.md"),
+      "# My Feature",
+    );
+    writeFileSync(
+      join(outDir, "progress-my-feature-20260101-120000.md"),
+      "## Progress",
+    );
+    writeFileSync(
+      join(outDir, "receipt-my-feature-20260101-120000.txt"),
+      "slug=my-feature",
+    );
+
+    const output = stripLogo(runCliOutput(["purge", "--yes"], ctx.dir));
+
+    expect(output).toContain("Purged");
+    expect(readdirSync(outDir)).toEqual([]);
+  });
+
+  it("purge --yes reports nothing when out/ is empty", () => {
+    runCliOutput(["init", "--yes"], ctx.dir);
+
+    const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
+    mkdirSync(outDir, { recursive: true });
+
+    const output = stripLogo(runCliOutput(["purge", "--yes"], ctx.dir));
+
+    expect(output).toContain("Nothing to purge");
+  });
+
+  it("purge --yes reports nothing when out/ does not exist", () => {
+    runCliOutput(["init", "--yes"], ctx.dir);
+
+    const output = stripLogo(runCliOutput(["purge", "--yes"], ctx.dir));
+
+    expect(output).toContain("Nothing to purge");
+  });
+
+  it("purge --yes shows summary counts by type", () => {
+    runCliOutput(["init", "--yes"], ctx.dir);
+
+    const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "feat-a-20260101-120000.md"), "# A");
+    writeFileSync(join(outDir, "feat-b-20260102-120000.md"), "# B");
+    writeFileSync(
+      join(outDir, "progress-feat-a-20260101-120000.md"),
+      "## Progress",
+    );
+    writeFileSync(
+      join(outDir, "receipt-feat-a-20260101-120000.txt"),
+      "slug=feat-a",
+    );
+    writeFileSync(
+      join(outDir, "receipt-feat-b-20260102-120000.txt"),
+      "slug=feat-b",
+    );
+
+    const output = stripLogo(runCliOutput(["purge", "--yes"], ctx.dir));
+
+    expect(output).toContain("2 archived plans");
+    expect(output).toContain("1 progress file");
+    expect(output).toContain("2 receipts");
+  });
+
+  it("purge errors when .ralphai/ does not exist", () => {
+    const result = runCli(["purge", "--yes"], ctx.dir);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("not set up");
+    expect(result.stderr).toContain("ralphai init");
+  });
+
+  it("purge --help shows usage", () => {
+    const result = runCli(["purge", "--help"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("purge");
+    expect(result.stdout).toContain("--yes");
+  });
+
+  it("purge rejects unknown flags", () => {
+    const result = runCli(["purge", "--bad-flag"], ctx.dir);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Unknown flag");
+    expect(result.stderr).toContain("--bad-flag");
+  });
+
+  it("purge --yes preserves the out/ directory itself", () => {
+    runCliOutput(["init", "--yes"], ctx.dir);
+
+    const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "plan-20260101-120000.md"), "# Plan");
+
+    runCliOutput(["purge", "--yes"], ctx.dir);
+
+    // Directory should still exist, just be empty
+    expect(existsSync(outDir)).toBe(true);
+    expect(readdirSync(outDir)).toEqual([]);
+  });
+});

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -28,6 +28,7 @@ type RalphaiSubcommand =
   | "worktree"
   | "status"
   | "reset"
+  | "purge"
   | "doctor";
 
 type WorktreeSubcommand = "run" | "list" | "clean";
@@ -89,6 +90,7 @@ const SUBCOMMANDS = new Set<RalphaiSubcommand>([
   "worktree",
   "status",
   "reset",
+  "purge",
   "doctor",
 ]);
 
@@ -1106,6 +1108,109 @@ async function runRalphaiReset(
 }
 
 // ---------------------------------------------------------------------------
+// purge — delete all archived artifacts from pipeline/out/
+// ---------------------------------------------------------------------------
+
+async function runRalphaiPurge(
+  options: RalphaiOptions,
+  cwd: string,
+): Promise<void> {
+  const ralphaiRoot = resolveRalphaiDir(cwd);
+  if (!ralphaiRoot) {
+    console.error(
+      `Ralphai is not set up. Run ${TEXT}ralphai init${RESET} first.`,
+    );
+    process.exit(1);
+  }
+
+  const outDir = join(ralphaiRoot, ".ralphai", "pipeline", "out");
+
+  if (!existsSync(outDir)) {
+    console.log("Nothing to purge — no out/ directory.");
+    return;
+  }
+
+  const files = readdirSync(outDir);
+  if (files.length === 0) {
+    console.log("Nothing to purge — out/ is already empty.");
+    return;
+  }
+
+  const planFiles = files.filter(
+    (f) => f.endsWith(".md") && !f.startsWith("progress-"),
+  );
+  const progressFiles = files.filter(
+    (f) => f.endsWith(".md") && f.startsWith("progress-"),
+  );
+  const receiptFiles = files.filter(
+    (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
+  );
+
+  // Show what will be deleted
+  console.log();
+  console.log(
+    `${TEXT}The following archived artifacts will be deleted:${RESET}`,
+  );
+  console.log();
+  if (planFiles.length > 0) {
+    console.log(
+      `  ${TEXT}Plans${RESET}       ${DIM}${planFiles.length} archived plan${planFiles.length !== 1 ? "s" : ""}${RESET}`,
+    );
+  }
+  if (progressFiles.length > 0) {
+    console.log(
+      `  ${TEXT}Progress${RESET}    ${DIM}${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""}${RESET}`,
+    );
+  }
+  if (receiptFiles.length > 0) {
+    console.log(
+      `  ${TEXT}Receipts${RESET}    ${DIM}${receiptFiles.length} receipt${receiptFiles.length !== 1 ? "s" : ""}${RESET}`,
+    );
+  }
+  console.log();
+
+  // Confirm unless --yes
+  if (!options.yes) {
+    clack.intro("Ralphai Purge");
+    const confirmed = await clack.confirm({
+      message:
+        "Delete all archived artifacts from pipeline/out/? This cannot be undone.",
+    });
+
+    if (clack.isCancel(confirmed) || !confirmed) {
+      clack.cancel("Purge cancelled.");
+      return;
+    }
+  }
+
+  // Delete all files in out/
+  for (const file of files) {
+    rmSync(join(outDir, file), { force: true });
+  }
+
+  // Summary
+  console.log(`${TEXT}Purged.${RESET}`);
+  console.log();
+  console.log(`${DIM}Deleted:${RESET}`);
+  if (planFiles.length > 0) {
+    console.log(
+      `  ${planFiles.length} archived plan${planFiles.length !== 1 ? "s" : ""}`,
+    );
+  }
+  if (progressFiles.length > 0) {
+    console.log(
+      `  ${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""}`,
+    );
+  }
+  if (receiptFiles.length > 0) {
+    console.log(
+      `  ${receiptFiles.length} receipt${receiptFiles.length !== 1 ? "s" : ""}`,
+    );
+  }
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
 
 function showRalphaiHelp(): void {
   console.log(`${TEXT}Usage:${RESET} ralphai <command> [options]`);
@@ -1125,6 +1230,9 @@ function showRalphaiHelp(): void {
   );
   console.log(
     `  ${TEXT}reset${RESET}       ${DIM}Move in-progress plans back to backlog and clean up${RESET}`,
+  );
+  console.log(
+    `  ${TEXT}purge${RESET}       ${DIM}Delete archived artifacts from pipeline/out/${RESET}`,
   );
   console.log(
     `  ${TEXT}update${RESET}      ${DIM}Update ralphai to the latest (or specified) version${RESET}`,
@@ -1155,6 +1263,7 @@ export async function runRalphai(args: string[]): Promise<void> {
     "init",
     "status",
     "reset",
+    "purge",
     "update",
     "teardown",
     "doctor",
@@ -1216,6 +1325,13 @@ export async function runRalphai(args: string[]): Promise<void> {
         return;
       }
       await runRalphaiReset(options, cwd);
+      break;
+    case "purge":
+      if (helpRequested) {
+        showPurgeHelp();
+        return;
+      }
+      await runRalphaiPurge(options, cwd);
       break;
     case "doctor":
       if (helpRequested) {
@@ -1697,6 +1813,19 @@ function showResetHelp(): void {
   console.log();
   console.log(
     `${DIM}Move in-progress plans back to backlog and clean up worktrees.${RESET}`,
+  );
+  console.log();
+  console.log(`${TEXT}Options:${RESET}`);
+  console.log(
+    `  ${TEXT}--yes, -y${RESET}   ${DIM}Skip confirmation prompt${RESET}`,
+  );
+}
+
+function showPurgeHelp(): void {
+  console.log(`${TEXT}Usage:${RESET} ralphai purge [options]`);
+  console.log();
+  console.log(
+    `${DIM}Delete all archived plans, progress files, and receipts from pipeline/out/.${RESET}`,
   );
   console.log();
   console.log(`${TEXT}Options:${RESET}`);


### PR DESCRIPTION
## Summary

- Adds `ralphai purge` command that deletes all files in `pipeline/out/` (archived plans, progress files, and receipts)
- Supports `--yes`/`-y` to skip confirmation prompt, consistent with `reset` and `teardown`
- Chose `purge` over `clean` to avoid mental collision with `worktree clean`

## Details

The `pipeline/out/` directory accumulates archived artifacts over time — completed plans, progress logs, and receipt files. This command provides a simple way to clear them all out.

**Behavior:**
- Shows a categorized preview (plans, progress files, receipts) before confirming
- Preserves the `out/` directory itself, only deletes its contents
- Reports "Nothing to purge" when `out/` is empty or doesn't exist
- Exits with error if `.ralphai/` is not set up
- Rejects unknown flags (strict subcommand)

**Tests:** 8 new tests in `src/purge.test.ts` covering happy path, empty state, error handling, help output, unknown flag rejection, and directory preservation.