### PR TITLE
fix: remove private field to unblock npm publish of v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,5 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "bun@1.3.10",
-  "private": true
+  "packageManager": "bun@1.3.10"
 }


### PR DESCRIPTION
## Summary
- The v0.6.0 publish workflow failed because `package.json` had `"private": true`, which causes npm to reject publishing regardless of `--access public`.
- Removes the `private` field so npm publish can succeed.