### PR TITLE
fix(init): remove patch auto-commit prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## WIP
+
+### Fixes
+
+- **Init wizard no longer asks patch-mode users about auto-commit** — patch mode now consistently means "leave changes uncommitted" during setup. Advanced users can still enable `autoCommit` later through config or CLI flags.
+
 ## 0.5.0
 
 ### Features

--- a/src/init-wizard.test.ts
+++ b/src/init-wizard.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("init wizard", () => {
+  it("does not prompt patch mode users about auto-commit", () => {
+    const source = readFileSync(join(__dirname, "ralphai.ts"), "utf-8");
+
+    expect(source).not.toContain('message: "Auto-commit between turns?"');
+  });
+});

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -532,23 +532,9 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
 
   const mode = modeSelection as "branch" | "pr" | "patch";
 
-  // 6. Auto-commit (only for patch mode)
   let autoCommit = false;
-  if (mode === "patch") {
-    const autoCommitAnswer = await clack.confirm({
-      message: "Auto-commit between turns?",
-      initialValue: false,
-    });
 
-    if (clack.isCancel(autoCommitAnswer)) {
-      clack.cancel("Setup cancelled.");
-      return null;
-    }
-
-    autoCommit = autoCommitAnswer;
-  }
-
-  // 7. GitHub Issues integration
+  // 6. GitHub Issues integration
   const enableIssues = await clack.confirm({
     message: "Enable GitHub Issues integration?",
     initialValue: false,
@@ -567,7 +553,7 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
     );
   }
 
-  // 8. Sample plan
+  // 7. Sample plan
   const createSamplePlan = await clack.confirm({
     message: "Create a sample plan to try your first run?",
     initialValue: true,
@@ -578,7 +564,7 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
     return null;
   }
 
-  // 9. Update AGENTS.md
+  // 8. Update AGENTS.md
   const agentsMdPath = join(cwd, "AGENTS.md");
   const agentsMdExists = existsSync(agentsMdPath);
   const agentsMdHasSection =


### PR DESCRIPTION
## Summary
- remove the patch-mode auto-commit question from the init wizard
- keep patch mode setup aligned with its user-facing promise: leave changes uncommitted
- add focused test coverage for the wizard behavior
- add a WIP changelog entry for the UX change

## Why
Patch mode is described as leaving changes uncommitted in the working tree. Asking first-time users whether Ralphai should auto-commit between turns makes that mode contradictory during setup and adds unnecessary confusion.

## Changes
- remove the `Auto-commit between turns?` prompt from the init wizard
- keep `autoCommit` available as an advanced config or CLI override rather than a first-run wizard choice
- add a focused regression test to ensure the prompt is not present in the wizard source
- record the change in the WIP changelog

## Testing
- pnpm vitest run src/init-wizard.test.ts src/init.test.ts