### PR TITLE
Warn when worktree has non-symlinked .ralphai/ directory

### DIFF
--- a/runner/lib/defaults.sh
+++ b/runner/lib/defaults.sh
@@ -76,6 +76,15 @@ if [[ "$RALPHAI_IS_WORKTREE" == true ]]; then
     PARKED_DIR="$RALPHAI_MAIN_WORKTREE/.ralphai/pipeline/parked"
     CONFIG_FILE="$RALPHAI_MAIN_WORKTREE/ralphai.json"
     PROGRESS_FILE="$WIP_DIR/<slug>/progress.md"
+
+    # Warn if .ralphai/ exists as a real directory — plans there will be ignored.
+    if [[ -d ".ralphai" ]]; then
+      echo "WARNING: .ralphai/ exists in this worktree but is not a symlink."
+      echo "  Pipeline dirs resolve to the main repo: $RALPHAI_MAIN_WORKTREE/.ralphai/"
+      echo "  Plans in $(pwd)/.ralphai/pipeline/backlog/ will be ignored."
+      echo "  Fix: replace with a symlink, or use 'ralphai worktree' to create worktrees."
+      echo ""
+    fi
   fi
 fi
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1,6 +1,7 @@
 import { execSync, spawn } from "child_process";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   copyFileSync,
   writeFileSync,
@@ -2612,6 +2613,31 @@ function checkOrphanedReceipts(cwd: string): DoctorCheckResult {
   return { status: "pass", message: "no orphaned receipts" };
 }
 
+function checkWorktreeSymlink(cwd: string): DoctorCheckResult {
+  if (!isGitWorktree(cwd)) {
+    return {
+      status: "pass",
+      message: "not a worktree (symlink check skipped)",
+    };
+  }
+  const ralphaiPath = join(cwd, ".ralphai");
+  if (!existsSync(ralphaiPath)) {
+    return { status: "pass", message: "worktree: no local .ralphai/ (ok)" };
+  }
+  try {
+    if (lstatSync(ralphaiPath).isSymbolicLink()) {
+      return { status: "pass", message: "worktree: .ralphai/ is a symlink" };
+    }
+  } catch {
+    return { status: "pass", message: "worktree: .ralphai/ check skipped" };
+  }
+  return {
+    status: "warn",
+    message:
+      ".ralphai/ is a directory in this worktree (not a symlink) — local plans will be ignored",
+  };
+}
+
 function runRalphaiDoctor(cwd: string): void {
   const results: DoctorCheckResult[] = [];
 
@@ -2623,6 +2649,11 @@ function runRalphaiDoctor(cwd: string): void {
 
   // 3. Git repo detected
   results.push(checkGitRepo(cwd));
+
+  // 3b. Worktree .ralphai/ symlink check (only if git repo detected)
+  if (results[2]!.status !== "fail") {
+    results.push(checkWorktreeSymlink(cwd));
+  }
 
   // 4. Working tree clean (only if git repo detected)
   if (results[2]!.status !== "fail") {

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -892,3 +892,107 @@ echo "PROGRESS_FILE=$PROGRESS_FILE"
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Doctor: worktree .ralphai/ symlink check
+// ---------------------------------------------------------------------------
+
+describe.skipIf(process.platform === "win32")(
+  "doctor worktree symlink check",
+  () => {
+    let mainRepo: string;
+    let worktreeDir: string;
+
+    beforeEach(() => {
+      mainRepo = join(
+        tmpdir(),
+        `ralphai-doc-wt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      mkdirSync(mainRepo, { recursive: true });
+      execSync("git init", { cwd: mainRepo, stdio: "ignore" });
+      execSync("git config user.name 'Test'", {
+        cwd: mainRepo,
+        stdio: "ignore",
+      });
+      execSync("git config user.email 'test@test.com'", {
+        cwd: mainRepo,
+        stdio: "ignore",
+      });
+      execSync("git checkout -b main", { cwd: mainRepo, stdio: "ignore" });
+      writeFileSync(join(mainRepo, "seed.txt"), "seed");
+      execSync("git add -A && git commit -m init", {
+        cwd: mainRepo,
+        stdio: "ignore",
+      });
+
+      // Initialize ralphai in the main repo
+      runCli(["init", "--yes"], mainRepo);
+      // Set agentCommand to something in PATH so doctor doesn't fail on that
+      const configPath = join(mainRepo, "ralphai.json");
+      const config = JSON.parse(readFileSync(configPath, "utf-8"));
+      config.agentCommand = "true";
+      config.feedbackCommands = ["true"];
+      writeFileSync(configPath, JSON.stringify(config, null, 2));
+      execSync("git add -A && git commit -m 'add ralphai'", {
+        cwd: mainRepo,
+        stdio: "ignore",
+      });
+
+      // Create a worktree
+      worktreeDir = join(
+        tmpdir(),
+        `ralphai-doc-tree-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      execSync(
+        `git worktree add ${JSON.stringify(worktreeDir)} -b ralphai/test-wt`,
+        { cwd: mainRepo, stdio: "ignore" },
+      );
+    });
+
+    afterEach(() => {
+      try {
+        execSync(`git worktree remove ${JSON.stringify(worktreeDir)} --force`, {
+          cwd: mainRepo,
+          stdio: "ignore",
+        });
+      } catch {
+        /* ignore */
+      }
+      if (existsSync(mainRepo)) {
+        rmSync(mainRepo, { recursive: true, force: true });
+      }
+      if (existsSync(worktreeDir)) {
+        rmSync(worktreeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("doctor warns when worktree has a real .ralphai/ directory (not a symlink)", () => {
+      // Place a real .ralphai/ directory in the worktree (not a symlink)
+      mkdirSync(join(worktreeDir, ".ralphai", "pipeline", "backlog"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(worktreeDir, ".ralphai", "pipeline", "backlog", "my-plan.md"),
+        "# Plan\n",
+      );
+
+      const result = runCli(["doctor"], worktreeDir, { NO_COLOR: "1" });
+      const output = result.stdout;
+
+      expect(output).toContain("not a symlink");
+      expect(output).toContain("local plans will be ignored");
+      expect(output).toContain("\u26A0"); // warning sign
+    });
+
+    it("doctor does not warn when worktree has .ralphai/ as a symlink", () => {
+      // Create a proper symlink in the worktree
+      symlinkSync(join(mainRepo, ".ralphai"), join(worktreeDir, ".ralphai"));
+
+      const result = runCli(["doctor"], worktreeDir, { NO_COLOR: "1" });
+      const output = result.stdout;
+
+      expect(output).not.toContain("not a symlink");
+      expect(output).toContain(".ralphai/ is a symlink");
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- When running in a git worktree where `.ralphai/` exists as a real directory (not a symlink), the runner silently resolves all pipeline paths to the main repo. This causes local backlog plans to be invisible, producing a confusing "backlog is empty" message.
- Adds a `WARNING:` message in the bash runner (`defaults.sh`) when this condition is detected, telling the user their local plans will be ignored and suggesting fixes.
- Adds a new `checkWorktreeSymlink` doctor check that flags the same condition as a warning in `ralphai doctor`.
- Adds 2 new tests in `worktree.test.ts` covering both the warning case and the symlink-present case.