### PR TITLE
Remove external tool deps for cross-platform portability

### DIFF
--- a/runner/lib/config.sh
+++ b/runner/lib/config.sh
@@ -3,7 +3,7 @@
 # and apply_env_overrides(). CLI parsing is in cli.sh.
 
 # --- Config file loader ---
-# Parses ralphai.json (JSON format via jq).
+# Parses ralphai.json (JSON format via Node.js).
 # Sets CONFIG_AGENT_COMMAND, CONFIG_FEEDBACK_COMMANDS, CONFIG_BASE_BRANCH,
 # CONFIG_MAX_STUCK, CONFIG_MODE, CONFIG_PROMPT_MODE when present.
 # Fails fast on unknown keys or invalid values.
@@ -16,14 +16,14 @@ load_config() {
   fi
 
   # Validate JSON syntax
-  if ! jq empty "$config_path" 2>/dev/null; then
+  if ! _json_q "" "$config_path" 2>/dev/null; then
     echo "ERROR: $config_path: invalid JSON"
     exit 1
   fi
 
   # Must be a JSON object
   local json_type
-  json_type=$(jq -r 'type' "$config_path")
+  json_type=$(_json_q "const t=typeof data; console.log(data===null?'null':Array.isArray(data)?'array':t)" "$config_path")
   if [[ "$json_type" != "object" ]]; then
     echo "ERROR: $config_path: expected a JSON object, got $json_type"
     exit 1
@@ -31,7 +31,10 @@ load_config() {
 
   # Check for unknown keys
   local unknown_keys
-  unknown_keys=$(jq -r 'keys[] | select(. as $k | ["agentCommand","feedbackCommands","baseBranch","maxStuck","mode","issueSource","issueLabel","issueInProgressLabel","issueRepo","issueCommentProgress","turnTimeout","promptMode","continuous","autoCommit","turns","maxLearnings","workspaces"] | index($k) | not)' "$config_path")
+  unknown_keys=$(_json_q "
+    const allowed = ['agentCommand','feedbackCommands','baseBranch','maxStuck','mode','issueSource','issueLabel','issueInProgressLabel','issueRepo','issueCommentProgress','turnTimeout','promptMode','continuous','autoCommit','turns','maxLearnings','workspaces'];
+    Object.keys(data).filter(k => !allowed.includes(k)).forEach(k => console.log(k));
+  " "$config_path")
   if [[ -n "$unknown_keys" ]]; then
     local first_unknown
     first_unknown=$(echo "$unknown_keys" | head -1)
@@ -40,17 +43,17 @@ load_config() {
 
   # Helper: read a string value from JSON (returns empty if key is missing or null)
   _json_str() {
-    jq -r "if has(\"$1\") then .$1 // \"\" else \"\" end" "$config_path"
+    _json_q "const v = data[process.argv[2]]; console.log(v == null ? '' : String(v))" "$config_path" "$1"
   }
 
   # Helper: read a raw value (preserves type info for validation)
   _json_raw() {
-    jq -r "if has(\"$1\") then (.$1 | tostring) else \"\" end" "$config_path"
+    _json_q "const v = data[process.argv[2]]; console.log(v === undefined ? '' : String(v))" "$config_path" "$1"
   }
 
   # Helper: check if key exists
   _json_has() {
-    jq -e "has(\"$1\")" "$config_path" >/dev/null 2>&1
+    _json_q "process.exit(process.argv[2] in data ? 0 : 1)" "$config_path" "$1"
   }
 
   local value
@@ -68,10 +71,10 @@ load_config() {
   # --- feedbackCommands (array of strings or comma-separated string) ---
   if _json_has "feedbackCommands"; then
     local fc_type
-    fc_type=$(jq -r '.feedbackCommands | type' "$config_path")
+    fc_type=$(_json_q "const v = data.feedbackCommands; console.log(Array.isArray(v) ? 'array' : typeof v)" "$config_path")
     if [[ "$fc_type" == "array" ]]; then
       # Join array elements with commas (matches internal format)
-      value=$(jq -r '.feedbackCommands | join(",")' "$config_path")
+      value=$(_json_q "console.log(data.feedbackCommands.join(','))" "$config_path")
       validate_comma_list "$value" "$config_path: 'feedbackCommands' array"
     elif [[ "$fc_type" == "string" ]]; then
       value=$(_json_str "feedbackCommands")
@@ -197,34 +200,34 @@ load_config() {
   # --- workspaces (object of per-package overrides) ---
   if _json_has "workspaces"; then
     local ws_type
-    ws_type=$(jq -r '.workspaces | type' "$config_path")
+    ws_type=$(_json_q "const v = data.workspaces; console.log(v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v)" "$config_path")
     if [[ "$ws_type" != "object" ]]; then
       echo "ERROR: $config_path: 'workspaces' must be an object, got $ws_type"
       exit 1
     fi
     # Validate each workspace entry is an object with valid feedbackCommands
     local ws_keys
-    ws_keys=$(jq -r '.workspaces | keys[]' "$config_path")
+    ws_keys=$(_json_q "Object.keys(data.workspaces).forEach(k => console.log(k))" "$config_path")
     while IFS= read -r ws_key; do
       [[ -z "$ws_key" ]] && continue
       local ws_entry_type
-      ws_entry_type=$(jq -r --arg k "$ws_key" '.workspaces[$k] | type' "$config_path")
+      ws_entry_type=$(_json_q "const v = data.workspaces[process.argv[2]]; console.log(v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v)" "$config_path" "$ws_key")
       if [[ "$ws_entry_type" != "object" ]]; then
         echo "ERROR: $config_path: workspaces['$ws_key'] must be an object, got $ws_entry_type"
         exit 1
       fi
       # Validate feedbackCommands if present
-      if jq -e --arg k "$ws_key" '.workspaces[$k] | has("feedbackCommands")' "$config_path" >/dev/null 2>&1; then
+      if _json_q "process.exit('feedbackCommands' in data.workspaces[process.argv[2]] ? 0 : 1)" "$config_path" "$ws_key"; then
         local ws_fc_type
-        ws_fc_type=$(jq -r --arg k "$ws_key" '.workspaces[$k].feedbackCommands | type' "$config_path")
+        ws_fc_type=$(_json_q "const v = data.workspaces[process.argv[2]].feedbackCommands; console.log(Array.isArray(v) ? 'array' : typeof v)" "$config_path" "$ws_key")
         if [[ "$ws_fc_type" != "array" && "$ws_fc_type" != "string" ]]; then
           echo "ERROR: $config_path: workspaces['$ws_key'].feedbackCommands must be an array of strings or a comma-separated string, got $ws_fc_type"
           exit 1
         fi
       fi
     done <<< "$ws_keys"
-    # Store the raw JSON for later jq queries at scope-resolution time
-    CONFIG_WORKSPACES=$(jq -c '.workspaces' "$config_path")
+    # Store the raw JSON for later queries at scope-resolution time
+    CONFIG_WORKSPACES=$(_json_q "console.log(JSON.stringify(data.workspaces))" "$config_path")
   fi
 }
 

--- a/runner/lib/json.sh
+++ b/runner/lib/json.sh
@@ -1,0 +1,34 @@
+# json.sh — JSON helpers using Node.js (no jq dependency).
+# Sourced by ralphai.sh before config.sh.
+#
+# Node.js is always available because ralphai is an npm package.
+# These helpers replace the previous jq dependency, which required
+# users to install jq separately (and produced misleading errors
+# when it was missing).
+
+# _json_q <js_expression> <file> [extra_args...]
+#   Reads JSON from <file>, binds it to `data`, evaluates <js_expression>.
+#   Extra args are available as process.argv[2], process.argv[3], etc.
+#   Returns non-zero if the file contains invalid JSON.
+_json_q() {
+  local expr="$1" file="$2"
+  shift 2
+  node -e "
+    const data = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf-8'));
+    $expr
+  " "$file" "$@"
+}
+
+# _json_q_stdin <js_expression> [extra_args...]
+#   Same as _json_q but reads JSON from stdin instead of a file.
+#   Extra args are available as process.argv[1], process.argv[2], etc.
+_json_q_stdin() {
+  local expr="$1"
+  shift
+  node -e "
+    let d = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', c => d += c);
+    process.stdin.on('end', () => { const data = JSON.parse(d); $expr });
+  " "$@"
+}

--- a/runner/lib/receipt.sh
+++ b/runner/lib/receipt.sh
@@ -76,7 +76,7 @@ update_receipt_turn() {
   current=$(sed -n 's/^turns_completed=//p' "$RECEIPT_FILE")
   current=${current:-0}
   local next=$((current + 1))
-  sed -i "s/^turns_completed=.*/turns_completed=$next/" "$RECEIPT_FILE"
+  sed "s/^turns_completed=.*/turns_completed=$next/" "$RECEIPT_FILE" > "$RECEIPT_FILE.tmp" && mv "$RECEIPT_FILE.tmp" "$RECEIPT_FILE"
 }
 
 # --- Recount tasks_completed from progress.md ---
@@ -112,7 +112,7 @@ update_receipt_tasks() {
 
   # Update or append tasks_completed in the receipt
   if grep -q '^tasks_completed=' "$RECEIPT_FILE"; then
-    sed -i "s/^tasks_completed=.*/tasks_completed=$count/" "$RECEIPT_FILE"
+    sed "s/^tasks_completed=.*/tasks_completed=$count/" "$RECEIPT_FILE" > "$RECEIPT_FILE.tmp" && mv "$RECEIPT_FILE.tmp" "$RECEIPT_FILE"
   else
     echo "tasks_completed=$count" >> "$RECEIPT_FILE"
   fi

--- a/runner/lib/scope.sh
+++ b/runner/lib/scope.sh
@@ -60,11 +60,13 @@ resolve_scoped_feedback() {
   # Check for workspace override first
   if [[ -n "$CONFIG_WORKSPACES" ]]; then
     local ws_fc
-    ws_fc=$(echo "$CONFIG_WORKSPACES" | jq -r --arg scope "$PLAN_SCOPE" '
-      if has($scope) and .[$scope].feedbackCommands then
-        (.[$scope].feedbackCommands | if type == "array" then join(",") else . end)
-      else empty end
-    ' 2>/dev/null) || ws_fc=""
+    ws_fc=$(echo "$CONFIG_WORKSPACES" | _json_q_stdin "
+      const scope = process.argv[1];
+      if (scope in data && data[scope].feedbackCommands) {
+        const fc = data[scope].feedbackCommands;
+        console.log(Array.isArray(fc) ? fc.join(',') : fc);
+      }
+    " "$PLAN_SCOPE" 2>/dev/null) || ws_fc=""
 
     if [[ -n "$ws_fc" ]]; then
       FEEDBACK_COMMANDS="$ws_fc"
@@ -86,7 +88,7 @@ resolve_scoped_feedback() {
   fi
 
   local pkg_name
-  pkg_name=$(jq -r '.name // empty' "$pkg_json" 2>/dev/null) || pkg_name=""
+  pkg_name=$(_json_q "if (data.name) console.log(data.name)" "$pkg_json" 2>/dev/null) || pkg_name=""
   if [[ -z "$pkg_name" ]]; then
     return 0
   fi

--- a/runner/lib/show_config.sh
+++ b/runner/lib/show_config.sh
@@ -132,7 +132,13 @@ if [[ "$SHOW_CONFIG" == true ]]; then
     if [[ -n "${CONFIG_WORKSPACES:-}" ]]; then
       echo ""
       echo "Workspaces (per-package overrides):"
-      echo "$CONFIG_WORKSPACES" | jq -r 'to_entries[] | "  \(.key): feedbackCommands=\(.value.feedbackCommands // "none" | if type == "array" then join(", ") else . end)"' 2>/dev/null || true
+      echo "$CONFIG_WORKSPACES" | _json_q_stdin "
+        Object.entries(data).forEach(([k, v]) => {
+          const fc = v.feedbackCommands;
+          const s = fc == null ? 'none' : Array.isArray(fc) ? fc.join(', ') : String(fc);
+          console.log('  ' + k + ': feedbackCommands=' + s);
+        });
+      " 2>/dev/null || true
     fi
   else
     echo "Config file: $CONFIG_FILE (not found, using defaults)"

--- a/runner/ralphai.sh
+++ b/runner/ralphai.sh
@@ -23,6 +23,7 @@ set -e
 RALPHAI_LIB_DIR="$(dirname "$0")/lib"
 source "$RALPHAI_LIB_DIR/defaults.sh"
 source "$RALPHAI_LIB_DIR/validate.sh"
+source "$RALPHAI_LIB_DIR/json.sh"
 source "$RALPHAI_LIB_DIR/config.sh"
 source "$RALPHAI_LIB_DIR/cli.sh"
 source "$RALPHAI_LIB_DIR/show_config.sh"
@@ -396,11 +397,24 @@ The <learnings> block is mandatory in every response. Ralphai will parse it and 
     agent_output_file=$(mktemp)
     set +e
     if [[ "$TURN_TIMEOUT" -gt 0 ]]; then
-      timeout "$TURN_TIMEOUT" $AGENT_COMMAND "$PROMPT" 2>&1 | tee "$agent_output_file"
-      agent_exit=${PIPESTATUS[0]}
-      if [[ $agent_exit -eq 124 ]]; then
-        echo ""
-        echo "WARNING: Agent command timed out after ${TURN_TIMEOUT}s."
+      # Resolve a portable timeout command (GNU timeout or macOS gtimeout)
+      local timeout_cmd=""
+      if command -v timeout &>/dev/null; then
+        timeout_cmd="timeout"
+      elif command -v gtimeout &>/dev/null; then
+        timeout_cmd="gtimeout"
+      fi
+      if [[ -n "$timeout_cmd" ]]; then
+        $timeout_cmd "$TURN_TIMEOUT" $AGENT_COMMAND "$PROMPT" 2>&1 | tee "$agent_output_file"
+        agent_exit=${PIPESTATUS[0]}
+        if [[ $agent_exit -eq 124 ]]; then
+          echo ""
+          echo "WARNING: Agent command timed out after ${TURN_TIMEOUT}s."
+        fi
+      else
+        echo "WARNING: turnTimeout=${TURN_TIMEOUT}s requested but neither 'timeout' nor 'gtimeout' is available. Running without timeout."
+        $AGENT_COMMAND "$PROMPT" 2>&1 | tee "$agent_output_file"
+        agent_exit=${PIPESTATUS[0]}
       fi
     else
       $AGENT_COMMAND "$PROMPT" 2>&1 | tee "$agent_output_file"
@@ -421,7 +435,7 @@ The <learnings> block is mandatory in every response. Ralphai will parse it and 
     # --- Stuck detection (BEFORE auto-commit to avoid false progress) ---
     if [[ "$MODE" == "patch" ]]; then
       # Patch mode: no commits are created, so compare working-tree diff hash
-      current_diff_hash=$(git diff HEAD 2>/dev/null | sha256sum | cut -d' ' -f1)
+      current_diff_hash=$(git diff HEAD 2>/dev/null | git hash-object --stdin)
       if [[ "$current_diff_hash" == "$last_diff_hash" ]]; then
         stuck_count=$((stuck_count + 1))
         echo "WARNING: No working-tree changes this turn ($stuck_count/$MAX_STUCK)."

--- a/src/monorepo-scope.test.ts
+++ b/src/monorepo-scope.test.ts
@@ -112,12 +112,13 @@ describe.skipIf(process.platform === "win32")(
       const configFile = join(ctx.dir, "ralphai.json");
       writeFileSync(configFile, configContent);
 
-      // Source defaults + config, pass config path as positional arg
+      // Source defaults + json + config, pass config path as positional arg
       const output = runBash(`
 source ${JSON.stringify(join(LIB_DIR, "defaults.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "json.sh"))}
 source ${JSON.stringify(join(LIB_DIR, "config.sh"))}
 load_config ${JSON.stringify(configFile)}
-echo "WORKSPACES=\$CONFIG_WORKSPACES"
+echo "WORKSPACES=$CONFIG_WORKSPACES"
 `);
       expect(output).not.toContain("unknown config key");
       expect(output).toContain("packages/web");
@@ -137,6 +138,7 @@ echo "WORKSPACES=\$CONFIG_WORKSPACES"
       try {
         runBash(`
 source ${JSON.stringify(join(LIB_DIR, "defaults.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "json.sh"))}
 source ${JSON.stringify(join(LIB_DIR, "config.sh"))}
 load_config ${JSON.stringify(configFile)}
 `);
@@ -194,6 +196,7 @@ AGENT_COMMAND="claude -p"
 detect_agent_type() { DETECTED_AGENT_TYPE="claude"; }
 
 source ${JSON.stringify(join(LIB_DIR, "prompt.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "json.sh"))}
 source ${JSON.stringify(join(LIB_DIR, "scope.sh"))}
 
 PLAN_SCOPE="${opts.scope}"
@@ -305,6 +308,7 @@ AGENT_COMMAND="claude -p"
 detect_agent_type() { DETECTED_AGENT_TYPE="claude"; }
 
 source ${JSON.stringify(join(LIB_DIR, "prompt.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "json.sh"))}
 source ${JSON.stringify(join(LIB_DIR, "scope.sh"))}
 
 PLAN_SCOPE=""
@@ -335,6 +339,7 @@ AGENT_COMMAND="claude -p"
 detect_agent_type() { DETECTED_AGENT_TYPE="claude"; }
 
 source ${JSON.stringify(join(LIB_DIR, "prompt.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "json.sh"))}
 source ${JSON.stringify(join(LIB_DIR, "scope.sh"))}
 
 PLAN_SCOPE="packages/web"
@@ -354,6 +359,7 @@ AGENT_COMMAND="claude -p"
 detect_agent_type() { DETECTED_AGENT_TYPE="claude"; }
 
 source ${JSON.stringify(join(LIB_DIR, "prompt.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "json.sh"))}
 source ${JSON.stringify(join(LIB_DIR, "scope.sh"))}
 
 PLAN_SCOPE=""


### PR DESCRIPTION
## Summary

- **Replace `jq` with Node.js JSON helpers** (`_json_q` / `_json_q_stdin` in new `runner/lib/json.sh`) — eliminates the misleading "invalid JSON" error on Windows when `jq` is not installed. Node.js is always available since ralphai is an npm package.
- **Replace `sha256sum`** with `git hash-object --stdin` — `sha256sum` is not available on macOS.
- **Make `sed -i` portable** in `receipt.sh` — use `sed > tmp && mv` pattern instead of GNU-only `sed -i` syntax that breaks on macOS BSD sed.
- **Add `gtimeout` fallback** for the `timeout` command in `ralphai.sh` — `timeout` is not available on macOS; falls back to `gtimeout` (from `brew install coreutils`) with a warning if neither is found.

## Changes

| File | What changed |
|---|---|
| `runner/lib/json.sh` | **New** — `_json_q` (file input) and `_json_q_stdin` (stdin input) helpers that use `node -e` |
| `runner/lib/config.sh` | 13 `jq` calls → `_json_q` |
| `runner/lib/scope.sh` | 2 `jq` calls → `_json_q` / `_json_q_stdin` |
| `runner/lib/show_config.sh` | 1 `jq` call → `_json_q` |
| `runner/ralphai.sh` | Source `json.sh`; `sha256sum` → `git hash-object`; portable `timeout` |
| `runner/lib/receipt.sh` | 2 `sed -i` sites → portable tmp-file pattern |
| `src/monorepo-scope.test.ts` | Add `source json.sh` in test scripts that source `config.sh` / `scope.sh` directly |

All 336 tests pass.