### PR TITLE
Plan: Concise Top-Level Help

### DIFF
--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -93,14 +93,22 @@ describe("CLI help and flags", () => {
   // Top-level help surfaces run flags
   // -------------------------------------------------------------------------
 
-  it("--help shows common run flags", () => {
+  it("--help shows command-specific help hint and quick-start examples", () => {
     const result = runCli(["--help"]);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("--turns");
-    expect(result.stdout).toContain("--dry-run");
-    expect(result.stdout).toContain("--pr");
-    expect(result.stdout).toContain("--resume");
-    expect(result.stdout).toContain("--continuous");
+    expect(result.stdout).toContain("ralphai <command> --help");
+    expect(result.stdout).toContain("ralphai init");
+    expect(result.stdout).toContain("ralphai run");
+    expect(result.stdout).toContain("ralphai run --pr");
+  });
+
+  it("--help does not show subcommand-specific flags", () => {
+    const result = runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("--turns");
+    expect(result.stdout).not.toContain("--dry-run");
+    expect(result.stdout).not.toContain("--resume");
+    expect(result.stdout).not.toContain("--continuous");
   });
 
   // -------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,70 +20,30 @@ function getVersion(): string {
 }
 
 function showHelp(): void {
-  console.log(`
-${BOLD}Usage:${RESET} ralphai <command> [options]
+  console.log(`${BOLD}Usage:${RESET} ralphai <command> [options]
 
 ${BOLD}Commands:${RESET}
-  init           Set up Ralphai in your project (interactive wizard)
-  run            Start the Ralphai task runner
-  worktree       Create or reuse an isolated git worktree
-  status         Show pipeline and worktree status
-  reset          Move in-progress plans back to backlog and clean up
-  purge          Delete archived artifacts from pipeline/out/
-  update [tag]   Update ralphai to the latest (or specified) version
-  teardown       Remove Ralphai from your project
-  doctor         Check your ralphai setup for problems
+  init         Set up Ralphai in your project (interactive wizard)
+  run          Start the Ralphai task runner
+  worktree     Run in an isolated git worktree
+  status       Show pipeline and worktree status
+  reset        Move in-progress plans back to backlog and clean up
+  purge        Delete archived artifacts from pipeline/out/
+  update       Update ralphai to the latest (or specified) version
+  teardown     Remove Ralphai from your project
+  doctor       Check your ralphai setup for problems
 
 ${BOLD}Options:${RESET}
-  --help, -h        Show this help message
-  --version, -v     Show version number
-  --no-color        Disable colored output (also: NO_COLOR env var)
+  --help, -h      Show this help message
+  --version, -v   Show version number
+  --no-color      Disable colored output (also: NO_COLOR env var)
 
-${BOLD}Init Options:${RESET}
-  --yes, -y              Skip prompts and use defaults
-  --force                Re-scaffold from scratch (deletes existing .ralphai/)
-  --shared               Track ralphai.json in git (for team-shared config)
-  --agent-command=CMD    Set the agent command (default: opencode run --agent build)
-
-${BOLD}Run Options:${RESET}
-  --turns=N              Number of turns per plan (default: 5, 0 = unlimited)
-  --dry-run              Preview which plans would run without executing
-  --pr                   Create a branch and open a PR after completing the plan
-  --resume               Resume the last in-progress plan
-  --continuous           Run plans in a loop until the backlog is empty
-  Run 'ralphai run --help' for all runner options.
-
-${BOLD}Worktree Options:${RESET}
-  --plan=<file>     Target a specific backlog plan (default: auto-detect)
-  --dir=<path>      Worktree directory (default: ../.ralphai-worktrees/<slug>)
-  worktree list     Show active ralphai-managed worktrees
-  worktree clean    Remove completed/orphaned worktrees
-
-${BOLD}Reset Options:${RESET}
-  --yes, -y         Skip confirmation prompt
-
-${BOLD}Purge Options:${RESET}
-  --yes, -y         Skip confirmation prompt
+Run ${TEXT}'ralphai <command> --help'${RESET} for command-specific options.
 
 ${BOLD}Examples:${RESET}
-  ${DIM}$${RESET} ralphai init                  ${DIM}# interactive setup${RESET}
-  ${DIM}$${RESET} ralphai init --yes             ${DIM}# setup with defaults${RESET}
-  ${DIM}$${RESET} ralphai run                    ${DIM}# run with defaults (5 turns per plan)${RESET}
-  ${DIM}$${RESET} ralphai run --turns=3          ${DIM}# 3 turns per plan${RESET}
-  ${DIM}$${RESET} ralphai run --dry-run          ${DIM}# preview only${RESET}
-  ${DIM}$${RESET} ralphai run --pr               ${DIM}# create branch and open PR${RESET}
-  ${DIM}$${RESET} ralphai worktree               ${DIM}# run next plan in an isolated worktree${RESET}
-  ${DIM}$${RESET} ralphai worktree --turns=3     ${DIM}# run in a worktree with 3 turns per plan${RESET}
-  ${DIM}$${RESET} ralphai worktree list           ${DIM}# show active ralphai worktrees${RESET}
-  ${DIM}$${RESET} ralphai worktree clean          ${DIM}# remove completed worktrees${RESET}
-  ${DIM}$${RESET} ralphai status                 ${DIM}# show pipeline and worktree status${RESET}
-  ${DIM}$${RESET} ralphai reset                  ${DIM}# move in-progress plans back to backlog${RESET}
-  ${DIM}$${RESET} ralphai reset --yes            ${DIM}# reset without confirmation${RESET}
-  ${DIM}$${RESET} ralphai purge --yes            ${DIM}# delete all archived artifacts${RESET}
-  ${DIM}$${RESET} ralphai update                 ${DIM}# update ralphai to latest${RESET}
-  ${DIM}$${RESET} ralphai update beta            ${DIM}# install beta version${RESET}
-  ${DIM}$${RESET} ralphai teardown --yes         ${DIM}# remove ralphai from project${RESET}
-`);
+  ${DIM}$${RESET} ralphai init          ${DIM}# set up your project${RESET}
+  ${DIM}$${RESET} ralphai run           ${DIM}# run the next plan${RESET}
+  ${DIM}$${RESET} ralphai run --pr      ${DIM}# run and open a PR${RESET}`);
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Plan

# Plan: Concise Top-Level Help

> Replace the wall-of-text `ralphai --help` with a short command listing and a "run `ralphai <command> --help`" hint. Subcommand details stay in their existing per-command help handlers.

## Background

Running `ralphai --help` currently dumps ~65 lines: every subcommand, every subcommand's options, and ~18 examples. This is overwhelming for new users who just want to know what commands exist. Meanwhile, every subcommand already has a dedicated `--help` handler (`showInitHelp()`, `showWorktreeHelp()`, etc. in `src/ralphai.ts` lines 2090-2200) and the bash runner has `print_usage()` in `runner/lib/cli.sh`.

There is also a concise `showRalphaiHelp()` function at `src/ralphai.ts:1431` used as the fallback for unrecognized subcommands. It already has the right shape: command list + "Run `ralphai <command> --help`" hint.

## References

- `src/cli.ts:22-87` — `showHelp()`, the bloated top-level help
- `src/cli.ts:102-111` — where `showHelp()` is called (bare invocation and `--help`)
- `src/ralphai.ts:1431-1466` — `showRalphaiHelp()`, the concise fallback help
- `src/ralphai.ts:2090-2200` — per-subcommand help functions (init, status, reset, purge, update, teardown, doctor, worktree)
- `runner/lib/cli.sh:7-75` — `print_usage()` for run-specific help
- `src/cli-help.test.ts` — tests for help output

## Acceptance Criteria

- [ ] `ralphai --help` output is ≤20 lines: usage line, command list with one-line descriptions, global options (--help, --version, --no-color), a "Run `ralphai <command> --help`" hint, and 2-3 quick-start examples
- [ ] `ralphai` (no args) shows the same concise help (preceded by the version line, as it does today)
- [ ] Each subcommand's `--help` still works and shows its full flags/examples (no regressions)
- [ ] The test in `cli-help.test.ts` line 96-104 ("--help shows common run flags") is updated to match the new top-level output, which no longer lists run flags
- [ ] All other existing tests in `cli-help.test.ts` continue to pass
- [ ] `pnpm test` passes

## Implementation Tasks

### Task 1: Replace `showHelp()` in `src/cli.ts` with concise output and update tests

**File:** `src/cli.ts` (primary), `src/cli-help.test.ts` (tests)

**What:** Replace the `showHelp()` function body (lines 22-87) with a concise version. The new output should be:

```
Usage: ralphai <command> [options]

Commands:
  init         Set up Ralphai in your project (interactive wizard)
  run          Start the Ralphai task runner
  worktree     Run in an isolated git worktree
  status       Show pipeline and worktree status
  reset        Move in-progress plans back to backlog and clean up
  purge        Delete archived artifacts from pipeline/out/
  update       Update ralphai to the latest (or specified) version
  teardown     Remove Ralphai from your project
  doctor       Check your ralphai setup for problems

Options:
  --help, -h      Show this help message
  --version, -v   Show version number
  --no-color      Disable colored output (also: NO_COLOR env var)

Run 'ralphai <command> --help' for command-specific options.

Examples:
  $ ralphai init          # set up your project
  $ ralphai run           # run the next plan
  $ ralphai run --pr      # run and open a PR
```

Keep the same ANSI formatting pattern (`BOLD`, `DIM`, `TEXT`, `RESET`) used today.

**Tests:** Update the test at `src/cli-help.test.ts:96-104` that asserts `--help` shows `--turns`, `--dry-run`, `--pr`, `--resume`, and `--continuous`. The new top-level help won't include these. Replace that test with one asserting the concise output contains the "Run 'ralphai <command> --help'" hint and the quick-start examples.

**What not to change:** The `showRalphaiHelp()` function in `ralphai.ts` (the fallback for unrecognized subcommands) is already concise. Leave it as-is.

## Verification

- `pnpm test` passes (all suites)
- `node --experimental-strip-types src/cli.ts --help` output fits in ~20 lines
- `node --experimental-strip-types src/cli.ts init --help` still shows init-specific flags
- `node --experimental-strip-types src/cli.ts run --help` still shows full runner usage

## Commits

```
46842b2 feat(cli): replace verbose top-level help with concise command listing
```