### PR TITLE
feat(pipeline): move plan artifacts into per-plan folders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,10 @@ Project-specific guidance for AI coding agents working in this codebase.
 - **Source files: max ~300 lines.** Extract modules when a file grows beyond this.
 - Before appending to any file, check its current size. If adding your changes would push it past the limit, split first.
 
-
 ## Ralphai
 
 This project uses [Ralphai](https://github.com/mfaux/ralphai) for autonomous task execution.
-Plan files go in `.ralphai/pipeline/backlog/`. See `.ralphai/PLANNING.md` for
+Plan files go in per-plan folders under `.ralphai/pipeline/backlog/`. See `.ralphai/PLANNING.md` for
 the plan writing guide.
 
 ## Learnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## WIP
 
+### Breaking
+
+- **Per-plan pipeline folders** — plans now live in per-plan folders under `pipeline/backlog/` (for example `backlog/<slug>/<slug>.md`), and `wip/` is renamed to `parked/`. This release removes backward compatibility with the old file layout.
+
 ### Fixes
 
 - **Init wizard no longer asks patch-mode users about auto-commit** — patch mode now consistently means "leave changes uncommitted" during setup. Advanced users can still enable `autoCommit` later through config or CLI flags.
@@ -148,7 +152,7 @@ npx ralphai teardown && npm install -g ralphai@latest
 ### Refactors
 
 - Rename `plans/` to `plan-types/` and nest lifecycle dirs under `pipeline/` (#20)
-- Rename `drafts/` to `wip/` (#13)
+- Rename `drafts/` to `parked/` (#13)
 - Add `sync-ralphai` script for dogfooding template changes (#19)
 - Refactor publish workflow for version bump handling (#4)
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,15 @@ ralphai worktree clean              # remove completed worktrees
 Plans flow through the pipeline:
 
 ```
-wip/ (parked)    backlog/  →  in-progress/  →  out/
+parked/    backlog/  →  in-progress/  →  out/
 ```
 
-Park unready plans in `wip/`. Ralphai ignores that folder.
+Park unready plans in `parked/`. Ralphai ignores that folder.
+Each plan lives in its own folder under `backlog/` (for example `backlog/<slug>/<slug>.md`).
 
 ### 4. Pause and resume
 
-Stop mid-run any time. Work stays in `in-progress/`. Resume with `ralphai run`, which auto-detects in-progress work. Use `ralphai status` to see what's queued, in progress, and any problems.
+Stop mid-run any time. Work stays in `in-progress/<slug>/`. Resume with `ralphai run`, which auto-detects in-progress work. Use `ralphai status` to see what's queued, in progress, and any problems.
 
 ### 5. Close the learnings loop
 

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -64,7 +64,7 @@ If **N consecutive turns** produce no new commits, Ralphai aborts. Default
 threshold is 3. Configurable via `maxStuck` in `ralphai.json`,
 `RALPHAI_MAX_STUCK`, or `--max-stuck`.
 
-The plan stays in `in-progress/` so you can inspect and resume.
+The plan stays in `in-progress/<slug>/` so you can inspect and resume.
 
 ## Continuous Mode
 
@@ -110,7 +110,7 @@ The PR body looks like:
 ### Failure handling
 
 - **Stuck** (N turns with no commits): Ralphai pushes partial work to the
-  continuous branch and exits. The plan stays in `in-progress/` for
+  continuous branch and exits. The plan stays in `in-progress/<slug>/` for
   inspection and resumption.
 - **Turn budget exhausted** (completed all turns without the agent
   signaling completion): same behavior — partial work is pushed and
@@ -139,15 +139,16 @@ starting — collisions skip to the next plan.
 ## Plan Lifecycle
 
 ```
-wip/       (parked — Ralphai ignores)
+parked/    (ignored by Ralphai)
 backlog/  →  in-progress/  →  out/
 ```
 
-- **`backlog/`** — the queue. Ralphai picks dependency-ready plans
+- **`backlog/`** — the queue. Each plan is a folder containing the plan file.
+  Ralphai picks dependency-ready plans
   (oldest first when multiple are ready).
-- **`in-progress/`** — active work. Plan + `progress.md` live here. Files
-  stay on interruption for resumption.
-- **`out/`** — archive. Moved here when the agent signals completion.
+- **`in-progress/`** — active work. The plan folder contains the plan file and
+  `progress.md`. Files stay on interruption for resumption.
+- **`out/`** — archive. Plan folders move here when the agent signals completion.
 
 Plans can declare `depends-on` in YAML frontmatter. A plan runs only when
 all dependencies are in `out/`.
@@ -162,7 +163,7 @@ depends-on: [foundation.md, wiring.md]
 
 When Ralphai looks for work, it follows this priority:
 
-1. **In-progress plans first** — if `in-progress/` contains a plan file,
+1. **In-progress plans first** — if `in-progress/` contains any plan folder,
    Ralphai resumes it (no selection needed).
 2. **Backlog selection** — otherwise, Ralphai scans `backlog/` for
    dependency-ready plans (all `depends-on` entries archived in `out/`).
@@ -182,10 +183,9 @@ run in filesystem order (typically alphabetical).
 
 ## Receipt Files
 
-When a run starts, Ralphai creates a **receipt file** in
-`pipeline/in-progress/` that tracks run metadata. The receipt is updated
-after each turn and used by `ralphai status` to show progress and
-diagnostics.
+When a run starts, Ralphai creates a **receipt file** inside the plan
+folder in `pipeline/in-progress/<slug>/`. The receipt is updated after each turn
+and used by `ralphai status` to show progress and diagnostics.
 
 Receipt files are plain text, one `key=value` per line:
 
@@ -224,7 +224,7 @@ tasks_completed=2
   the run originated (`source`, `worktree_path`, `branch`).
 - **Status diagnostics** — `ralphai status` reads receipt files
   automatically. If you need more detail, inspect the receipt directly at
-  `.ralphai/pipeline/in-progress/receipt-<slug>.txt`.
+  `.ralphai/pipeline/in-progress/<slug>/receipt.txt`.
 
 After a plan is archived to `out/`, the receipt moves with it.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,13 +4,13 @@ Common issues and how to resolve them.
 
 ## "My plan is stuck"
 
-Ralphai aborts when it detects 3 consecutive turns with no new commits (configurable via `maxStuck`). The plan stays in `pipeline/in-progress/` so you can resume after fixing the issue.
+Ralphai aborts when it detects 3 consecutive turns with no new commits (configurable via `maxStuck`). The plan stays in `pipeline/in-progress/<slug>/` so you can resume after fixing the issue.
 
 **Steps:**
 
 1. Check `.ralphai/LEARNINGS.md` for repeated errors — if the agent logged the same mistake multiple times, the plan likely needs adjustment.
-2. Open the progress file in `pipeline/in-progress/progress-<slug>.md` to see what the agent attempted and where it got stuck.
-3. Edit the plan file in `pipeline/in-progress/<slug>.md` — simplify the stuck task, add hints, or break it into smaller steps.
+2. Open the progress file in `pipeline/in-progress/<slug>/progress.md` to see what the agent attempted and where it got stuck.
+3. Edit the plan file in `pipeline/in-progress/<slug>/<slug>.md` — simplify the stuck task, add hints, or break it into smaller steps.
 4. Resume: `ralphai run --resume`
 
 The `--resume` flag auto-commits any dirty working tree state and continues from where the agent left off, preserving the existing progress file.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -40,7 +40,7 @@ Runs a single turn to verify the agent understands the plan before committing to
 ## Resume after editing a stuck plan
 
 ```bash
-# Edit the plan or progress file in .ralphai/pipeline/in-progress/
+# Edit the plan or progress file in .ralphai/pipeline/in-progress/<slug>/
 ralphai run
 ```
 

--- a/runner/lib/defaults.sh
+++ b/runner/lib/defaults.sh
@@ -38,8 +38,9 @@ MAX_LEARNINGS="$DEFAULT_MAX_LEARNINGS"
 WIP_DIR=".ralphai/pipeline/in-progress"
 BACKLOG_DIR=".ralphai/pipeline/backlog"
 ARCHIVE_DIR=".ralphai/pipeline/out"
+PARKED_DIR=".ralphai/pipeline/parked"
 CONFIG_FILE="ralphai.json"
-PROGRESS_FILE="$WIP_DIR/progress.md"
+PROGRESS_FILE="$WIP_DIR/<slug>/progress.md"
 
 # --- Worktree detection ---
 RALPHAI_IS_WORKTREE=false
@@ -72,8 +73,9 @@ if [[ "$RALPHAI_IS_WORKTREE" == true ]]; then
     WIP_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/in-progress"
     BACKLOG_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/backlog"
     ARCHIVE_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/out"
+    PARKED_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/parked"
     CONFIG_FILE="$RALPHAI_MAIN_WORKTREE/ralphai.json"
-    PROGRESS_FILE="$WIP_DIR/progress.md"
+    PROGRESS_FILE="$WIP_DIR/<slug>/progress.md"
   fi
 fi
 

--- a/runner/lib/issues.sh
+++ b/runner/lib/issues.sh
@@ -68,9 +68,11 @@ pull_github_issues() {
 
   slug=$(slugify "$title")
   filename="gh-${number}-${slug}.md"
+  local plan_dir="$BACKLOG_DIR/${filename%.md}"
 
   # Write plan file with frontmatter
-  cat > "$BACKLOG_DIR/$filename" <<PLAN_EOF
+  mkdir -p "$plan_dir"
+  cat > "$plan_dir/$filename" <<PLAN_EOF
 ---
 source: github
 issue: ${number}

--- a/runner/lib/plans.sh
+++ b/runner/lib/plans.sh
@@ -84,18 +84,15 @@ extract_depends_on() {
 dependency_status() {
   local dep_base
   dep_base=$(basename "$1")
+  local dep_slug
+  dep_slug="${dep_base%.md}"
 
-  if [[ -f "$ARCHIVE_DIR/$dep_base" ]]; then
+  if [[ -d "$ARCHIVE_DIR/$dep_slug" ]]; then
     echo "done"
     return 0
   fi
 
-  if compgen -G "$ARCHIVE_DIR/${dep_base%.md}-*.md" >/dev/null; then
-    echo "done"
-    return 0
-  fi
-
-  if [[ -f "$WIP_DIR/$dep_base" || -f "$BACKLOG_DIR/$dep_base" ]]; then
+  if [[ -d "$WIP_DIR/$dep_slug" || -d "$BACKLOG_DIR/$dep_slug" ]]; then
     echo "pending"
     return 0
   fi
@@ -144,6 +141,19 @@ plan_readiness() {
   echo "blocked:$joined"
 }
 
+# --- Resolve plan file path inside a plan directory ---
+plan_file_for_dir() {
+  local dir="$1"
+  local slug
+  slug=$(basename "$dir")
+  local candidate="$dir/${slug}.md"
+  if [[ -f "$candidate" ]]; then
+    echo "$candidate"
+    return 0
+  fi
+  return 1
+}
+
 # --- Detect plan: find in-progress work or pick from backlog ---
 # Sets: WIP_FILES, FILE_REFS, RESUMING
 detect_plan() {
@@ -152,7 +162,7 @@ detect_plan() {
   RESUMING=false
 
   # Check for in-progress plan files
-  local wip_plans=()
+  local in_progress_plans=()
   if [[ "$RALPHAI_IS_WORKTREE" == true ]]; then
     # In worktree mode, only consider the plan matching this branch.
     # Multiple worktrees share the same .ralphai/ directory via symlink,
@@ -160,26 +170,27 @@ detect_plan() {
     local _branch
     _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
     local _slug="${_branch#ralphai/}"
-    for _f in "$WIP_DIR"/*.md; do
-      [[ -f "$_f" ]] || continue
-      local _base
-      _base=$(basename "$_f")
-      [[ "$_base" == progress-* || "$_base" == receipt-* ]] && continue
-      if [[ "${_base%.md}" == "$_slug" ]]; then
-        wip_plans+=("$_f")
-        break
+    local _dir="$WIP_DIR/$_slug"
+    if [[ -d "$_dir" ]]; then
+      local _plan_file
+      _plan_file=$(plan_file_for_dir "$_dir") || _plan_file=""
+      if [[ -n "$_plan_file" ]]; then
+        in_progress_plans+=("$_plan_file")
       fi
-    done
+    fi
   else
-    for f in "$WIP_DIR"/*.md; do
-      [[ -f "$f" ]] && wip_plans+=("$f")
+    for d in "$WIP_DIR"/*; do
+      [[ -d "$d" ]] || continue
+      local plan_file
+      plan_file=$(plan_file_for_dir "$d") || continue
+      in_progress_plans+=("$plan_file")
     done
   fi
 
-  if [[ ${#wip_plans[@]} -gt 0 ]]; then
+  if [[ ${#in_progress_plans[@]} -gt 0 ]]; then
     # Resume in-progress work
     RESUMING=true
-    WIP_FILES=("${wip_plans[@]}")
+    WIP_FILES=("${in_progress_plans[@]}")
     for f in "${WIP_FILES[@]}"; do
       FILE_REFS="$FILE_REFS $(format_file_ref "$f")"
     done
@@ -189,22 +200,28 @@ detect_plan() {
 
   # Check backlog
   local backlog_plans=()
-  for f in "$BACKLOG_DIR"/*.md; do
-    [[ -f "$f" ]] && backlog_plans+=("$f")
+  for d in "$BACKLOG_DIR"/*; do
+    [[ -d "$d" ]] || continue
+    local plan_file
+    plan_file=$(plan_file_for_dir "$d") || continue
+    backlog_plans+=("$plan_file")
   done
 
   if [[ ${#backlog_plans[@]} -eq 0 ]]; then
     if pull_github_issues; then
       # Re-scan backlog after pulling issue
-      for f in "$BACKLOG_DIR"/*.md; do
-        [[ -f "$f" ]] && backlog_plans+=("$f")
+      for d in "$BACKLOG_DIR"/*; do
+        [[ -d "$d" ]] || continue
+        local plan_file
+        plan_file=$(plan_file_for_dir "$d") || continue
+        backlog_plans+=("$plan_file")
       done
       if [[ ${#backlog_plans[@]} -eq 0 ]]; then
-        echo "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/ — see .ralphai/PLANNING.md"
+        echo "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md"
         return 1
       fi
     else
-      echo "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/ — see .ralphai/PLANNING.md"
+      echo "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md"
       return 1
     fi
   fi
@@ -271,21 +288,30 @@ detect_plan() {
     echo "[dry-run] Would select: $chosen"
     local chosen_base
     chosen_base=$(basename "$chosen")
-    WIP_FILES=("$chosen")
-    FILE_REFS=" $(format_file_ref "$chosen")"
+    local chosen_dir
+    chosen_dir=$(dirname "$chosen")
+    local dest_dir
+    dest_dir="$WIP_DIR/$(basename "$chosen_dir")"
+    local dest_plan
+    dest_plan="$dest_dir/$chosen_base"
+    WIP_FILES=("$dest_plan")
+    FILE_REFS=" $(format_file_ref "$dest_plan")"
     RESUMING=false
-    echo "[dry-run] Would move: $chosen -> $WIP_DIR/$chosen_base"
+    echo "[dry-run] Would move: $chosen_dir -> $dest_dir"
   else
     # Move chosen plan to in-progress
     mkdir -p "$WIP_DIR"
-    local dest_basename
-    dest_basename=$(basename "$chosen")
-    local dest="$WIP_DIR/$dest_basename"
-    mv "$chosen" "$dest"
-    echo "Moved $chosen -> $dest"
+    local chosen_dir
+    chosen_dir=$(dirname "$chosen")
+    local dest_dir
+    dest_dir="$WIP_DIR/$(basename "$chosen_dir")"
+    mv "$chosen_dir" "$dest_dir"
+    echo "Moved $chosen_dir -> $dest_dir"
 
-    WIP_FILES=("$dest")
-    FILE_REFS=" $(format_file_ref "$dest")"
+    local dest_plan
+    dest_plan="$dest_dir/$(basename "$chosen")"
+    WIP_FILES=("$dest_plan")
+    FILE_REFS=" $(format_file_ref "$dest_plan")"
     RESUMING=false
   fi
   return 0

--- a/runner/lib/pr.sh
+++ b/runner/lib/pr.sh
@@ -1,12 +1,15 @@
 # pr.sh — PR lifecycle: archive, create, continuous PR management
 # Sourced by ralphai.sh — do not execute directly.
 
-# --- Archive function: move PRD + progress from in-progress/ to out/ ---
+# --- Archive function: move plan folder from in-progress/ to out/ ---
 # Only called on actual completion (COMPLETE signal).
 archive_run() {
-  local timestamp
-  timestamp=$(date +%Y%m%d-%H%M%S)
   mkdir -p "$ARCHIVE_DIR"
+
+  local plan_dir
+  plan_dir=$(dirname "${WIP_FILES[0]}")
+  local plan_slug
+  plan_slug=$(basename "$plan_dir")
 
   # Read issue frontmatter before files are moved (needed for post-completion hooks)
   for f in "${WIP_FILES[@]}"; do
@@ -17,28 +20,10 @@ archive_run() {
     fi
   done
 
-  # Move progress file
-  if [[ -f "$PROGRESS_FILE" ]]; then
-    mv "$PROGRESS_FILE" "$ARCHIVE_DIR/progress-${PLAN_SLUG}-${timestamp}.md"
-    echo "Archived $PROGRESS_FILE -> $ARCHIVE_DIR/progress-${PLAN_SLUG}-${timestamp}.md"
-  fi
-
-  # Move receipt file
-  if [[ -n "${RECEIPT_FILE:-}" && -f "$RECEIPT_FILE" ]]; then
-    mv "$RECEIPT_FILE" "$ARCHIVE_DIR/receipt-${PLAN_SLUG}-${timestamp}.txt"
-    echo "Archived $RECEIPT_FILE -> $ARCHIVE_DIR/receipt-${PLAN_SLUG}-${timestamp}.txt"
-  fi
-
-  # Move PRD/plan files from in-progress/ to out/
-  for f in "${WIP_FILES[@]}"; do
-    if [[ -f "$f" ]]; then
-      local basename
-      basename=$(basename "$f")
-      local dest="$ARCHIVE_DIR/${basename%.md}-${timestamp}.md"
-      mv "$f" "$dest"
-      echo "Archived $f -> $dest"
-    fi
-  done
+  # Move plan folder from in-progress/ to out/
+  local dest="$ARCHIVE_DIR/$plan_slug"
+  mv "$plan_dir" "$dest"
+  echo "Archived $plan_dir -> $dest"
 
   # Plan files are gitignored (local-only state), so no git operations needed.
   # The mv commands above are the entire archive step.
@@ -88,12 +73,14 @@ create_pr() {
       break
     fi
   done
-  # If plan was already archived, check out/ for the timestamped copy
+  # If plan was already archived, check out/ for the plan file copy
   if [[ -z "$plan_content" ]]; then
-    local latest_archived
-    latest_archived=$(ls -t "$ARCHIVE_DIR"/*.md 2>/dev/null | head -1)
-    if [[ -n "$latest_archived" ]]; then
-      plan_content=$(cat "$latest_archived")
+    local plan_slug
+    plan_slug=$(basename "$(dirname "${WIP_FILES[0]}")")
+    local archived_plan
+    archived_plan="$ARCHIVE_DIR/$plan_slug/$(basename "${WIP_FILES[0]}")"
+    if [[ -f "$archived_plan" ]]; then
+      plan_content=$(cat "$archived_plan")
     fi
   fi
 
@@ -152,8 +139,11 @@ build_continuous_pr_body() {
 
   # Remaining plans section (scan backlog)
   local remaining=()
-  for f in "$BACKLOG_DIR"/*.md; do
-    [[ -f "$f" ]] && remaining+=("$(basename "$f")")
+  for d in "$BACKLOG_DIR"/*; do
+    [[ -d "$d" ]] || continue
+    local plan_file
+    plan_file=$(plan_file_for_dir "$d") || continue
+    remaining+=("$(basename "$plan_file")")
   done
 
   body+=$'\n'"## Remaining Plans"$'\n\n'
@@ -261,4 +251,3 @@ finalize_continuous_pr() {
 
   echo "PR ready for review: $CONTINUOUS_PR_URL"
 }
-

--- a/runner/lib/receipt.sh
+++ b/runner/lib/receipt.sh
@@ -7,7 +7,7 @@
 # plan being resumed by `ralphai run` in the main repo) and to provide
 # status information.
 #
-# Receipt files live at: .ralphai/pipeline/in-progress/receipt-<slug>.txt
+# Receipt files live at: .ralphai/pipeline/in-progress/<slug>/receipt.txt
 # Format: key=value (one per line, no quoting needed).
 #
 # Fields:
@@ -15,7 +15,7 @@
 #   source           — "main" or "worktree"
 #   worktree_path    — absolute path to worktree (only when source=worktree)
 #   branch           — git branch name
-#   slug             — plan slug (derived from filename: basename minus .md)
+#   slug             — plan slug (derived from plan folder name)
 #   plan_file        — exact plan filename (basename, e.g. "dark-mode.md")
 #   turns_budget     — total turn budget for the run (resolved $TURNS; 0 = unlimited)
 #   turns_completed  — number of agent turns completed
@@ -28,16 +28,11 @@ resolve_receipt_path() {
   local plan_basename
   plan_basename=$(basename "${WIP_FILES[0]}")
   PLAN_BASENAME="$plan_basename"
-  PLAN_SLUG="${plan_basename%.md}"
-  RECEIPT_FILE="$WIP_DIR/receipt-${PLAN_SLUG}.txt"
-  PROGRESS_FILE="$WIP_DIR/progress-${PLAN_SLUG}.md"
-
-  # Backward-compat: migrate legacy progress.md → progress-<slug>.md
-  # when there is exactly one plan in-progress and the old file exists.
-  if [[ ! -f "$PROGRESS_FILE" && -f "$WIP_DIR/progress.md" ]]; then
-    mv "$WIP_DIR/progress.md" "$PROGRESS_FILE"
-    echo "Migrated progress.md -> $(basename "$PROGRESS_FILE")"
-  fi
+  local plan_dir
+  plan_dir=$(dirname "${WIP_FILES[0]}")
+  PLAN_SLUG=$(basename "$plan_dir")
+  RECEIPT_FILE="$plan_dir/receipt.txt"
+  PROGRESS_FILE="$plan_dir/progress.md"
 }
 
 # --- Write a new receipt file ---

--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -5,8 +5,8 @@
 # Usage: ralphai run [--turns=<n>] [--dry-run] [--resume] [--agent-command=<cmd>] [--feedback-commands=<list>] [--base-branch=<branch>] [--branch] [--pr] [--patch] [--max-stuck=<n>] [--show-config] [--help]
 #
 # Auto-detects what to work on:
-#   1. If .ralphai/pipeline/in-progress/ has plan files → resume on the current ralphai/* branch
-#   2. Otherwise, pick the best plan from .ralphai/pipeline/backlog/ (LLM-selected if multiple)
+#   1. If .ralphai/pipeline/in-progress/ has plan folders → resume on the current ralphai/* branch
+#   2. Otherwise, pick the best plan from .ralphai/pipeline/backlog/
 #
 # On completion (branch mode, the default): creates an isolated ralphai/<slug>
 # branch, commits changes, but does not push or create a PR.
@@ -56,12 +56,14 @@ if [[ "$MODE" == "patch" ]]; then
     echo "  ralphai run --pr"
     # Peek at backlog to suggest a branch name
     _first_plan=""
-    for _f in "$BACKLOG_DIR"/*.md; do
-      [[ -f "$_f" ]] && _first_plan="$_f" && break
-    done
-    if [[ -n "$_first_plan" ]]; then
-      _slug=$(basename "$_first_plan")
-      _slug="${_slug%.md}"
+  for _d in "$BACKLOG_DIR"/*; do
+    [[ -d "$_d" ]] || continue
+    _plan_file=$(plan_file_for_dir "$_d") || continue
+    _first_plan="$_plan_file"
+    break
+  done
+  if [[ -n "$_first_plan" ]]; then
+    _slug=$(basename "$(dirname "$_first_plan")")
       echo ""
       if [[ "$RALPHAI_IS_WORKTREE" == true ]]; then
         echo "Or create a worktree on a feature branch:"
@@ -99,6 +101,8 @@ if [[ "$DRY_RUN" == true ]]; then
     exit 0
   fi
 
+  resolve_receipt_path
+
   PLAN_DESC=$(plan_description "${WIP_FILES[0]}")
   echo "[dry-run] Plan: $(basename "${WIP_FILES[0]}")"
   echo "[dry-run] Description: $PLAN_DESC"
@@ -120,7 +124,7 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "[dry-run] Would initialize: $PROGRESS_FILE"
   elif [[ "$MODE" == "branch" ]]; then
     plan_basename=$(basename "${WIP_FILES[0]}")
-    slug="${plan_basename%.md}"
+    slug=$(basename "$(dirname "${WIP_FILES[0]}")")
     branch="ralphai/${slug}"
     if git show-ref --verify --quiet "refs/heads/ralphai"; then
       echo "[dry-run] WARNING: Branch 'ralphai' exists and would block creation of '$branch'."
@@ -135,7 +139,7 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "[dry-run] Would initialize: $PROGRESS_FILE"
   else
     plan_basename=$(basename "${WIP_FILES[0]}")
-    slug="${plan_basename%.md}"
+    slug=$(basename "$(dirname "${WIP_FILES[0]}")")
     branch="ralphai/${slug}"
     if git show-ref --verify --quiet "refs/heads/ralphai"; then
       echo "[dry-run] WARNING: Branch 'ralphai' exists and would block creation of '$branch'."
@@ -198,7 +202,7 @@ while true; do
     echo "Patch mode: working on current branch '$branch' (changes will be left uncommitted)"
 
     # Initialize progress file
-    mkdir -p "$WIP_DIR"
+    mkdir -p "$(dirname "$PROGRESS_FILE")"
     echo "## Progress Log" > "$PROGRESS_FILE"
     echo "" >> "$PROGRESS_FILE"
     echo "Initialized $PROGRESS_FILE"
@@ -209,7 +213,7 @@ while true; do
     echo "Continuous mode: continuing on branch '$branch'"
 
     # Re-initialize progress file for the new plan
-    mkdir -p "$WIP_DIR"
+    mkdir -p "$(dirname "$PROGRESS_FILE")"
     echo "## Progress Log" > "$PROGRESS_FILE"
     echo "" >> "$PROGRESS_FILE"
     echo "Initialized $PROGRESS_FILE"
@@ -223,18 +227,18 @@ while true; do
     if [[ "$branch" == "$BASE_BRANCH" ]]; then
       echo "ERROR: Running in a worktree on the base branch '$BASE_BRANCH'."
       echo "Create a worktree on a feature branch instead:"
-      slug="${plan_basename%.md}"
+      slug=$(basename "$(dirname "${WIP_FILES[0]}")")
       echo "  git worktree add ../<dir> -b ralphai/${slug} $BASE_BRANCH"
       # Roll back plan
-      rollback_dest="$BACKLOG_DIR/${plan_basename}"
-      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rollback_dest="$BACKLOG_DIR/${slug}"
+      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
       echo "Rolled back: moved plan to $rollback_dest"
       exit 1
     fi
     echo "Worktree mode: working on existing branch '$branch' (no checkout)"
 
     # Initialize progress file
-    mkdir -p "$WIP_DIR"
+    mkdir -p "$(dirname "$PROGRESS_FILE")"
     echo "## Progress Log" > "$PROGRESS_FILE"
     echo "" >> "$PROGRESS_FILE"
     echo "Initialized $PROGRESS_FILE"
@@ -242,7 +246,7 @@ while true; do
   else
     git checkout "$BASE_BRANCH"
     plan_basename=$(basename "${WIP_FILES[0]}")
-    slug="${plan_basename%.md}"
+    slug=$(basename "$(dirname "${WIP_FILES[0]}")")
     branch="ralphai/${slug}"
 
     # Guard: a bare "ralphai" branch blocks all "ralphai/*" branches (git ref hierarchy conflict)
@@ -255,8 +259,8 @@ while true; do
       echo "  git branch -m ralphai ralphai-legacy   # rename"
       echo "  git branch -D ralphai                # or delete"
       # Roll back: move plan file back to backlog
-      rollback_dest="$BACKLOG_DIR/${plan_basename}"
-      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rollback_dest="$BACKLOG_DIR/${slug}"
+      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
       echo ""
       echo "Rolled back: moved plan to $rollback_dest"
       exit 1
@@ -268,8 +272,8 @@ while true; do
       echo "SKIP: $COLLISION_REASON"
       echo "Plan '$plan_basename' already has open work. Skipping to next plan."
       # Roll back: move plan file back to backlog
-      rollback_dest="$BACKLOG_DIR/${plan_basename}"
-      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rollback_dest="$BACKLOG_DIR/${slug}"
+      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
       echo "Rolled back: moved plan to $rollback_dest"
       SKIPPED_PLANS["$plan_basename"]=1
       continue
@@ -278,8 +282,8 @@ while true; do
       echo ""
       echo "ERROR: Failed to create branch '$branch'."
       # Roll back: move plan file back to backlog
-      rollback_dest="$BACKLOG_DIR/${plan_basename}"
-      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rollback_dest="$BACKLOG_DIR/${slug}"
+      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
       echo "Rolled back: moved plan to $rollback_dest"
       exit 1
     fi
@@ -291,7 +295,7 @@ while true; do
     fi
 
     # Initialize progress file
-    mkdir -p "$WIP_DIR"
+    mkdir -p "$(dirname "$PROGRESS_FILE")"
     echo "## Progress Log" > "$PROGRESS_FILE"
     echo "" >> "$PROGRESS_FILE"
     echo "Initialized $PROGRESS_FILE"

--- a/src/init-agents-md.test.ts
+++ b/src/init-agents-md.test.ts
@@ -107,7 +107,7 @@ describe("init AGENTS.md integration", () => {
       "This project uses [Ralphai](https://github.com/mfaux/ralphai) for autonomous task execution.",
     );
     expect(agentsMd).toContain(
-      "Plan files go in `.ralphai/pipeline/backlog/`.",
+      "Plan files go in per-plan folders under `.ralphai/pipeline/backlog/`.",
     );
     expect(agentsMd).toContain(
       "See `.ralphai/PLANNING.md` for\nthe plan writing guide.",

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -37,7 +37,9 @@ describe("init command", () => {
     expect(existsSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"))).toBe(
       true,
     );
-    expect(existsSync(join(ctx.dir, ".ralphai", "pipeline", "wip"))).toBe(true);
+    expect(existsSync(join(ctx.dir, ".ralphai", "pipeline", "parked"))).toBe(
+      true,
+    );
     expect(
       existsSync(join(ctx.dir, ".ralphai", "pipeline", "in-progress")),
     ).toBe(true);
@@ -262,10 +264,10 @@ describe("init command", () => {
     const plans = readFileSync(join(templateLib, "plans.sh"), "utf-8");
     // Both "nothing to do" messages should include the hint
     expect(plans).toContain(
-      "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/ — see .ralphai/PLANNING.md",
+      "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md",
     );
     expect(plans).toContain(
-      "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/ — see .ralphai/PLANNING.md",
+      "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md",
     );
   });
 
@@ -457,6 +459,7 @@ describe("init command", () => {
       ".ralphai",
       "pipeline",
       "backlog",
+      "hello-ralphai",
       "hello-ralphai.md",
     );
     expect(existsSync(samplePlanPath)).toBe(true);
@@ -466,7 +469,14 @@ describe("init command", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const samplePlan = readFileSync(
-      join(ctx.dir, ".ralphai", "pipeline", "backlog", "hello-ralphai.md"),
+      join(
+        ctx.dir,
+        ".ralphai",
+        "pipeline",
+        "backlog",
+        "hello-ralphai",
+        "hello-ralphai.md",
+      ),
       "utf-8",
     );
 
@@ -497,6 +507,7 @@ describe("init command", () => {
       ".ralphai",
       "pipeline",
       "backlog",
+      "hello-ralphai",
       "hello-ralphai.md",
     );
 
@@ -582,20 +593,21 @@ describe("init command", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     // Add a plan file
-    writeFileSync(
-      join(ctx.dir, ".ralphai", "pipeline", "backlog", "old-plan.md"),
-      "# Old plan",
+    const planDir = join(
+      ctx.dir,
+      ".ralphai",
+      "pipeline",
+      "backlog",
+      "old-plan",
     );
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "old-plan.md"), "# Old plan");
 
     // Force re-scaffold
     runCliOutput(["init", "--force", "--yes"], ctx.dir);
 
     // Plan file should be gone (directory was deleted and recreated)
-    expect(
-      existsSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "old-plan.md"),
-      ),
-    ).toBe(false);
+    expect(existsSync(join(planDir, "old-plan.md"))).toBe(false);
     expect(existsSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"))).toBe(
       true,
     );

--- a/src/purge.test.ts
+++ b/src/purge.test.ts
@@ -15,19 +15,11 @@ describe("purge command", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
-    mkdirSync(outDir, { recursive: true });
-    writeFileSync(
-      join(outDir, "my-feature-20260101-120000.md"),
-      "# My Feature",
-    );
-    writeFileSync(
-      join(outDir, "progress-my-feature-20260101-120000.md"),
-      "## Progress",
-    );
-    writeFileSync(
-      join(outDir, "receipt-my-feature-20260101-120000.txt"),
-      "slug=my-feature",
-    );
+    const planDir = join(outDir, "my-feature");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "my-feature.md"), "# My Feature");
+    writeFileSync(join(planDir, "progress.md"), "## Progress");
+    writeFileSync(join(planDir, "receipt.txt"), "slug=my-feature");
 
     const output = stripLogo(runCliOutput(["purge", "--yes"], ctx.dir));
 
@@ -58,21 +50,15 @@ describe("purge command", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
-    mkdirSync(outDir, { recursive: true });
-    writeFileSync(join(outDir, "feat-a-20260101-120000.md"), "# A");
-    writeFileSync(join(outDir, "feat-b-20260102-120000.md"), "# B");
-    writeFileSync(
-      join(outDir, "progress-feat-a-20260101-120000.md"),
-      "## Progress",
-    );
-    writeFileSync(
-      join(outDir, "receipt-feat-a-20260101-120000.txt"),
-      "slug=feat-a",
-    );
-    writeFileSync(
-      join(outDir, "receipt-feat-b-20260102-120000.txt"),
-      "slug=feat-b",
-    );
+    const planDirA = join(outDir, "feat-a");
+    const planDirB = join(outDir, "feat-b");
+    mkdirSync(planDirA, { recursive: true });
+    mkdirSync(planDirB, { recursive: true });
+    writeFileSync(join(planDirA, "feat-a.md"), "# A");
+    writeFileSync(join(planDirB, "feat-b.md"), "# B");
+    writeFileSync(join(planDirA, "progress.md"), "## Progress");
+    writeFileSync(join(planDirA, "receipt.txt"), "slug=feat-a");
+    writeFileSync(join(planDirB, "receipt.txt"), "slug=feat-b");
 
     const output = stripLogo(runCliOutput(["purge", "--yes"], ctx.dir));
 
@@ -109,8 +95,9 @@ describe("purge command", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
-    mkdirSync(outDir, { recursive: true });
-    writeFileSync(join(outDir, "plan-20260101-120000.md"), "# Plan");
+    const planDir = join(outDir, "plan");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "plan.md"), "# Plan");
 
     runCliOutput(["purge", "--yes"], ctx.dir);
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -752,19 +752,21 @@ function scaffold(
   writeFileSync(join(cwd, "ralphai.json"), config);
 
   // Create pipeline subdirectories (no .gitkeep — .ralphai/ is fully gitignored)
-  for (const subdir of ["backlog", "wip", "in-progress", "out"]) {
+  for (const subdir of ["backlog", "parked", "in-progress", "out"]) {
     mkdirSync(join(ralphaiDir, "pipeline", subdir), { recursive: true });
   }
 
   // Write sample plan if requested
-  const samplePlanPath = join(
+  const samplePlanDir = join(
     ralphaiDir,
     "pipeline",
     "backlog",
-    "hello-ralphai.md",
+    "hello-ralphai",
   );
+  const samplePlanPath = join(samplePlanDir, "hello-ralphai.md");
   const samplePlanCreated = answers.createSamplePlan === true;
   if (samplePlanCreated && !existsSync(samplePlanPath)) {
+    mkdirSync(samplePlanDir, { recursive: true });
     const samplePlanContent = `# Plan: Hello Ralphai
 
 > A tiny first plan to verify the full Ralphai loop — init, run, commit.
@@ -824,7 +826,7 @@ Each entry should include:
   const agentsMdSection = `## Ralphai
 
 This project uses [Ralphai](https://github.com/mfaux/ralphai) for autonomous task execution.
-Plan files go in \`.ralphai/pipeline/backlog/\`. See \`.ralphai/PLANNING.md\` for
+Plan files go in per-plan folders under \`.ralphai/pipeline/backlog/\`. See \`.ralphai/PLANNING.md\` for
 the plan writing guide.
 `;
 
@@ -915,7 +917,7 @@ Project-specific guidance for AI coding agents working in this codebase.
     );
   }
   console.log(
-    `  .ralphai/pipeline/wip/     ${DIM}Park unready plans here${RESET}`,
+    `  .ralphai/pipeline/parked/  ${DIM}Park unready plans here${RESET}`,
   );
   if (labelResult) {
     if (labelResult.success) {
@@ -986,17 +988,8 @@ async function runRalphaiReset(
     return;
   }
 
-  const files = readdirSync(inProgressDir);
-  const planFiles = files.filter(
-    (f) =>
-      f.endsWith(".md") && f !== "progress.md" && !f.startsWith("progress-"),
-  );
-  const progressFiles = files.filter(
-    (f) => f === "progress.md" || f.startsWith("progress-"),
-  );
-  const receiptFiles = files.filter(
-    (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
-  );
+  const planSlugs = listPlanFolders(inProgressDir);
+  const planFiles = planSlugs.map((slug) => `${slug}.md`);
 
   // Check for worktrees to clean
   let worktrees: WorktreeEntry[] = [];
@@ -1006,12 +999,7 @@ async function runRalphaiReset(
     // Not in a git repo or git not available
   }
 
-  if (
-    planFiles.length === 0 &&
-    progressFiles.length === 0 &&
-    receiptFiles.length === 0 &&
-    worktrees.length === 0
-  ) {
+  if (planFiles.length === 0 && worktrees.length === 0) {
     console.log("Nothing to reset — pipeline is already clean.");
     return;
   }
@@ -1028,14 +1016,9 @@ async function runRalphaiReset(
       console.log(`    ${DIM}${f}${RESET}`);
     }
   }
-  if (progressFiles.length > 0) {
+  if (planFiles.length > 0) {
     console.log(
-      `  ${TEXT}Progress${RESET}    ${DIM}${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""} will be deleted${RESET}`,
-    );
-  }
-  if (receiptFiles.length > 0) {
-    console.log(
-      `  ${TEXT}Receipts${RESET}    ${DIM}${receiptFiles.length} receipt${receiptFiles.length !== 1 ? "s" : ""} will be deleted${RESET}`,
+      `  ${TEXT}Artifacts${RESET}   ${DIM}progress.md + receipt.txt removed per plan${RESET}`,
     );
   }
   if (worktrees.length > 0) {
@@ -1064,24 +1047,14 @@ async function runRalphaiReset(
 
   let actions = 0;
 
-  // 1. Move plan files back to backlog
-  for (const planFile of planFiles) {
-    const src = join(inProgressDir, planFile);
-    const dest = join(backlogDir, planFile);
+  // 1. Move plan folders back to backlog (remove progress/receipt first)
+  for (const slug of planSlugs) {
+    const src = join(inProgressDir, slug);
+    const dest = join(backlogDir, slug);
     mkdirSync(backlogDir, { recursive: true });
+    rmSync(join(src, "progress.md"), { force: true });
+    rmSync(join(src, "receipt.txt"), { force: true });
     renameSync(src, dest);
-    actions++;
-  }
-
-  // 2. Delete progress file(s)
-  for (const pf of progressFiles) {
-    rmSync(join(inProgressDir, pf), { force: true });
-    actions++;
-  }
-
-  // 3. Delete receipt files
-  for (const receiptFile of receiptFiles) {
-    rmSync(join(inProgressDir, receiptFile), { force: true });
     actions++;
   }
 
@@ -1131,14 +1104,9 @@ async function runRalphaiReset(
       `  ${planFiles.length} plan${planFiles.length !== 1 ? "s" : ""} moved to backlog`,
     );
   }
-  if (progressFiles.length > 0) {
+  if (planFiles.length > 0) {
     console.log(
-      `  Deleted ${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""}`,
-    );
-  }
-  if (receiptFiles.length > 0) {
-    console.log(
-      `  Deleted ${receiptFiles.length} receipt${receiptFiles.length !== 1 ? "s" : ""}`,
+      `  Deleted progress.md and receipt.txt in ${planFiles.length} plan${planFiles.length !== 1 ? "s" : ""}`,
     );
   }
   if (worktrees.length > 0) {
@@ -1172,21 +1140,23 @@ async function runRalphaiPurge(
     return;
   }
 
-  const files = readdirSync(outDir);
-  if (files.length === 0) {
+  const entries = readdirSync(outDir, { withFileTypes: true });
+  const planDirs = entries.filter((entry) => entry.isDirectory());
+  if (planDirs.length === 0) {
     console.log("Nothing to purge — out/ is already empty.");
     return;
   }
 
-  const planFiles = files.filter(
-    (f) => f.endsWith(".md") && !f.startsWith("progress-"),
-  );
-  const progressFiles = files.filter(
-    (f) => f.endsWith(".md") && f.startsWith("progress-"),
-  );
-  const receiptFiles = files.filter(
-    (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
-  );
+  const planFiles = planDirs.filter((entry) => {
+    const planPath = planPathForSlug(outDir, entry.name);
+    return existsSync(planPath);
+  }).length;
+  const progressFiles = planDirs.filter((entry) =>
+    existsSync(join(outDir, entry.name, "progress.md")),
+  ).length;
+  const receiptFiles = planDirs.filter((entry) =>
+    existsSync(join(outDir, entry.name, "receipt.txt")),
+  ).length;
 
   // Show what will be deleted
   console.log();
@@ -1194,19 +1164,19 @@ async function runRalphaiPurge(
     `${TEXT}The following archived artifacts will be deleted:${RESET}`,
   );
   console.log();
-  if (planFiles.length > 0) {
+  if (planFiles > 0) {
     console.log(
-      `  ${TEXT}Plans${RESET}       ${DIM}${planFiles.length} archived plan${planFiles.length !== 1 ? "s" : ""}${RESET}`,
+      `  ${TEXT}Plans${RESET}       ${DIM}${planFiles} archived plan${planFiles !== 1 ? "s" : ""}${RESET}`,
     );
   }
-  if (progressFiles.length > 0) {
+  if (progressFiles > 0) {
     console.log(
-      `  ${TEXT}Progress${RESET}    ${DIM}${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""}${RESET}`,
+      `  ${TEXT}Progress${RESET}    ${DIM}${progressFiles} progress file${progressFiles !== 1 ? "s" : ""}${RESET}`,
     );
   }
-  if (receiptFiles.length > 0) {
+  if (receiptFiles > 0) {
     console.log(
-      `  ${TEXT}Receipts${RESET}    ${DIM}${receiptFiles.length} receipt${receiptFiles.length !== 1 ? "s" : ""}${RESET}`,
+      `  ${TEXT}Receipts${RESET}    ${DIM}${receiptFiles} receipt${receiptFiles !== 1 ? "s" : ""}${RESET}`,
     );
   }
   console.log();
@@ -1225,29 +1195,25 @@ async function runRalphaiPurge(
     }
   }
 
-  // Delete all files in out/
-  for (const file of files) {
-    rmSync(join(outDir, file), { force: true });
+  // Delete all plan folders in out/
+  for (const planDir of planDirs) {
+    rmSync(join(outDir, planDir.name), { recursive: true, force: true });
   }
 
   // Summary
   console.log(`${TEXT}Purged.${RESET}`);
   console.log();
   console.log(`${DIM}Deleted:${RESET}`);
-  if (planFiles.length > 0) {
+  if (planFiles > 0) {
+    console.log(`  ${planFiles} archived plan${planFiles !== 1 ? "s" : ""}`);
+  }
+  if (progressFiles > 0) {
     console.log(
-      `  ${planFiles.length} archived plan${planFiles.length !== 1 ? "s" : ""}`,
+      `  ${progressFiles} progress file${progressFiles !== 1 ? "s" : ""}`,
     );
   }
-  if (progressFiles.length > 0) {
-    console.log(
-      `  ${progressFiles.length} progress file${progressFiles.length !== 1 ? "s" : ""}`,
-    );
-  }
-  if (receiptFiles.length > 0) {
-    console.log(
-      `  ${receiptFiles.length} receipt${receiptFiles.length !== 1 ? "s" : ""}`,
-    );
+  if (receiptFiles > 0) {
+    console.log(`  ${receiptFiles} receipt${receiptFiles !== 1 ? "s" : ""}`);
   }
   console.log();
 }
@@ -1638,11 +1604,10 @@ function checkReceiptSource(ralphaiDir: string, isWorktree: boolean): boolean {
   const inProgressDir = join(ralphaiDir, "pipeline", "in-progress");
   if (!existsSync(inProgressDir)) return true;
 
-  const receiptFiles = readdirSync(inProgressDir).filter(
-    (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
-  );
-  for (const receiptFile of receiptFiles) {
-    const receipt = parseReceipt(join(inProgressDir, receiptFile));
+  const planSlugs = listPlanFolders(inProgressDir);
+  for (const slug of planSlugs) {
+    const receiptPath = join(inProgressDir, slug, "receipt.txt");
+    const receipt = parseReceipt(receiptPath);
     if (!receipt) continue;
 
     if (receipt.source === "worktree" && !isWorktree) {
@@ -1729,19 +1694,25 @@ function selectPlanForWorktree(
     activeWorktrees.map((wt) => wt.branch.replace("ralphai/", "")),
   );
 
+  const resolvePlanInDir = (
+    baseDir: string,
+    planFile: string,
+  ): string | null => {
+    const slug = planFile.replace(/\.md$/, "");
+    const candidate = planPathForSlug(baseDir, slug);
+    return existsSync(candidate) ? candidate : null;
+  };
+
   // --- Specific plan requested ---
   if (specificPlan) {
-    const inProgressPath = join(inProgressDir, specificPlan);
-    if (existsSync(inProgressPath)) {
-      const slug = specificPlan.replace(/\.md$/, "");
+    const slug = specificPlan.replace(/\.md$/, "");
+    const inProgressPath = resolvePlanInDir(inProgressDir, specificPlan);
+    if (inProgressPath) {
       return { planFile: specificPlan, slug, source: "in-progress" };
     }
-    if (existsSync(backlogDir)) {
-      const planPath = join(backlogDir, specificPlan);
-      if (existsSync(planPath)) {
-        const slug = specificPlan.replace(/\.md$/, "");
-        return { planFile: specificPlan, slug, source: "backlog" };
-      }
+    const backlogPath = resolvePlanInDir(backlogDir, specificPlan);
+    if (backlogPath) {
+      return { planFile: specificPlan, slug, source: "backlog" };
     }
     console.error(
       `Plan '${specificPlan}' not found in backlog or in-progress.`,
@@ -1751,15 +1722,7 @@ function selectPlanForWorktree(
 
   // --- Auto-detect plan ---
 
-  // Filter in-progress plans: .md files excluding progress/receipt files
-  const inProgressPlans = existsSync(inProgressDir)
-    ? readdirSync(inProgressDir).filter(
-        (f) =>
-          f.endsWith(".md") &&
-          !f.startsWith("progress-") &&
-          !f.startsWith("receipt-"),
-      )
-    : [];
+  const inProgressPlans = listPlanFiles(inProgressDir);
 
   // Plans without an active worktree are "unattended" — resume first
   const unattendedPlans = inProgressPlans.filter(
@@ -1783,9 +1746,7 @@ function selectPlanForWorktree(
   }
 
   // No unattended plans — check backlog for new work
-  const backlogPlans = existsSync(backlogDir)
-    ? readdirSync(backlogDir).filter((f) => f.endsWith(".md"))
-    : [];
+  const backlogPlans = listPlanFiles(backlogDir);
 
   if (backlogPlans.length > 0) {
     const firstPlan = backlogPlans[0]!;
@@ -1945,22 +1906,35 @@ function showWorktreeHelp(): void {
 }
 
 /**
- * Check if any plan file in `dir` has a slug (filename minus `.md`) matching
- * the given slug. Skips progress-* and receipt-* files.
+ * Check if a plan directory in `dir` matches the given slug.
  */
-function planExistsForSlug(dir: string, slug: string): boolean {
-  if (!existsSync(dir)) return false;
+function listPlanFolders(dir: string): string[] {
+  if (!existsSync(dir)) return [];
   try {
-    return readdirSync(dir).some(
-      (f) =>
-        f.endsWith(".md") &&
-        !f.startsWith("progress-") &&
-        !f.startsWith("receipt-") &&
-        f.replace(/\.md$/, "") === slug,
-    );
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
   } catch {
-    return false;
+    return [];
   }
+}
+
+function planPathForSlug(dir: string, slug: string): string {
+  return join(dir, slug, `${slug}.md`);
+}
+
+function listPlanSlugs(dir: string): string[] {
+  return listPlanFolders(dir).filter((slug) =>
+    existsSync(planPathForSlug(dir, slug)),
+  );
+}
+
+function listPlanFiles(dir: string): string[] {
+  return listPlanSlugs(dir).map((slug) => `${slug}.md`);
+}
+
+function planExistsForSlug(dir: string, slug: string): boolean {
+  return existsSync(planPathForSlug(dir, slug));
 }
 
 function listWorktrees(cwd: string): void {
@@ -2024,16 +1998,14 @@ function cleanWorktrees(cwd: string): void {
         }
 
         // Archive receipt if one exists for this slug
-        const receiptFile = join(inProgressDir, `receipt-${slug}.txt`);
+        const planDir = join(inProgressDir, slug);
+        const receiptFile = join(planDir, "receipt.txt");
         if (existsSync(receiptFile)) {
-          mkdirSync(archiveDir, { recursive: true });
-          const timestamp = new Date()
-            .toISOString()
-            .replace(/[T:]/g, "-")
-            .replace(/\.\d+Z$/, "");
-          const dest = join(archiveDir, `receipt-${slug}-${timestamp}.txt`);
+          const destDir = join(archiveDir, slug);
+          mkdirSync(destDir, { recursive: true });
+          const dest = join(destDir, "receipt.txt");
           renameSync(receiptFile, dest);
-          console.log(`  Archived receipt: receipt-${slug}.txt`);
+          console.log(`  Archived receipt: ${slug}/receipt.txt`);
         }
 
         cleaned++;
@@ -2223,7 +2195,7 @@ function checkBacklogHasPlans(cwd: string): DoctorCheckResult {
   if (!existsSync(backlogDir)) {
     return { status: "warn", message: "backlog: directory not found" };
   }
-  const plans = readdirSync(backlogDir).filter((f) => f.endsWith(".md"));
+  const plans = listPlanSlugs(backlogDir);
   if (plans.length === 0) {
     return { status: "warn", message: "backlog: no plans queued" };
   }
@@ -2238,18 +2210,14 @@ function checkOrphanedReceipts(cwd: string): DoctorCheckResult {
   if (!existsSync(inProgressDir)) {
     return { status: "pass", message: "no orphaned receipts" };
   }
-  const files = readdirSync(inProgressDir);
-  const receiptFiles = files.filter(
-    (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
-  );
 
   const orphaned: string[] = [];
-  for (const rf of receiptFiles) {
-    const receipt = parseReceipt(join(inProgressDir, rf));
-    if (!receipt) continue;
-    const planFile = receipt.plan_file || `prd-${receipt.slug}.md`;
-    if (!existsSync(join(inProgressDir, planFile))) {
-      orphaned.push(rf);
+  for (const slug of listPlanFolders(inProgressDir)) {
+    const receiptPath = join(inProgressDir, slug, "receipt.txt");
+    if (!existsSync(receiptPath)) continue;
+    const planPath = join(inProgressDir, slug, `${slug}.md`);
+    if (!existsSync(planPath)) {
+      orphaned.push(`${slug}/receipt.txt`);
     }
   }
 
@@ -2422,38 +2390,22 @@ function runRalphaiStatus(cwd: string): void {
   const archiveDir = join(ralphaiDir, "pipeline", "out");
 
   // --- Collect data ---
-  const backlogPlans = existsSync(backlogDir)
-    ? readdirSync(backlogDir).filter((f) => f.endsWith(".md"))
-    : [];
+  const backlogPlans = listPlanFiles(backlogDir);
 
-  const inProgressFiles = existsSync(inProgressDir)
-    ? readdirSync(inProgressDir)
-    : [];
-  const inProgressPlans = inProgressFiles.filter(
-    (f) =>
-      f.endsWith(".md") && f !== "progress.md" && !f.startsWith("progress-"),
-  );
-  const receiptFiles = inProgressFiles.filter(
-    (f) => f.startsWith("receipt-") && f.endsWith(".txt"),
+  const inProgressPlans = listPlanFiles(inProgressDir);
+  const receiptFiles = listPlanFolders(inProgressDir).filter((slug) =>
+    existsSync(join(inProgressDir, slug, "receipt.txt")),
   );
 
-  const completedFiles = existsSync(archiveDir)
-    ? readdirSync(archiveDir).filter((f) => f.endsWith(".md"))
-    : [];
-  // Deduplicate completed plans by removing timestamps
-  const completedSlugs = new Set(
-    completedFiles.map((f) => f.replace(/-\d{8}-\d{6}\.md$/, "")),
-  );
+  const completedSlugs = new Set(listPlanSlugs(archiveDir));
 
   // Build receipt lookup: plan filename → Receipt
   const receiptsByPlan = new Map<string, Receipt>();
-  for (const rf of receiptFiles) {
-    const slug = rf.replace(/^receipt-/, "").replace(/\.txt$/, "");
-    const receipt = parseReceipt(join(inProgressDir, rf));
+  for (const slug of receiptFiles) {
+    const receipt = parseReceipt(join(inProgressDir, slug, "receipt.txt"));
     if (receipt) {
-      // Key by plan_file when present; fall back to prd-<slug>.md for old receipts
-      const key = receipt.plan_file || `prd-${slug}.md`;
-      receiptsByPlan.set(key, receipt);
+      const planFile = receipt.plan_file || `${slug}.md`;
+      receiptsByPlan.set(planFile, receipt);
     }
   }
 
@@ -2468,7 +2420,9 @@ function runRalphaiStatus(cwd: string): void {
   );
   for (const plan of backlogPlans) {
     let suffix = "";
-    const deps = extractDependsOn(join(backlogDir, plan));
+    const deps = extractDependsOn(
+      join(backlogDir, plan.replace(/\.md$/, ""), plan),
+    );
     if (deps.length > 0) {
       suffix = `${DIM}waiting on ${deps.join(", ")}${RESET}`;
     }
@@ -2485,7 +2439,8 @@ function runRalphaiStatus(cwd: string): void {
     const parts: string[] = [];
 
     // Task progress
-    const totalTasks = countPlanTasks(join(inProgressDir, plan));
+    const slug = plan.replace(/\.md$/, "");
+    const totalTasks = countPlanTasks(join(inProgressDir, slug, plan));
     if (totalTasks > 0) {
       const completed = receipt?.tasks_completed ?? 0;
       parts.push(`${completed} of ${totalTasks} tasks`);
@@ -2504,8 +2459,7 @@ function runRalphaiStatus(cwd: string): void {
 
     // Worktree info from receipt
     if (receipt?.source === "worktree") {
-      const planSlug = plan.replace(/\.md$/, "");
-      parts.push(`worktree: ${planSlug}`);
+      parts.push(`worktree: ${slug}`);
     }
 
     // Outcome / status tag
@@ -2556,9 +2510,11 @@ function runRalphaiStatus(cwd: string): void {
 
   // Orphaned receipts: receipt exists but no matching plan file
   for (const [planFile, receipt] of receiptsByPlan) {
-    if (!existsSync(join(inProgressDir, planFile))) {
+    const slug = planFile.replace(/\.md$/, "");
+    const planPath = join(inProgressDir, slug, planFile);
+    if (!existsSync(planPath)) {
       problems.push(
-        `Orphaned receipt: receipt-${receipt.slug}.txt (no matching plan file)`,
+        `Orphaned receipt: ${slug}/receipt.txt (no matching plan file)`,
       );
     }
   }
@@ -2657,7 +2613,8 @@ async function runRalphaiWorktree(
     ".ralphai",
     "pipeline",
     "in-progress",
-    `receipt-${plan.slug}.txt`,
+    plan.slug,
+    "receipt.txt",
   );
   const receipt = parseReceipt(receiptPath);
   if (receipt && receipt.source === "main") {

--- a/src/runner-config.test.ts
+++ b/src/runner-config.test.ts
@@ -201,9 +201,11 @@ ${cleanupFile}
         const result = formatRef({
           promptMode: "auto",
           agentType: "claude",
-          filepath: ".ralphai/pipeline/in-progress/prd-foo.md",
+          filepath: ".ralphai/pipeline/in-progress/prd-foo/prd-foo.md",
         });
-        expect(result).toBe("@.ralphai/pipeline/in-progress/prd-foo.md");
+        expect(result).toBe(
+          "@.ralphai/pipeline/in-progress/prd-foo/prd-foo.md",
+        );
       });
 
       it("auto mode with opencode agent returns @filepath", () => {
@@ -1210,9 +1212,9 @@ echo "$MODE"
     // detect_plan: FILE_REFS uses format_file_ref
     expect(plans).toContain('FILE_REFS="$FILE_REFS $(format_file_ref "$f")"');
     // detect_plan: dry-run chosen
-    expect(plans).toContain('FILE_REFS=" $(format_file_ref "$chosen")"');
+    expect(plans).toContain('FILE_REFS=" $(format_file_ref "$dest_plan")"');
     // detect_plan: normal chosen
-    expect(plans).toContain('FILE_REFS=" $(format_file_ref "$dest")"');
+    expect(plans).toContain('FILE_REFS=" $(format_file_ref "$dest_plan")"');
     // LEARNINGS_REF uses format_file_ref
     expect(prompt).toContain(
       'LEARNINGS_REF=" $(format_file_ref "$RALPHAI_LEARNINGS_FILE")"',
@@ -1386,14 +1388,15 @@ echo "$MODE"
       });
 
       // Remove sample plan so the backlog is empty for this test
-      const samplePlan = join(
+      const samplePlanDir = join(
         ctx.dir,
         ".ralphai",
         "pipeline",
         "backlog",
-        "hello-ralphai.md",
+        "hello-ralphai",
       );
-      if (existsSync(samplePlan)) rmSync(samplePlan);
+      if (existsSync(samplePlanDir))
+        rmSync(samplePlanDir, { recursive: true, force: true });
 
       const output = execFileSync(
         "node",

--- a/src/status-doctor.test.ts
+++ b/src/status-doctor.test.ts
@@ -285,14 +285,15 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     // Remove sample plan to test truly empty pipeline
-    const samplePlan = join(
+    const samplePlanDir = join(
       ctx.dir,
       ".ralphai",
       "pipeline",
       "backlog",
-      "hello-ralphai.md",
+      "hello-ralphai",
     );
-    if (existsSync(samplePlan)) rmSync(samplePlan);
+    if (existsSync(samplePlanDir))
+      rmSync(samplePlanDir, { recursive: true, force: true });
 
     const result = runCli(["status"], ctx.dir);
     const output = result.stdout + result.stderr;
@@ -308,15 +309,17 @@ describe("status subcommand", () => {
   it("status shows backlog plans", () => {
     runCli(["init", "--yes"], ctx.dir);
 
-    mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"), {
-      recursive: true,
-    });
+    const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+    const authDir = join(backlogDir, "prd-auth");
+    const searchDir = join(backlogDir, "prd-search");
+    mkdirSync(authDir, { recursive: true });
+    mkdirSync(searchDir, { recursive: true });
     writeFileSync(
-      join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-auth.md"),
+      join(authDir, "prd-auth.md"),
       "# Auth\n\n### Task 1: Login\n### Task 2: Signup\n",
     );
     writeFileSync(
-      join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-search.md"),
+      join(searchDir, "prd-search.md"),
       "---\ndepends-on: [prd-auth.md]\n---\n\n# Search\n\n### Task 1: Index\n",
     );
 
@@ -334,23 +337,24 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-dark-mode");
+    mkdirSync(planDir, { recursive: true });
 
     // Plan with 3 tasks
     writeFileSync(
-      join(ipDir, "prd-dark-mode.md"),
+      join(planDir, "prd-dark-mode.md"),
       "# Dark Mode\n\n### Task 1: Theme\n### Task 2: Toggle\n### Task 3: Persist\n",
     );
 
     // Progress file with 1 completed task
     writeFileSync(
-      join(ipDir, "progress.md"),
+      join(planDir, "progress.md"),
       "## Progress Log\n\n### Task 1: Theme\n\n**Status:** Complete\n",
     );
 
     // Receipt for this plan — includes tasks_completed
     writeFileSync(
-      join(ipDir, "receipt-dark-mode.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=worktree",
@@ -377,17 +381,18 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-legacy");
+    mkdirSync(planDir, { recursive: true });
 
     // Plan with 2 tasks
     writeFileSync(
-      join(ipDir, "prd-legacy.md"),
+      join(planDir, "prd-legacy.md"),
       "# Legacy\n\n### Task 1: Migrate\n### Task 2: Validate\n",
     );
 
     // Receipt WITHOUT tasks_completed (backwards compatibility)
     writeFileSync(
-      join(ipDir, "receipt-legacy.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -408,23 +413,24 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-feature");
+    mkdirSync(planDir, { recursive: true });
 
     // Plan with 4 tasks
     writeFileSync(
-      join(ipDir, "prd-feature.md"),
+      join(planDir, "prd-feature.md"),
       "# Feature\n\n### Task 1: A\n### Task 2: B\n### Task 3: C\n### Task 4: D\n",
     );
 
     // Progress file with 2 completed tasks
     writeFileSync(
-      join(ipDir, "progress.md"),
+      join(planDir, "progress.md"),
       "## Progress Log\n\n### Task 1: A\n**Status:** Complete\n\n### Task 2: B\n**Status:** Complete\n",
     );
 
     // Receipt says 3 tasks completed (receipt is authoritative)
     writeFileSync(
-      join(ipDir, "receipt-feature.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -447,17 +453,18 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-search");
+    mkdirSync(planDir, { recursive: true });
 
     // Plan with 2 tasks
     writeFileSync(
-      join(ipDir, "prd-search.md"),
+      join(planDir, "prd-search.md"),
       "# Search\n\n### Task 1: Index\n### Task 2: Query\n",
     );
 
     // Receipt with turns_budget=5, turns_completed=2
     writeFileSync(
-      join(ipDir, "receipt-search.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -480,17 +487,18 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-refactor");
+    mkdirSync(planDir, { recursive: true });
 
     // Plan with 1 task
     writeFileSync(
-      join(ipDir, "prd-refactor.md"),
+      join(planDir, "prd-refactor.md"),
       "# Refactor\n\n### Task 1: Cleanup\n",
     );
 
     // Receipt with turns_budget=0 (unlimited)
     writeFileSync(
-      join(ipDir, "receipt-refactor.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -513,16 +521,17 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-old-plan");
+    mkdirSync(planDir, { recursive: true });
 
     writeFileSync(
-      join(ipDir, "prd-old-plan.md"),
+      join(planDir, "prd-old-plan.md"),
       "# Old Plan\n\n### Task 1: Stuff\n",
     );
 
     // Old receipt without turns_budget field — defaults to 0 in parseReceipt
     writeFileSync(
-      join(ipDir, "receipt-old-plan.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -545,11 +554,12 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const orphanDir = join(ipDir, "orphan");
+    mkdirSync(orphanDir, { recursive: true });
 
     // Receipt with no matching plan file
     writeFileSync(
-      join(ipDir, "receipt-orphan.txt"),
+      join(orphanDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -564,18 +574,21 @@ describe("status subcommand", () => {
 
     expect(result.exitCode).toBe(0);
     expect(output).toContain("Problems");
-    expect(output).toContain("Orphaned receipt: receipt-orphan.txt");
+    expect(output).toContain("Orphaned receipt: orphan/receipt.txt");
   });
 
   it("status counts completed plans from archive", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
-    mkdirSync(outDir, { recursive: true });
+    const authDir = join(outDir, "prd-auth");
+    const searchDir = join(outDir, "prd-search");
+    mkdirSync(authDir, { recursive: true });
+    mkdirSync(searchDir, { recursive: true });
 
-    // Two archived plans (same slug, different timestamps)
-    writeFileSync(join(outDir, "prd-auth-20260306-120000.md"), "# Auth\n");
-    writeFileSync(join(outDir, "prd-search-20260306-130000.md"), "# Search\n");
+    // Two archived plans
+    writeFileSync(join(authDir, "prd-auth.md"), "# Auth\n");
+    writeFileSync(join(searchDir, "prd-search.md"), "# Search\n");
 
     const result = runCli(["status"], ctx.dir);
     const output = result.stdout + result.stderr;
@@ -592,17 +605,18 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "remove-fallback-agents");
+    mkdirSync(planDir, { recursive: true });
 
     // Plan without prd- prefix (e.g. hand-named plan)
     writeFileSync(
-      join(ipDir, "remove-fallback-agents.md"),
+      join(planDir, "remove-fallback-agents.md"),
       "# Remove Fallback Agents\n\n### Task 1: Remove\n### Task 2: Test\n### Task 3: Docs\n",
     );
 
     // Receipt with plan_file field pointing to the non-prd plan
     writeFileSync(
-      join(ipDir, "receipt-remove-fallback-agents.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -630,17 +644,18 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "gh-42-search");
+    mkdirSync(planDir, { recursive: true });
 
     // Plan from issue intake (gh- prefix)
     writeFileSync(
-      join(ipDir, "gh-42-search.md"),
+      join(planDir, "gh-42-search.md"),
       "# Search Feature\n\n### Task 1: Index\n### Task 2: Query\n",
     );
 
     // Receipt with plan_file field for the gh-prefixed plan
     writeFileSync(
-      join(ipDir, "receipt-gh-42-search.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=worktree",
@@ -664,58 +679,24 @@ describe("status subcommand", () => {
     expect(output).not.toContain("Orphaned");
   });
 
-  it("status backward compat: old receipt without plan_file matches prd-prefixed plan", () => {
-    runCli(["init", "--yes"], ctx.dir);
-
-    const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
-
-    // Plan with prd- prefix (existing convention)
-    writeFileSync(
-      join(ipDir, "prd-auth.md"),
-      "# Auth\n\n### Task 1: Login\n### Task 2: Signup\n",
-    );
-
-    // Old receipt WITHOUT plan_file field — should fall back to prd-<slug>.md
-    writeFileSync(
-      join(ipDir, "receipt-auth.txt"),
-      [
-        "started_at=2026-03-07T12:00:00Z",
-        "source=main",
-        "branch=ralphai/auth",
-        "slug=auth",
-        "turns_completed=3",
-        "tasks_completed=1",
-      ].join("\n"),
-    );
-
-    const result = runCli(["status"], ctx.dir);
-    const output = result.stdout + result.stderr;
-
-    expect(result.exitCode).toBe(0);
-    expect(output).toContain("prd-auth.md");
-    expect(output).toContain("1 of 2 tasks");
-    // No orphaned receipt — backward compat fallback works
-    expect(output).not.toContain("Problems");
-    expect(output).not.toContain("Orphaned");
-  });
-
   it("status counts completed non-prd plans from archive", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
-    mkdirSync(outDir, { recursive: true });
+    const agentsDir = join(outDir, "remove-fallback-agents");
+    const searchDir = join(outDir, "gh-42-search");
+    const authDir = join(outDir, "prd-auth");
+    mkdirSync(agentsDir, { recursive: true });
+    mkdirSync(searchDir, { recursive: true });
+    mkdirSync(authDir, { recursive: true });
 
     // Archived plans with various naming conventions
     writeFileSync(
-      join(outDir, "remove-fallback-agents-20260306-120000.md"),
+      join(agentsDir, "remove-fallback-agents.md"),
       "# Remove Fallback Agents\n",
     );
-    writeFileSync(
-      join(outDir, "gh-42-search-20260306-130000.md"),
-      "# Search\n",
-    );
-    writeFileSync(join(outDir, "prd-auth-20260306-140000.md"), "# Auth\n");
+    writeFileSync(join(searchDir, "gh-42-search.md"), "# Search\n");
+    writeFileSync(join(authDir, "prd-auth.md"), "# Auth\n");
 
     const result = runCli(["status"], ctx.dir);
     const output = result.stdout + result.stderr;
@@ -732,16 +713,17 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-stuck-plan");
+    mkdirSync(planDir, { recursive: true });
 
     writeFileSync(
-      join(ipDir, "prd-stuck-plan.md"),
+      join(planDir, "prd-stuck-plan.md"),
       "# Stuck Plan\n\n### Task 1: A\n### Task 2: B\n",
     );
 
     // Receipt with outcome=stuck
     writeFileSync(
-      join(ipDir, "receipt-stuck-plan.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",
@@ -766,13 +748,17 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const ipDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    mkdirSync(ipDir, { recursive: true });
+    const planDir = join(ipDir, "prd-active");
+    mkdirSync(planDir, { recursive: true });
 
-    writeFileSync(join(ipDir, "prd-active.md"), "# Active\n\n### Task 1: Do\n");
+    writeFileSync(
+      join(planDir, "prd-active.md"),
+      "# Active\n\n### Task 1: Do\n",
+    );
 
     // Receipt without outcome field
     writeFileSync(
-      join(ipDir, "receipt-active.txt"),
+      join(planDir, "receipt.txt"),
       [
         "started_at=2026-03-07T12:00:00Z",
         "source=main",

--- a/src/teardown-reset.test.ts
+++ b/src/teardown-reset.test.ts
@@ -68,7 +68,9 @@ describe("reset command", () => {
 
     // Simulate an in-progress plan
     const inProgressDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    writeFileSync(join(inProgressDir, "prd-my-feature.md"), "# My Feature");
+    const planDir = join(inProgressDir, "prd-my-feature");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "prd-my-feature.md"), "# My Feature");
 
     const output = stripLogo(runCliOutput(["reset", "--yes"], ctx.dir));
 
@@ -76,77 +78,100 @@ describe("reset command", () => {
     // Plan should be back in backlog
     expect(
       existsSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-my-feature.md"),
+        join(
+          ctx.dir,
+          ".ralphai",
+          "pipeline",
+          "backlog",
+          "prd-my-feature",
+          "prd-my-feature.md",
+        ),
       ),
     ).toBe(true);
     // Plan should NOT be in in-progress
-    expect(existsSync(join(inProgressDir, "prd-my-feature.md"))).toBe(false);
+    expect(existsSync(join(inProgressDir, "prd-my-feature"))).toBe(false);
   });
 
   it("reset --yes deletes progress files", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const inProgressDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    writeFileSync(join(inProgressDir, "prd-test.md"), "# Test");
+    const planDir = join(inProgressDir, "prd-test");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "prd-test.md"), "# Test");
     writeFileSync(
-      join(inProgressDir, "progress-test.md"),
+      join(planDir, "progress.md"),
       "## Progress Log\n### Task 1:\n**Status:** Complete",
     );
 
     runCliOutput(["reset", "--yes"], ctx.dir);
 
-    expect(existsSync(join(inProgressDir, "progress-test.md"))).toBe(false);
+    expect(existsSync(join(inProgressDir, "prd-test", "progress.md"))).toBe(
+      false,
+    );
   });
 
   it("reset --yes deletes receipt files", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const inProgressDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    writeFileSync(join(inProgressDir, "prd-test.md"), "# Test");
+    const planDir = join(inProgressDir, "prd-test");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "prd-test.md"), "# Test");
     writeFileSync(
-      join(inProgressDir, "receipt-test.txt"),
+      join(planDir, "receipt.txt"),
       "started_at=2025-01-15T10:30:00Z\nsource=main\nbranch=ralphai/test\nslug=test\nturns_completed=3",
     );
 
     runCliOutput(["reset", "--yes"], ctx.dir);
 
-    expect(existsSync(join(inProgressDir, "receipt-test.txt"))).toBe(false);
+    expect(existsSync(join(inProgressDir, "prd-test", "receipt.txt"))).toBe(
+      false,
+    );
   });
 
   it("reset --yes handles multiple plans, progress, and receipts", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const inProgressDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    writeFileSync(join(inProgressDir, "prd-feature-a.md"), "# Feature A");
-    writeFileSync(join(inProgressDir, "prd-feature-b.md"), "# Feature B");
-    writeFileSync(
-      join(inProgressDir, "progress-feature-a.md"),
-      "## Progress Log",
-    );
-    writeFileSync(
-      join(inProgressDir, "receipt-feature-a.txt"),
-      "slug=feature-a",
-    );
-    writeFileSync(
-      join(inProgressDir, "receipt-feature-b.txt"),
-      "slug=feature-b",
-    );
+    const planDirA = join(inProgressDir, "prd-feature-a");
+    const planDirB = join(inProgressDir, "prd-feature-b");
+    mkdirSync(planDirA, { recursive: true });
+    mkdirSync(planDirB, { recursive: true });
+    writeFileSync(join(planDirA, "prd-feature-a.md"), "# Feature A");
+    writeFileSync(join(planDirB, "prd-feature-b.md"), "# Feature B");
+    writeFileSync(join(planDirA, "progress.md"), "## Progress Log");
+    writeFileSync(join(planDirA, "receipt.txt"), "slug=feature-a");
+    writeFileSync(join(planDirB, "receipt.txt"), "slug=feature-b");
 
     const output = stripLogo(runCliOutput(["reset", "--yes"], ctx.dir));
 
     expect(output).toContain("2 plans moved to backlog");
-    expect(output).toContain("Deleted 1 progress file");
-    expect(output).toContain("Deleted 2 receipts");
+    expect(output).toContain("Deleted progress.md and receipt.txt in 2 plans");
 
     // Both plans should be in backlog
     expect(
       existsSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-feature-a.md"),
+        join(
+          ctx.dir,
+          ".ralphai",
+          "pipeline",
+          "backlog",
+          "prd-feature-a",
+          "prd-feature-a.md",
+        ),
       ),
     ).toBe(true);
     expect(
       existsSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-feature-b.md"),
+        join(
+          ctx.dir,
+          ".ralphai",
+          "pipeline",
+          "backlog",
+          "prd-feature-b",
+          "prd-feature-b.md",
+        ),
       ),
     ).toBe(true);
 
@@ -175,7 +200,9 @@ describe("reset command", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const inProgressDir = join(ctx.dir, ".ralphai", "pipeline", "in-progress");
-    writeFileSync(join(inProgressDir, "prd-test.md"), "# Test");
+    const planDir = join(inProgressDir, "prd-test");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "prd-test.md"), "# Test");
 
     runCliOutput(["reset", "--yes"], ctx.dir);
 

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -168,7 +168,7 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         // Config falls back to main repo's absolute path (manual worktree without symlink)
         expect(result).toContain(`CONFIG_FILE=${mainRepo}/ralphai.json`);
         expect(result).toContain(
-          `PROGRESS_FILE=${mainRepo}/.ralphai/pipeline/in-progress/progress.md`,
+          `PROGRESS_FILE=${mainRepo}/.ralphai/pipeline/in-progress/<slug>/progress.md`,
         );
       } finally {
         try {
@@ -226,7 +226,7 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         expect(result).toContain("ARCHIVE_DIR=.ralphai/pipeline/out");
         expect(result).toContain("CONFIG_FILE=ralphai.json");
         expect(result).toContain(
-          "PROGRESS_FILE=.ralphai/pipeline/in-progress/progress.md",
+          "PROGRESS_FILE=.ralphai/pipeline/in-progress/<slug>/progress.md",
         );
       } finally {
         try {
@@ -276,7 +276,7 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         expect(result).toContain("ARCHIVE_DIR=.ralphai/pipeline/out");
         expect(result).toContain("CONFIG_FILE=ralphai.json");
         expect(result).toContain(
-          "PROGRESS_FILE=.ralphai/pipeline/in-progress/progress.md",
+          "PROGRESS_FILE=.ralphai/pipeline/in-progress/<slug>/progress.md",
         );
       } finally {
         try {
@@ -335,13 +335,10 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
 
       // Initialize ralphai so the worktree guard runs (it checks before .ralphai)
       // Create a minimal .ralphai in main repo so worktree resolves
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"), {
-        recursive: true,
-      });
-      writeFileSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-test.md"),
-        "# Test plan\n",
-      );
+      const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+      const planDir = join(backlogDir, "prd-test");
+      mkdirSync(planDir, { recursive: true });
+      writeFileSync(join(planDir, "prd-test.md"), "# Test plan\n");
 
       const result = runCli(["worktree"], worktreeDir);
       expect(result.exitCode).not.toBe(0);
@@ -421,7 +418,7 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         stdio: "ignore",
       });
 
-      // No .ralphai/pipeline/in-progress/prd-done-feature.md exists,
+      // No .ralphai/pipeline/in-progress/done-feature/done-feature.md exists,
       // so it should be cleaned
       const output = runCliOutput(["worktree", "clean"], ctx.dir);
       expect(output).toContain("Removing:");
@@ -444,19 +441,15 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       );
 
       // Create matching in-progress plan
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "in-progress"), {
-        recursive: true,
-      });
-      writeFileSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "in-progress",
-          "prd-active-feature.md",
-        ),
-        "# Active plan\n",
+      const inProgressDir = join(
+        ctx.dir,
+        ".ralphai",
+        "pipeline",
+        "in-progress",
       );
+      const planDir = join(inProgressDir, "prd-active-feature");
+      mkdirSync(planDir, { recursive: true });
+      writeFileSync(join(planDir, "prd-active-feature.md"), "# Active plan\n");
 
       const output = runCliOutput(["worktree", "clean"], ctx.dir);
       expect(output).toContain("Keeping:");
@@ -474,17 +467,13 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       gitInitialCommit(ctx.dir);
 
       // Create .ralphai with two plans
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"), {
-        recursive: true,
-      });
-      writeFileSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-first.md"),
-        "# First\n",
-      );
-      writeFileSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-second.md"),
-        "# Second\n",
-      );
+      const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+      const firstDir = join(backlogDir, "prd-first");
+      const secondDir = join(backlogDir, "prd-second");
+      mkdirSync(firstDir, { recursive: true });
+      mkdirSync(secondDir, { recursive: true });
+      writeFileSync(join(firstDir, "prd-first.md"), "# First\n");
+      writeFileSync(join(secondDir, "prd-second.md"), "# Second\n");
 
       // Use a stub runner that just exits 0
       const stubScript = join(ctx.dir, "stub-runner.sh");
@@ -507,13 +496,10 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       gitInitialCommit(ctx.dir);
 
       // Create .ralphai with a plan
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"), {
-        recursive: true,
-      });
-      writeFileSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-symlink-test.md"),
-        "# Symlink test\n",
-      );
+      const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+      const planDir = join(backlogDir, "prd-symlink-test");
+      mkdirSync(planDir, { recursive: true });
+      writeFileSync(join(planDir, "prd-symlink-test.md"), "# Symlink test\n");
 
       // Use a stub runner that just exits 0
       const stubScript = join(ctx.dir, "stub-runner.sh");
@@ -547,17 +533,11 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       gitInitialCommit(ctx.dir);
 
       // Create .ralphai with a plan
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"), {
-        recursive: true,
-      });
+      const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+      const planDir = join(backlogDir, "prd-config-symlink");
+      mkdirSync(planDir, { recursive: true });
       writeFileSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "backlog",
-          "prd-config-symlink.md",
-        ),
+        join(planDir, "prd-config-symlink.md"),
         "# Config symlink test\n",
       );
 
@@ -597,17 +577,11 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       gitInitialCommit(ctx.dir);
 
       // Create .ralphai with a plan
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"), {
-        recursive: true,
-      });
+      const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+      const planDir = join(backlogDir, "prd-committed-cfg");
+      mkdirSync(planDir, { recursive: true });
       writeFileSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "backlog",
-          "prd-committed-cfg.md",
-        ),
+        join(planDir, "prd-committed-cfg.md"),
         "# Committed config test\n",
       );
 
@@ -645,13 +619,10 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       gitInitialCommit(ctx.dir);
 
       // Create .ralphai with a plan (not git-tracked since .ralphai/ is gitignored)
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"), {
-        recursive: true,
-      });
-      writeFileSync(
-        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-tracked-test.md"),
-        "# Tracked test\n",
-      );
+      const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+      const planDir = join(backlogDir, "prd-tracked-test");
+      mkdirSync(planDir, { recursive: true });
+      writeFileSync(join(planDir, "prd-tracked-test.md"), "# Tracked test\n");
 
       // Use a stub runner that just exits 0
       const stubScript = join(ctx.dir, "stub-runner.sh");
@@ -736,13 +707,15 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
     it("worktree reuses an existing in-progress worktree and auto-resumes", () => {
       gitInitialCommit(ctx.dir);
 
-      mkdirSync(join(ctx.dir, ".ralphai", "pipeline", "in-progress"), {
-        recursive: true,
-      });
-      writeFileSync(
-        join(ctx.dir, ".ralphai", "pipeline", "in-progress", "prd-resume.md"),
-        "# Resume test\n",
+      const inProgressDir = join(
+        ctx.dir,
+        ".ralphai",
+        "pipeline",
+        "in-progress",
       );
+      const planDir = join(inProgressDir, "prd-resume");
+      mkdirSync(planDir, { recursive: true });
+      writeFileSync(join(planDir, "prd-resume.md"), "# Resume test\n");
 
       const worktreeDir = join(ctx.dir, "wt-resume");
       execSync(`git worktree add "${worktreeDir}" -b ralphai/prd-resume HEAD`, {
@@ -789,24 +762,17 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         join(ctx.dir, "ralphai.json"),
         JSON.stringify({ agentCommand: "claude -p" }) + "\n",
       );
-      writeFileSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "in-progress",
-          "prd-dark-mode.md",
-        ),
-        "# Dark mode\n",
+      const planDir = join(
+        ctx.dir,
+        ".ralphai",
+        "pipeline",
+        "in-progress",
+        "dark-mode",
       );
+      mkdirSync(planDir, { recursive: true });
+      writeFileSync(join(planDir, "dark-mode.md"), "# Dark mode\n");
       writeFileSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "in-progress",
-          "receipt-dark-mode.txt",
-        ),
+        join(planDir, "receipt.txt"),
         [
           "started_at=2026-03-07T12:00:00Z",
           "source=worktree",
@@ -835,18 +801,17 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
         join(ctx.dir, "ralphai.json"),
         JSON.stringify({ agentCommand: "claude -p" }) + "\n",
       );
-      writeFileSync(
-        join(ctx.dir, ".ralphai", "pipeline", "in-progress", "prd-search.md"),
-        "# Search\n",
+      const planDir = join(
+        ctx.dir,
+        ".ralphai",
+        "pipeline",
+        "in-progress",
+        "prd-search",
       );
+      mkdirSync(planDir, { recursive: true });
+      writeFileSync(join(planDir, "prd-search.md"), "# Search\n");
       writeFileSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "in-progress",
-          "receipt-prd-search.txt",
-        ),
+        join(planDir, "receipt.txt"),
         [
           "started_at=2026-03-07T12:00:00Z",
           "source=main",
@@ -881,14 +846,16 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       });
 
       // Write a receipt for the slug "done"
+      const planDir = join(
+        ctx.dir,
+        ".ralphai",
+        "pipeline",
+        "in-progress",
+        "done",
+      );
+      mkdirSync(planDir, { recursive: true });
       writeFileSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "in-progress",
-          "receipt-done.txt",
-        ),
+        join(planDir, "receipt.txt"),
         [
           "started_at=2026-03-07T12:00:00Z",
           "source=worktree",
@@ -903,7 +870,7 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       const combined = result.stdout + result.stderr;
 
       expect(result.exitCode).toBe(0);
-      expect(combined).toContain("Archived receipt: receipt-done.txt");
+      expect(combined).toContain("Archived receipt: done/receipt.txt");
 
       // Receipt should no longer exist in in-progress
       expect(
@@ -913,7 +880,8 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
             ".ralphai",
             "pipeline",
             "in-progress",
-            "receipt-done.txt",
+            "done",
+            "receipt.txt",
           ),
         ),
       ).toBe(false);
@@ -921,11 +889,8 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       // Receipt should exist in out/
       const outDir = join(ctx.dir, ".ralphai", "pipeline", "out");
       expect(existsSync(outDir)).toBe(true);
-      const outFiles = readdirSync(outDir);
-      const archivedReceipt = outFiles.find((f: string) =>
-        f.startsWith("receipt-done-"),
-      );
-      expect(archivedReceipt).toBeDefined();
+      const archivedReceipt = join(outDir, "done", "receipt.txt");
+      expect(existsSync(archivedReceipt)).toBe(true);
     });
   });
 });

--- a/templates/ralphai/PLANNING.md
+++ b/templates/ralphai/PLANNING.md
@@ -1,6 +1,6 @@
 # Writing Ralphai Plan Files
 
-Guide for coding agents writing plan files that Ralphai executes autonomously. Plans go in `.ralphai/pipeline/backlog/`.
+Guide for coding agents writing plan files that Ralphai executes autonomously. Plans go in `.ralphai/pipeline/backlog/<slug>/<slug>.md`.
 
 ## How to Write a Plan
 
@@ -11,7 +11,7 @@ Guide for coding agents writing plan files that Ralphai executes autonomously. P
    - **[Refactor](plans/refactor.md)** — structural change, no behavior change
 3. **Explore the codebase.** Before writing anything, find the files, functions, and line numbers relevant to the work. The plan must contain concrete references, not guesses.
 4. **Fill in the template.** Follow the guide's template. Every file path, function name, and line number you include saves Ralphai tokens it would otherwise spend exploring.
-5. **Write the plan file** to `.ralphai/pipeline/backlog/<slug>.md`.
+5. **Write the plan file** to `.ralphai/pipeline/backlog/<slug>/<slug>.md`.
 
 ## Core Principles
 
@@ -43,6 +43,7 @@ it checks `item.type === 'foo'` at line 104. No changes needed here.
 Each task is one logical commit with implementation, tests, and doc updates together. The same context window that writes the code should also write the tests and update docs.
 
 Bad:
+
 ```
 Task 1: Add parser
 Task 2: Test parser
@@ -50,6 +51,7 @@ Task 3: Document parser
 ```
 
 Good:
+
 ```
 Task 1: Add parser with tests and doc updates
 ```

--- a/templates/ralphai/README.md
+++ b/templates/ralphai/README.md
@@ -19,13 +19,13 @@ ralphai run --help       # show all options
 Plans flow through four directories:
 
 ```
-wip/ (parked)    backlog/  →  in-progress/  →  out/
+parked/    backlog/  →  in-progress/  →  out/
 ```
 
-1. **`wip/`** — Not ready. Ralphai ignores this directory.
-2. **`backlog/`** — Queued plans. Ralphai picks dependency-ready plans automatically.
-3. **`in-progress/`** — Active work. Plan + `progress.md` live here. Files stay on interruption for resumption.
-4. **`out/`** — Archive. Moved here when the agent signals completion.
+1. **`parked/`** — Not ready. Ralphai ignores this directory.
+2. **`backlog/`** — Queued plans. Each plan lives in its own folder (for example `backlog/<slug>/<slug>.md`).
+3. **`in-progress/`** — Active work. Plan folder + `progress.md` live here (for example `in-progress/<slug>/`). Files stay on interruption for resumption.
+4. **`out/`** — Archive. Plan folders move here when the agent signals completion.
 
 All pipeline files are **gitignored** (local-only state).
 
@@ -77,16 +77,16 @@ Requires `gh` CLI. If `gh` is unavailable, hooks are silently skipped.
 
 ## Files
 
-| File / Directory        | Purpose                             |
-| ----------------------- | ----------------------------------- |
-| `README.md`             | This file                           |
-| `PLANNING.md`           | Guide for writing plan files        |
-| `LEARNINGS.md`          | Auto-written learnings (local-only) |
+| File / Directory         | Purpose                             |
+| ------------------------ | ----------------------------------- |
+| `README.md`              | This file                           |
+| `PLANNING.md`            | Guide for writing plan files        |
+| `LEARNINGS.md`           | Auto-written learnings (local-only) |
 | `LEARNING_CANDIDATES.md` | Candidate lessons for human review  |
-| `pipeline/wip/`         | Parked plans                        |
-| `pipeline/backlog/`     | Queued plans                        |
-| `pipeline/in-progress/` | Active plans + progress.md          |
-| `pipeline/out/`         | Completed plans archive             |
+| `pipeline/parked/`       | Parked plans                        |
+| `pipeline/backlog/`      | Queued plan folders                 |
+| `pipeline/in-progress/`  | Active plan folders + `progress.md` |
+| `pipeline/out/`          | Completed plan folders archive      |
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- switch pipeline storage to per-plan folders under `pipeline/backlog/`, `pipeline/in-progress/`, and `pipeline/out/`
- rename `wip/` to `parked/` and update runner, CLI, and docs accordingly
- update tests and receipt/progress handling to use per-plan directories

## Testing
- npm test