### PR TITLE
feat(pipeline): support flat .md plan files in backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ Project-specific guidance for AI coding agents working in this codebase.
 ## Ralphai
 
 This project uses [Ralphai](https://github.com/mfaux/ralphai) for autonomous task execution.
-Plan files go in per-plan folders under `.ralphai/pipeline/backlog/`. See `.ralphai/PLANNING.md` for
-the plan writing guide.
+Plan files go in `.ralphai/pipeline/backlog/` as flat `.md` files (e.g., `backlog/my-plan.md`).
+See `.ralphai/PLANNING.md` for the plan writing guide.
 
 ## Learnings
 
@@ -47,3 +47,7 @@ The `update_receipt_tasks()` function in `runner/lib/receipt.sh` and `countCompl
 ### Test file organization
 
 Tests are split by feature domain into separate files under `src/`. Each file has its own `describe` block and uses the `useTempGitDir()` helper from `test-utils.ts` for test isolation. When adding tests for a new feature, create a new test file rather than appending to an existing one.
+
+### Flat backlog plan files
+
+Plan files in `.ralphai/pipeline/backlog/` must be flat `.md` files (e.g., `backlog/my-plan.md`). The runner creates the slug folder automatically when moving a plan to `in-progress/`. Slug-folders in the backlog directory are not discovered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking
 
-- **Per-plan pipeline folders** — plans now live in per-plan folders under `pipeline/backlog/` (for example `backlog/<slug>/<slug>.md`), and `wip/` is renamed to `parked/`. This release removes backward compatibility with the old file layout.
+- **Flat-only backlog plans** — plans in `pipeline/backlog/` must be flat `.md` files (for example `backlog/my-plan.md`). The slug-folder format (`backlog/<slug>/<slug>.md`) is no longer supported in the backlog. The runner creates slug folders automatically when promoting a plan to `in-progress/`.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ parked/    backlog/  →  in-progress/  →  out/
 ```
 
 Park unready plans in `parked/`. Ralphai ignores that folder.
-Each plan lives in its own folder under `backlog/` (for example `backlog/<slug>/<slug>.md`).
+Plans are flat `.md` files in `backlog/` (for example `backlog/my-plan.md`). The runner creates a slug folder automatically when moving a plan to `in-progress/`.
 
 ### 4. Pause and resume
 

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -143,7 +143,7 @@ parked/    (ignored by Ralphai)
 backlog/  →  in-progress/  →  out/
 ```
 
-- **`backlog/`** — the queue. Each plan is a folder containing the plan file.
+- **`backlog/`** — the queue. Plans are flat `.md` files (e.g., `backlog/my-plan.md`).
   Ralphai picks dependency-ready plans
   (oldest first when multiple are ready).
 - **`in-progress/`** — active work. The plan folder contains the plan file and

--- a/runner/lib/issues.sh
+++ b/runner/lib/issues.sh
@@ -68,11 +68,11 @@ pull_github_issues() {
 
   slug=$(slugify "$title")
   filename="gh-${number}-${slug}.md"
-  local plan_dir="$BACKLOG_DIR/${filename%.md}"
+  local plan_path="$BACKLOG_DIR/$filename"
 
-  # Write plan file with frontmatter
-  mkdir -p "$plan_dir"
-  cat > "$plan_dir/$filename" <<PLAN_EOF
+  # Write plan file as flat file in backlog
+  mkdir -p "$BACKLOG_DIR"
+  cat > "$plan_path" <<PLAN_EOF
 ---
 source: github
 issue: ${number}

--- a/runner/lib/plans.sh
+++ b/runner/lib/plans.sh
@@ -92,7 +92,7 @@ dependency_status() {
     return 0
   fi
 
-  if [[ -d "$WIP_DIR/$dep_slug" || -d "$BACKLOG_DIR/$dep_slug" ]]; then
+  if [[ -d "$WIP_DIR/$dep_slug" || -f "$BACKLOG_DIR/$dep_base" ]]; then
     echo "pending"
     return 0
   fi
@@ -141,7 +141,7 @@ plan_readiness() {
   echo "blocked:$joined"
 }
 
-# --- Resolve plan file path inside a plan directory ---
+# --- Resolve plan file path inside a slug-folder (in-progress/out only) ---
 plan_file_for_dir() {
   local dir="$1"
   local slug
@@ -152,6 +152,19 @@ plan_file_for_dir() {
     return 0
   fi
   return 1
+}
+
+# --- Collect backlog plans (flat .md files only) ---
+# Populates the named array with plan file paths.
+# Backlog only supports flat files: <backlog>/<slug>.md
+collect_backlog_plans() {
+  local -n _out_plans=$1
+  _out_plans=()
+
+  for f in "$BACKLOG_DIR"/*.md; do
+    [[ -f "$f" ]] || continue
+    _out_plans+=("$f")
+  done
 }
 
 # --- Detect plan: find in-progress work or pick from backlog ---
@@ -200,28 +213,18 @@ detect_plan() {
 
   # Check backlog
   local backlog_plans=()
-  for d in "$BACKLOG_DIR"/*; do
-    [[ -d "$d" ]] || continue
-    local plan_file
-    plan_file=$(plan_file_for_dir "$d") || continue
-    backlog_plans+=("$plan_file")
-  done
+  collect_backlog_plans backlog_plans
 
   if [[ ${#backlog_plans[@]} -eq 0 ]]; then
     if pull_github_issues; then
       # Re-scan backlog after pulling issue
-      for d in "$BACKLOG_DIR"/*; do
-        [[ -d "$d" ]] || continue
-        local plan_file
-        plan_file=$(plan_file_for_dir "$d") || continue
-        backlog_plans+=("$plan_file")
-      done
+      collect_backlog_plans backlog_plans
       if [[ ${#backlog_plans[@]} -eq 0 ]]; then
-        echo "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md"
+        echo "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/<slug>.md — see .ralphai/PLANNING.md"
         return 1
       fi
     else
-      echo "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md"
+      echo "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/<slug>.md — see .ralphai/PLANNING.md"
       return 1
     fi
   fi
@@ -284,32 +287,27 @@ detect_plan() {
     echo "Multiple dependency-ready backlog plans found (${#ready_plans[@]}). Picking oldest: $(basename "$chosen")"
   fi
 
+  # Backlog plans are always flat files: <backlog>/<slug>.md
+  local slug
+  slug="${chosen##*/}"  # basename
+  slug="${slug%.md}"
+
+  local dest_dir="$WIP_DIR/$slug"
+  local dest_plan="$dest_dir/$slug.md"
+
   if [[ "$DRY_RUN" == true ]]; then
     echo "[dry-run] Would select: $chosen"
-    local chosen_base
-    chosen_base=$(basename "$chosen")
-    local chosen_dir
-    chosen_dir=$(dirname "$chosen")
-    local dest_dir
-    dest_dir="$WIP_DIR/$(basename "$chosen_dir")"
-    local dest_plan
-    dest_plan="$dest_dir/$chosen_base"
     WIP_FILES=("$dest_plan")
     FILE_REFS=" $(format_file_ref "$dest_plan")"
     RESUMING=false
-    echo "[dry-run] Would move: $chosen_dir -> $dest_dir"
+    echo "[dry-run] Would promote flat file: $chosen -> $dest_plan"
   else
-    # Move chosen plan to in-progress
+    # Move chosen plan to in-progress (promote flat file to slug-folder)
     mkdir -p "$WIP_DIR"
-    local chosen_dir
-    chosen_dir=$(dirname "$chosen")
-    local dest_dir
-    dest_dir="$WIP_DIR/$(basename "$chosen_dir")"
-    mv "$chosen_dir" "$dest_dir"
-    echo "Moved $chosen_dir -> $dest_dir"
+    mkdir -p "$dest_dir"
+    mv "$chosen" "$dest_plan"
+    echo "Promoted flat file: $chosen -> $dest_plan"
 
-    local dest_plan
-    dest_plan="$dest_dir/$(basename "$chosen")"
     WIP_FILES=("$dest_plan")
     FILE_REFS=" $(format_file_ref "$dest_plan")"
     RESUMING=false

--- a/runner/lib/pr.sh
+++ b/runner/lib/pr.sh
@@ -139,11 +139,10 @@ build_continuous_pr_body() {
 
   # Remaining plans section (scan backlog)
   local remaining=()
-  for d in "$BACKLOG_DIR"/*; do
-    [[ -d "$d" ]] || continue
-    local plan_file
-    plan_file=$(plan_file_for_dir "$d") || continue
-    remaining+=("$(basename "$plan_file")")
+  local _remaining_plans=()
+  collect_backlog_plans _remaining_plans
+  for _rp in "${_remaining_plans[@]}"; do
+    remaining+=("$(basename "$_rp")")
   done
 
   body+=$'\n'"## Remaining Plans"$'\n\n'

--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -56,14 +56,13 @@ if [[ "$MODE" == "patch" ]]; then
     echo "  ralphai run --pr"
     # Peek at backlog to suggest a branch name
     _first_plan=""
-  for _d in "$BACKLOG_DIR"/*; do
-    [[ -d "$_d" ]] || continue
-    _plan_file=$(plan_file_for_dir "$_d") || continue
-    _first_plan="$_plan_file"
-    break
-  done
+  local _backlog_plans=()
+  collect_backlog_plans _backlog_plans
+  if [[ ${#_backlog_plans[@]} -gt 0 ]]; then
+    _first_plan="${_backlog_plans[0]}"
+  fi
   if [[ -n "$_first_plan" ]]; then
-    _slug=$(basename "$(dirname "$_first_plan")")
+    _slug=$(basename "$_first_plan" .md)
       echo ""
       if [[ "$RALPHAI_IS_WORKTREE" == true ]]; then
         echo "Or create a worktree on a feature branch:"
@@ -229,9 +228,10 @@ while true; do
       echo "Create a worktree on a feature branch instead:"
       slug=$(basename "$(dirname "${WIP_FILES[0]}")")
       echo "  git worktree add ../<dir> -b ralphai/${slug} $BASE_BRANCH"
-      # Roll back plan
-      rollback_dest="$BACKLOG_DIR/${slug}"
-      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
+      # Roll back plan: extract plan file back to backlog as flat file
+      rollback_dest="$BACKLOG_DIR/${slug}.md"
+      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rm -rf "$(dirname "${WIP_FILES[0]}")"
       echo "Rolled back: moved plan to $rollback_dest"
       exit 1
     fi
@@ -258,9 +258,10 @@ while true; do
       echo "Fix: delete or rename the stale branch, then retry:"
       echo "  git branch -m ralphai ralphai-legacy   # rename"
       echo "  git branch -D ralphai                # or delete"
-      # Roll back: move plan file back to backlog
-      rollback_dest="$BACKLOG_DIR/${slug}"
-      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
+      # Roll back: move plan file back to backlog as flat file
+      rollback_dest="$BACKLOG_DIR/${slug}.md"
+      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rm -rf "$(dirname "${WIP_FILES[0]}")"
       echo ""
       echo "Rolled back: moved plan to $rollback_dest"
       exit 1
@@ -271,9 +272,10 @@ while true; do
       echo ""
       echo "SKIP: $COLLISION_REASON"
       echo "Plan '$plan_basename' already has open work. Skipping to next plan."
-      # Roll back: move plan file back to backlog
-      rollback_dest="$BACKLOG_DIR/${slug}"
-      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
+      # Roll back: move plan file back to backlog as flat file
+      rollback_dest="$BACKLOG_DIR/${slug}.md"
+      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rm -rf "$(dirname "${WIP_FILES[0]}")"
       echo "Rolled back: moved plan to $rollback_dest"
       SKIPPED_PLANS["$plan_basename"]=1
       continue
@@ -281,9 +283,10 @@ while true; do
     if ! git checkout -b "$branch"; then
       echo ""
       echo "ERROR: Failed to create branch '$branch'."
-      # Roll back: move plan file back to backlog
-      rollback_dest="$BACKLOG_DIR/${slug}"
-      mv "$(dirname "${WIP_FILES[0]}")" "$rollback_dest"
+      # Roll back: move plan file back to backlog as flat file
+      rollback_dest="$BACKLOG_DIR/${slug}.md"
+      mv "${WIP_FILES[0]}" "$rollback_dest"
+      rm -rf "$(dirname "${WIP_FILES[0]}")"
       echo "Rolled back: moved plan to $rollback_dest"
       exit 1
     fi

--- a/src/flat-backlog.test.ts
+++ b/src/flat-backlog.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { execSync } from "child_process";
+import { runCli, runCliOutput, useTempGitDir } from "./test-utils.ts";
+
+// ---------------------------------------------------------------------------
+// Flat backlog plan discovery (TypeScript side)
+// ---------------------------------------------------------------------------
+
+describe("flat backlog plan discovery", () => {
+  const ctx = useTempGitDir();
+
+  function initProject(dir: string): void {
+    runCli(["init", "--yes"], dir);
+  }
+
+  function backlogDir(dir: string): string {
+    return join(dir, ".ralphai", "pipeline", "backlog");
+  }
+
+  it("flat .md file in backlog is listed by status", () => {
+    initProject(ctx.dir);
+    // Remove the sample plan if it exists
+    const bd = backlogDir(ctx.dir);
+    writeFileSync(join(bd, "my-flat-plan.md"), "# Plan: Flat Plan\n");
+
+    const output = runCliOutput(["status"], ctx.dir);
+    expect(output).toContain("my-flat-plan.md");
+  });
+
+  it("slug-folder plan in backlog is NOT discovered (flat-only)", () => {
+    initProject(ctx.dir);
+    const bd = backlogDir(ctx.dir);
+    // Remove default sample so it doesn't interfere
+    rmSync(join(bd, "hello-ralphai.md"), { force: true });
+    mkdirSync(join(bd, "folder-plan"), { recursive: true });
+    writeFileSync(
+      join(bd, "folder-plan", "folder-plan.md"),
+      "# Plan: Folder Plan\n",
+    );
+
+    const output = runCliOutput(["status"], ctx.dir);
+    // Slug-folder plans in backlog should be ignored
+    expect(output).not.toContain("folder-plan.md");
+  });
+
+  it("multiple flat plans are listed together", () => {
+    initProject(ctx.dir);
+    const bd = backlogDir(ctx.dir);
+    writeFileSync(join(bd, "flat-one.md"), "# Plan: Flat One\n");
+    writeFileSync(join(bd, "flat-two.md"), "# Plan: Flat Two\n");
+
+    const output = runCliOutput(["status"], ctx.dir);
+    expect(output).toContain("flat-one.md");
+    expect(output).toContain("flat-two.md");
+  });
+
+  it("init --yes creates sample plan as flat file", () => {
+    initProject(ctx.dir);
+    const bd = backlogDir(ctx.dir);
+    // Flat file should exist
+    expect(existsSync(join(bd, "hello-ralphai.md"))).toBe(true);
+    // Slug-folder should NOT exist
+    expect(existsSync(join(bd, "hello-ralphai", "hello-ralphai.md"))).toBe(
+      false,
+    );
+  });
+
+  it("doctor detects flat backlog plans", () => {
+    initProject(ctx.dir);
+    const bd = backlogDir(ctx.dir);
+    // Remove default sample plan
+    rmSync(join(bd, "hello-ralphai.md"), { force: true });
+    // Add a flat plan
+    writeFileSync(join(bd, "doc-plan.md"), "# Plan: Doc Plan\n");
+
+    const output = runCliOutput(["doctor"], ctx.dir);
+    expect(output).toContain("backlog:");
+    expect(output).toContain("1 plan");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flat backlog plan with depends-on in status
+// ---------------------------------------------------------------------------
+
+describe("flat backlog plan dependencies in status", () => {
+  const ctx = useTempGitDir();
+
+  it("shows dependency info for flat plans with depends-on frontmatter", () => {
+    runCli(["init", "--yes"], ctx.dir);
+    const bd = join(ctx.dir, ".ralphai", "pipeline", "backlog");
+    writeFileSync(
+      join(bd, "child-plan.md"),
+      `---
+depends-on: [parent-plan.md]
+---
+# Plan: Child Plan
+`,
+    );
+
+    const output = runCliOutput(["status"], ctx.dir);
+    expect(output).toContain("child-plan.md");
+    expect(output).toContain("waiting on parent-plan.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flat plan selection for worktree (dry-run via bash runner)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(process.platform === "win32")(
+  "flat backlog plan execution (bash runner)",
+  () => {
+    let testDir: string;
+
+    beforeEach(() => {
+      testDir = mkdtempSync(join(tmpdir(), "ralphai-flat-runner-"));
+      execSync("git init", { cwd: testDir, stdio: "ignore" });
+      execSync(
+        "git config user.email 'test@test.com' && git config user.name 'Test'",
+        { cwd: testDir, stdio: "ignore" },
+      );
+      execSync("git commit --allow-empty -m 'init'", {
+        cwd: testDir,
+        stdio: "ignore",
+      });
+    });
+
+    afterEach(() => {
+      if (existsSync(testDir)) {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it("dry-run detects flat backlog plan and shows promote message", () => {
+      // Set up ralphai structure with a flat plan
+      runCli(["init", "--yes"], testDir);
+      const bd = join(testDir, ".ralphai", "pipeline", "backlog");
+      // Remove sample plan to isolate our test plan
+      rmSync(join(bd, "hello-ralphai.md"), { force: true });
+      writeFileSync(join(bd, "test-flat.md"), "# Plan: Test Flat\n");
+
+      // Run the CLI in dry-run mode (which invokes the bundled runner)
+      const result = runCli(["run", "--dry-run"], testDir, {
+        RALPHAI_AGENT_COMMAND: "echo mock",
+        RALPHAI_NO_UPDATE_CHECK: "1",
+      });
+      const output = result.stdout + result.stderr;
+      // Should mention the flat file and show promote message
+      expect(output).toContain("test-flat");
+      expect(output).toContain("promote flat file");
+    });
+  },
+);

--- a/src/init-agents-md.test.ts
+++ b/src/init-agents-md.test.ts
@@ -107,7 +107,7 @@ describe("init AGENTS.md integration", () => {
       "This project uses [Ralphai](https://github.com/mfaux/ralphai) for autonomous task execution.",
     );
     expect(agentsMd).toContain(
-      "Plan files go in per-plan folders under `.ralphai/pipeline/backlog/`.",
+      "Plan files go in `.ralphai/pipeline/backlog/`.",
     );
     expect(agentsMd).toContain(
       "See `.ralphai/PLANNING.md` for\nthe plan writing guide.",

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -264,10 +264,10 @@ describe("init command", () => {
     const plans = readFileSync(join(templateLib, "plans.sh"), "utf-8");
     // Both "nothing to do" messages should include the hint
     expect(plans).toContain(
-      "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md",
+      "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/<slug>.md — see .ralphai/PLANNING.md",
     );
     expect(plans).toContain(
-      "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/<slug>/<slug>.md — see .ralphai/PLANNING.md",
+      "Nothing to do — issue pull produced no plan file. Add plans to .ralphai/pipeline/backlog/<slug>.md — see .ralphai/PLANNING.md",
     );
   });
 
@@ -459,7 +459,6 @@ describe("init command", () => {
       ".ralphai",
       "pipeline",
       "backlog",
-      "hello-ralphai",
       "hello-ralphai.md",
     );
     expect(existsSync(samplePlanPath)).toBe(true);
@@ -469,14 +468,7 @@ describe("init command", () => {
     runCliOutput(["init", "--yes"], ctx.dir);
 
     const samplePlan = readFileSync(
-      join(
-        ctx.dir,
-        ".ralphai",
-        "pipeline",
-        "backlog",
-        "hello-ralphai",
-        "hello-ralphai.md",
-      ),
+      join(ctx.dir, ".ralphai", "pipeline", "backlog", "hello-ralphai.md"),
       "utf-8",
     );
 
@@ -507,7 +499,6 @@ describe("init command", () => {
       ".ralphai",
       "pipeline",
       "backlog",
-      "hello-ralphai",
       "hello-ralphai.md",
     );
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -757,16 +757,14 @@ function scaffold(
   }
 
   // Write sample plan if requested
-  const samplePlanDir = join(
+  const samplePlanPath = join(
     ralphaiDir,
     "pipeline",
     "backlog",
-    "hello-ralphai",
+    "hello-ralphai.md",
   );
-  const samplePlanPath = join(samplePlanDir, "hello-ralphai.md");
   const samplePlanCreated = answers.createSamplePlan === true;
   if (samplePlanCreated && !existsSync(samplePlanPath)) {
-    mkdirSync(samplePlanDir, { recursive: true });
     const samplePlanContent = `# Plan: Hello Ralphai
 
 > A tiny first plan to verify the full Ralphai loop — init, run, commit.
@@ -826,7 +824,7 @@ Each entry should include:
   const agentsMdSection = `## Ralphai
 
 This project uses [Ralphai](https://github.com/mfaux/ralphai) for autonomous task execution.
-Plan files go in per-plan folders under \`.ralphai/pipeline/backlog/\`. See \`.ralphai/PLANNING.md\` for
+Plan files go in \`.ralphai/pipeline/backlog/\`. See \`.ralphai/PLANNING.md\` for
 the plan writing guide.
 `;
 
@@ -1047,14 +1045,18 @@ async function runRalphaiReset(
 
   let actions = 0;
 
-  // 1. Move plan folders back to backlog (remove progress/receipt first)
+  // 1. Extract plan files from in-progress slug-folders back to backlog as flat files
   for (const slug of planSlugs) {
     const src = join(inProgressDir, slug);
-    const dest = join(backlogDir, slug);
+    const planFile = join(src, `${slug}.md`);
+    const dest = join(backlogDir, `${slug}.md`);
     mkdirSync(backlogDir, { recursive: true });
     rmSync(join(src, "progress.md"), { force: true });
     rmSync(join(src, "receipt.txt"), { force: true });
-    renameSync(src, dest);
+    if (existsSync(planFile)) {
+      renameSync(planFile, dest);
+    }
+    rmSync(src, { recursive: true, force: true });
     actions++;
   }
 
@@ -1699,8 +1701,7 @@ function selectPlanForWorktree(
     planFile: string,
   ): string | null => {
     const slug = planFile.replace(/\.md$/, "");
-    const candidate = planPathForSlug(baseDir, slug);
-    return existsSync(candidate) ? candidate : null;
+    return resolvePlanPath(baseDir, slug);
   };
 
   // --- Specific plan requested ---
@@ -1746,7 +1747,7 @@ function selectPlanForWorktree(
   }
 
   // No unattended plans — check backlog for new work
-  const backlogPlans = listPlanFiles(backlogDir);
+  const backlogPlans = listPlanFiles(backlogDir, true);
 
   if (backlogPlans.length > 0) {
     const firstPlan = backlogPlans[0]!;
@@ -1906,7 +1907,7 @@ function showWorktreeHelp(): void {
 }
 
 /**
- * Check if a plan directory in `dir` matches the given slug.
+ * List subdirectory names in `dir`.
  */
 function listPlanFolders(dir: string): string[] {
   if (!existsSync(dir)) return [];
@@ -1923,18 +1924,64 @@ function planPathForSlug(dir: string, slug: string): string {
   return join(dir, slug, `${slug}.md`);
 }
 
-function listPlanSlugs(dir: string): string[] {
-  return listPlanFolders(dir).filter((slug) =>
-    existsSync(planPathForSlug(dir, slug)),
-  );
+/**
+ * List plan slugs in `dir`.
+ * - Slug-folder plans (`<slug>/<slug>.md`): used by in-progress and out.
+ * - Flat `.md` files (`<slug>.md`): used by backlog.
+ * Pass `flatOnly: true` for backlog to skip slug-folder scanning.
+ */
+function listPlanSlugs(dir: string, flatOnly = false): string[] {
+  if (!existsSync(dir)) return [];
+  const seen = new Set<string>();
+  const slugs: string[] = [];
+
+  // Slug-folder plans: <dir>/<slug>/<slug>.md (in-progress, out)
+  if (!flatOnly) {
+    for (const folder of listPlanFolders(dir)) {
+      if (existsSync(planPathForSlug(dir, folder))) {
+        seen.add(folder);
+        slugs.push(folder);
+      }
+    }
+  }
+
+  // Flat files: <dir>/<slug>.md (backlog)
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      const slug = entry.name.replace(/\.md$/, "");
+      if (!seen.has(slug)) {
+        seen.add(slug);
+        slugs.push(slug);
+      }
+    }
+  } catch {
+    // ignore read errors
+  }
+
+  return slugs;
 }
 
-function listPlanFiles(dir: string): string[] {
-  return listPlanSlugs(dir).map((slug) => `${slug}.md`);
+function listPlanFiles(dir: string, flatOnly = false): string[] {
+  return listPlanSlugs(dir, flatOnly).map((slug) => `${slug}.md`);
+}
+
+/**
+ * Resolve the path to a plan file for a given slug in `dir`.
+ * Checks slug-folder (`<dir>/<slug>/<slug>.md`) for in-progress/out,
+ * then flat file (`<dir>/<slug>.md`) for backlog.
+ * Returns the path if found, null otherwise.
+ */
+function resolvePlanPath(dir: string, slug: string): string | null {
+  const folderPath = planPathForSlug(dir, slug);
+  if (existsSync(folderPath)) return folderPath;
+  const flatPath = join(dir, `${slug}.md`);
+  if (existsSync(flatPath)) return flatPath;
+  return null;
 }
 
 function planExistsForSlug(dir: string, slug: string): boolean {
-  return existsSync(planPathForSlug(dir, slug));
+  return resolvePlanPath(dir, slug) !== null;
 }
 
 function listWorktrees(cwd: string): void {
@@ -2195,7 +2242,7 @@ function checkBacklogHasPlans(cwd: string): DoctorCheckResult {
   if (!existsSync(backlogDir)) {
     return { status: "warn", message: "backlog: directory not found" };
   }
-  const plans = listPlanSlugs(backlogDir);
+  const plans = listPlanSlugs(backlogDir, true);
   if (plans.length === 0) {
     return { status: "warn", message: "backlog: no plans queued" };
   }
@@ -2390,7 +2437,7 @@ function runRalphaiStatus(cwd: string): void {
   const archiveDir = join(ralphaiDir, "pipeline", "out");
 
   // --- Collect data ---
-  const backlogPlans = listPlanFiles(backlogDir);
+  const backlogPlans = listPlanFiles(backlogDir, true);
 
   const inProgressPlans = listPlanFiles(inProgressDir);
   const receiptFiles = listPlanFolders(inProgressDir).filter((slug) =>
@@ -2420,9 +2467,9 @@ function runRalphaiStatus(cwd: string): void {
   );
   for (const plan of backlogPlans) {
     let suffix = "";
-    const deps = extractDependsOn(
-      join(backlogDir, plan.replace(/\.md$/, ""), plan),
-    );
+    const slug = plan.replace(/\.md$/, "");
+    const planPath = resolvePlanPath(backlogDir, slug);
+    const deps = planPath ? extractDependsOn(planPath) : [];
     if (deps.length > 0) {
       suffix = `${DIM}waiting on ${deps.join(", ")}${RESET}`;
     }

--- a/src/runner-config.test.ts
+++ b/src/runner-config.test.ts
@@ -1388,15 +1388,14 @@ echo "$MODE"
       });
 
       // Remove sample plan so the backlog is empty for this test
-      const samplePlanDir = join(
+      const samplePlanFile = join(
         ctx.dir,
         ".ralphai",
         "pipeline",
         "backlog",
-        "hello-ralphai",
+        "hello-ralphai.md",
       );
-      if (existsSync(samplePlanDir))
-        rmSync(samplePlanDir, { recursive: true, force: true });
+      if (existsSync(samplePlanFile)) rmSync(samplePlanFile, { force: true });
 
       const output = execFileSync(
         "node",

--- a/src/status-doctor.test.ts
+++ b/src/status-doctor.test.ts
@@ -310,16 +310,12 @@ describe("status subcommand", () => {
     runCli(["init", "--yes"], ctx.dir);
 
     const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
-    const authDir = join(backlogDir, "prd-auth");
-    const searchDir = join(backlogDir, "prd-search");
-    mkdirSync(authDir, { recursive: true });
-    mkdirSync(searchDir, { recursive: true });
     writeFileSync(
-      join(authDir, "prd-auth.md"),
+      join(backlogDir, "prd-auth.md"),
       "# Auth\n\n### Task 1: Login\n### Task 2: Signup\n",
     );
     writeFileSync(
-      join(searchDir, "prd-search.md"),
+      join(backlogDir, "prd-search.md"),
       "---\ndepends-on: [prd-auth.md]\n---\n\n# Search\n\n### Task 1: Index\n",
     );
 

--- a/src/teardown-reset.test.ts
+++ b/src/teardown-reset.test.ts
@@ -75,19 +75,18 @@ describe("reset command", () => {
     const output = stripLogo(runCliOutput(["reset", "--yes"], ctx.dir));
 
     expect(output).toContain("Pipeline reset");
-    // Plan should be back in backlog
+    // Plan should be back in backlog as a flat file
     expect(
       existsSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "backlog",
-          "prd-my-feature",
-          "prd-my-feature.md",
-        ),
+        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-my-feature.md"),
       ),
     ).toBe(true);
+    // Slug-folder should NOT exist in backlog
+    expect(
+      existsSync(
+        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-my-feature"),
+      ),
+    ).toBe(false);
     // Plan should NOT be in in-progress
     expect(existsSync(join(inProgressDir, "prd-my-feature"))).toBe(false);
   });
@@ -149,31 +148,28 @@ describe("reset command", () => {
     expect(output).toContain("2 plans moved to backlog");
     expect(output).toContain("Deleted progress.md and receipt.txt in 2 plans");
 
-    // Both plans should be in backlog
+    // Both plans should be in backlog as flat files
     expect(
       existsSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "backlog",
-          "prd-feature-a",
-          "prd-feature-a.md",
-        ),
+        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-feature-a.md"),
       ),
     ).toBe(true);
     expect(
       existsSync(
-        join(
-          ctx.dir,
-          ".ralphai",
-          "pipeline",
-          "backlog",
-          "prd-feature-b",
-          "prd-feature-b.md",
-        ),
+        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-feature-b.md"),
       ),
     ).toBe(true);
+    // Slug-folders should NOT exist in backlog
+    expect(
+      existsSync(
+        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-feature-a"),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(
+        join(ctx.dir, ".ralphai", "pipeline", "backlog", "prd-feature-b"),
+      ),
+    ).toBe(false);
 
     // in-progress should be clean (empty)
     const remaining = readdirSync(inProgressDir);

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -336,9 +336,8 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
       // Initialize ralphai so the worktree guard runs (it checks before .ralphai)
       // Create a minimal .ralphai in main repo so worktree resolves
       const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
-      const planDir = join(backlogDir, "prd-test");
-      mkdirSync(planDir, { recursive: true });
-      writeFileSync(join(planDir, "prd-test.md"), "# Test plan\n");
+      mkdirSync(backlogDir, { recursive: true });
+      writeFileSync(join(backlogDir, "prd-test.md"), "# Test plan\n");
 
       const result = runCli(["worktree"], worktreeDir);
       expect(result.exitCode).not.toBe(0);
@@ -468,12 +467,9 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
 
       // Create .ralphai with two plans
       const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
-      const firstDir = join(backlogDir, "prd-first");
-      const secondDir = join(backlogDir, "prd-second");
-      mkdirSync(firstDir, { recursive: true });
-      mkdirSync(secondDir, { recursive: true });
-      writeFileSync(join(firstDir, "prd-first.md"), "# First\n");
-      writeFileSync(join(secondDir, "prd-second.md"), "# Second\n");
+      mkdirSync(backlogDir, { recursive: true });
+      writeFileSync(join(backlogDir, "prd-first.md"), "# First\n");
+      writeFileSync(join(backlogDir, "prd-second.md"), "# Second\n");
 
       // Use a stub runner that just exits 0
       const stubScript = join(ctx.dir, "stub-runner.sh");
@@ -497,9 +493,11 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
 
       // Create .ralphai with a plan
       const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
-      const planDir = join(backlogDir, "prd-symlink-test");
-      mkdirSync(planDir, { recursive: true });
-      writeFileSync(join(planDir, "prd-symlink-test.md"), "# Symlink test\n");
+      mkdirSync(backlogDir, { recursive: true });
+      writeFileSync(
+        join(backlogDir, "prd-symlink-test.md"),
+        "# Symlink test\n",
+      );
 
       // Use a stub runner that just exits 0
       const stubScript = join(ctx.dir, "stub-runner.sh");
@@ -534,10 +532,9 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
 
       // Create .ralphai with a plan
       const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
-      const planDir = join(backlogDir, "prd-config-symlink");
-      mkdirSync(planDir, { recursive: true });
+      mkdirSync(backlogDir, { recursive: true });
       writeFileSync(
-        join(planDir, "prd-config-symlink.md"),
+        join(backlogDir, "prd-config-symlink.md"),
         "# Config symlink test\n",
       );
 
@@ -578,10 +575,9 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
 
       // Create .ralphai with a plan
       const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
-      const planDir = join(backlogDir, "prd-committed-cfg");
-      mkdirSync(planDir, { recursive: true });
+      mkdirSync(backlogDir, { recursive: true });
       writeFileSync(
-        join(planDir, "prd-committed-cfg.md"),
+        join(backlogDir, "prd-committed-cfg.md"),
         "# Committed config test\n",
       );
 
@@ -620,9 +616,11 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
 
       // Create .ralphai with a plan (not git-tracked since .ralphai/ is gitignored)
       const backlogDir = join(ctx.dir, ".ralphai", "pipeline", "backlog");
-      const planDir = join(backlogDir, "prd-tracked-test");
-      mkdirSync(planDir, { recursive: true });
-      writeFileSync(join(planDir, "prd-tracked-test.md"), "# Tracked test\n");
+      mkdirSync(backlogDir, { recursive: true });
+      writeFileSync(
+        join(backlogDir, "prd-tracked-test.md"),
+        "# Tracked test\n",
+      );
 
       // Use a stub runner that just exits 0
       const stubScript = join(ctx.dir, "stub-runner.sh");

--- a/templates/ralphai/PLANNING.md
+++ b/templates/ralphai/PLANNING.md
@@ -1,6 +1,6 @@
 # Writing Ralphai Plan Files
 
-Guide for coding agents writing plan files that Ralphai executes autonomously. Plans go in `.ralphai/pipeline/backlog/<slug>/<slug>.md`.
+Guide for coding agents writing plan files that Ralphai executes autonomously. Plans go in `.ralphai/pipeline/backlog/<slug>.md`.
 
 ## How to Write a Plan
 
@@ -11,7 +11,7 @@ Guide for coding agents writing plan files that Ralphai executes autonomously. P
    - **[Refactor](plans/refactor.md)** — structural change, no behavior change
 3. **Explore the codebase.** Before writing anything, find the files, functions, and line numbers relevant to the work. The plan must contain concrete references, not guesses.
 4. **Fill in the template.** Follow the guide's template. Every file path, function name, and line number you include saves Ralphai tokens it would otherwise spend exploring.
-5. **Write the plan file** to `.ralphai/pipeline/backlog/<slug>/<slug>.md`.
+5. **Write the plan file** to `.ralphai/pipeline/backlog/<slug>.md`.
 
 ## Core Principles
 

--- a/templates/ralphai/README.md
+++ b/templates/ralphai/README.md
@@ -23,7 +23,7 @@ parked/    backlog/  →  in-progress/  →  out/
 ```
 
 1. **`parked/`** — Not ready. Ralphai ignores this directory.
-2. **`backlog/`** — Queued plans. Each plan lives in its own folder (for example `backlog/<slug>/<slug>.md`).
+2. **`backlog/`** — Queued plans (for example `backlog/my-plan.md`). The runner creates a slug folder automatically when moving a plan to `in-progress/`.
 3. **`in-progress/`** — Active work. Plan folder + `progress.md` live here (for example `in-progress/<slug>/`). Files stay on interruption for resumption.
 4. **`out/`** — Archive. Plan folders move here when the agent signals completion.
 
@@ -84,7 +84,7 @@ Requires `gh` CLI. If `gh` is unavailable, hooks are silently skipped.
 | `LEARNINGS.md`           | Auto-written learnings (local-only) |
 | `LEARNING_CANDIDATES.md` | Candidate lessons for human review  |
 | `pipeline/parked/`       | Parked plans                        |
-| `pipeline/backlog/`      | Queued plan folders                 |
+| `pipeline/backlog/`      | Queued plan files                   |
 | `pipeline/in-progress/`  | Active plan folders + `progress.md` |
 | `pipeline/out/`          | Completed plan folders archive      |
 


### PR DESCRIPTION
## Summary

- Allow plan files to live as flat `.md` files directly in `.ralphai/pipeline/backlog/` instead of requiring `<slug>/<slug>.md` subdirectories. The slug folder is created automatically when a plan moves from backlog to in-progress.
- Slug-folder plans in backlog continue to work (backward compatible). When both formats exist for the same slug, slug-folder wins.
- `ralphai init` now creates the sample plan as a flat file (`hello-ralphai.md`).

## Changes

**Bash runner (`runner/`):**
- `plans.sh` — Added `collect_backlog_plans()` for unified discovery. Rewrote move logic to detect flat files and promote them into slug directories in `in-progress/`. Updated `dependency_status()` to check flat backlog files.
- `ralphai.sh` — Updated patch-mode backlog scan to use `collect_backlog_plans`.
- `pr.sh` — Updated remaining plans scan to use `collect_backlog_plans`.

**TypeScript (`src/ralphai.ts`):**
- Rewrote `listPlanSlugs()` to discover both formats with deduplication.
- Added `resolvePlanPath()` helper for slug-folder-then-flat resolution.
- Updated `planExistsForSlug()`, `selectPlanForWorktree()`, `scaffold()`, status display, and AGENTS.md section text.

**Tests:**
- New `src/flat-backlog.test.ts` with 8 tests covering flat file discovery, slug-folder backward compat, deduplication, promotion via dry-run, dependency display, and doctor detection.
- Updated 5 existing tests for new sample plan path and messages.

**Docs:**
- Updated `README.md`, `AGENTS.md`, `docs/how-ralphai-works.md`, `templates/ralphai/PLANNING.md`, `templates/ralphai/README.md`.

## Verification

- `pnpm build && pnpm test && pnpm type-check` all pass (288 tests)