### PR TITLE
fix(init): stop generating bloated workspaces config and fix mixed-repo scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ ralphai teardown         # remove Ralphai from your project
 
 ## Monorepo Support
 
-`ralphai init` automatically detects workspace packages from `pnpm-workspace.yaml`, the `workspaces` field in `package.json`, or `.sln` files (for .NET projects). In interactive mode, it offers to add per-workspace feedback commands to `ralphai.json`. In `--yes` mode, it prints the detected workspaces and relies on automatic scope filtering at runtime.
+`ralphai init` automatically detects workspace packages from `pnpm-workspace.yaml`, the `workspaces` field in `package.json`, or `.sln` files (for .NET projects). In mixed repos (e.g., Node.js + .NET), workspaces from both ecosystems are merged. Both `--yes` and interactive modes display detected workspaces and rely on automatic scope filtering at runtime.
 
 Plans can target a specific package by adding `scope` to the frontmatter:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,7 +35,7 @@ ralphai <command> [options]
 --agent-command=CMD    Set the agent command
 ```
 
-In monorepo projects, `init` detects workspace packages from `pnpm-workspace.yaml`, `package.json` `workspaces`, or `.sln` files (for .NET projects). In interactive mode, it offers to generate per-workspace feedback commands. In `--yes` mode, it prints workspace info without adding config (commands are auto-filtered by scope at runtime).
+In monorepo projects, `init` detects workspace packages from `pnpm-workspace.yaml`, `package.json` `workspaces`, or `.sln` files (for .NET projects). In mixed repos, workspaces from all ecosystems are merged. Both modes display workspace info without adding config; feedback commands are auto-filtered by scope at runtime.
 
 ## Run
 

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -253,7 +253,7 @@ scope: packages/web
 
 ### Workspace Detection
 
-`ralphai init` detects workspace packages from three sources: `pnpm-workspace.yaml` globs, the `workspaces` field in `package.json`, and `.sln` files (which list `.csproj` projects for .NET monorepos). In interactive mode, it asks whether to add per-workspace feedback commands to the config. In `--yes` mode, it prints the discovered workspaces and skips config generation (root feedback commands are auto-filtered by scope at runtime).
+`ralphai init` detects workspace packages from three sources: `pnpm-workspace.yaml` globs, the `workspaces` field in `package.json`, and `.sln` files (which list `.csproj` projects for .NET monorepos). In mixed repos, workspaces from all sources are merged (deduplicated by path). Both `--yes` and interactive modes display the detected workspaces and rely on automatic scope filtering at runtime. The `workspaces` config key is an escape hatch for custom per-package overrides; `init` does not generate it.
 
 ### Multi-Ecosystem Detection
 
@@ -274,6 +274,8 @@ When a plan has a scope, the runner rewrites feedback commands to target the sco
 1. **Appends the scope path** to dotnet commands: `dotnet build` becomes `dotnet build <scope>`, `dotnet test` becomes `dotnet test <scope>`.
 
 **Other ecosystems:** Commands pass through unchanged.
+
+**Mixed repos (e.g., Node.js + .NET):** Dotnet commands are scoped regardless of the primary ecosystem. If the scope directory contains a `package.json`, Node.js PM commands are also rewritten. This means a plan scoping to a .NET sub-project in a mixed repo gets `dotnet build <scope>` even when Node.js is the primary ecosystem.
 
 In all cases, the runner **adds a scope hint** to the agent prompt so the agent focuses on files within the scoped directory. Commands that don't match the detected ecosystem (e.g., `make test`) also pass through unchanged.
 

--- a/runner/lib/config.sh
+++ b/runner/lib/config.sh
@@ -3,7 +3,8 @@
 # and apply_env_overrides(). CLI parsing is in cli.sh.
 
 # --- Config file loader ---
-# Parses ralphai.json (JSON format via Node.js).
+# Parses ralphai.json in a single Node.js invocation (avoiding ~35 separate
+# node -e calls that accumulated ~15-30 s on Windows due to V8 startup cost).
 # Sets CONFIG_AGENT_COMMAND, CONFIG_FEEDBACK_COMMANDS, CONFIG_BASE_BRANCH,
 # CONFIG_MAX_STUCK, CONFIG_MODE, CONFIG_PROMPT_MODE when present.
 # Fails fast on unknown keys or invalid values.
@@ -15,220 +16,223 @@ load_config() {
     return 0
   fi
 
-  # Validate JSON syntax
-  if ! _json_q "" "$config_path" 2>/dev/null; then
-    echo "ERROR: $config_path: invalid JSON"
+  # Single Node.js invocation: validate + extract all config values.
+  # Output format: one "KEY=VALUE" per line for simple values,
+  # "KEY_JSON=<json>" for complex objects, "WARNING:msg" for warnings,
+  # "ERROR:msg" for fatal errors.
+  local node_output
+  if ! node_output=$(node -e "
+    'use strict';
+    const fs = require('fs');
+    const file = process.argv[1];
+    let raw;
+    try { raw = fs.readFileSync(file, 'utf-8'); } catch (e) {
+      console.log('ERROR:' + file + ': cannot read file: ' + e.message);
+      process.exit(0);
+    }
+    let data;
+    try { data = JSON.parse(raw); } catch (e) {
+      console.log('ERROR:' + file + ': invalid JSON');
+      process.exit(0);
+    }
+    if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+      const t = data === null ? 'null' : Array.isArray(data) ? 'array' : typeof data;
+      console.log('ERROR:' + file + ': expected a JSON object, got ' + t);
+      process.exit(0);
+    }
+    const allowed = new Set(['agentCommand','feedbackCommands','baseBranch','maxStuck','mode','issueSource','issueLabel','issueInProgressLabel','issueRepo','issueCommentProgress','turnTimeout','promptMode','continuous','autoCommit','turns','maxLearnings','workspaces']);
+    const unknown = Object.keys(data).filter(k => !allowed.has(k));
+    if (unknown.length > 0) console.log('WARNING:' + file + \": ignoring unknown config key '\" + unknown[0] + \"'\");
+    function emit(key, val) { console.log(key + '=' + val); }
+    function err(msg) { console.log('ERROR:' + file + ': ' + msg); process.exit(0); }
+
+    // agentCommand (string, non-empty)
+    if ('agentCommand' in data) {
+      const v = data.agentCommand;
+      if (typeof v !== 'string' || v === '') err(\"'agentCommand' must be a non-empty string\");
+      else emit('CONFIG_AGENT_COMMAND', v);
+    }
+
+    // feedbackCommands (array of strings or comma-separated string)
+    if ('feedbackCommands' in data) {
+      const v = data.feedbackCommands;
+      if (Array.isArray(v)) {
+        const joined = v.join(',');
+        // Validate no empty entries
+        if (v.some(s => typeof s !== 'string' || s.trim() === ''))
+          err(\"'feedbackCommands' array contains an empty entry\");
+        else emit('CONFIG_FEEDBACK_COMMANDS', joined);
+      } else if (typeof v === 'string') {
+        emit('CONFIG_FEEDBACK_COMMANDS', v);
+      } else {
+        err(\"'feedbackCommands' must be an array of strings or a comma-separated string, got \" + typeof v);
+      }
+    }
+
+    // baseBranch (string, non-empty, no spaces)
+    if ('baseBranch' in data) {
+      const v = String(data.baseBranch || '');
+      if (v === '') err(\"'baseBranch' must be a non-empty branch name\");
+      else if (/\s/.test(v)) err(\"'baseBranch' must be a single token without spaces, got '\" + v + \"'\");
+      else emit('CONFIG_BASE_BRANCH', v);
+    }
+
+    // maxStuck (positive integer)
+    if ('maxStuck' in data) {
+      const v = data.maxStuck;
+      if (typeof v !== 'number' || !Number.isInteger(v) || v < 1)
+        err(\"'maxStuck' must be a positive integer, got '\" + v + \"'\");
+      else emit('CONFIG_MAX_STUCK', v);
+    }
+
+    // mode (enum)
+    if ('mode' in data) {
+      const v = String(data.mode || '');
+      if (!['branch','pr','patch'].includes(v))
+        err(\"'mode' must be 'branch', 'pr', or 'patch', got '\" + v + \"'\");
+      else emit('CONFIG_MODE', v);
+    }
+
+    // issueSource (enum)
+    if ('issueSource' in data) {
+      const v = String(data.issueSource || '');
+      if (!['none','github'].includes(v))
+        err(\"'issueSource' must be 'none' or 'github', got '\" + v + \"'\");
+      else emit('CONFIG_ISSUE_SOURCE', v);
+    }
+
+    // issueLabel (string, non-empty)
+    if ('issueLabel' in data) {
+      const v = String(data.issueLabel || '');
+      if (v === '') err(\"'issueLabel' must be a non-empty label name\");
+      else emit('CONFIG_ISSUE_LABEL', v);
+    }
+
+    // issueInProgressLabel (string, non-empty)
+    if ('issueInProgressLabel' in data) {
+      const v = String(data.issueInProgressLabel || '');
+      if (v === '') err(\"'issueInProgressLabel' must be a non-empty label name\");
+      else emit('CONFIG_ISSUE_IN_PROGRESS_LABEL', v);
+    }
+
+    // issueRepo (string, can be empty)
+    if ('issueRepo' in data) {
+      emit('CONFIG_ISSUE_REPO', String(data.issueRepo || ''));
+    }
+
+    // issueCommentProgress (boolean)
+    if ('issueCommentProgress' in data) {
+      const v = data.issueCommentProgress;
+      if (typeof v !== 'boolean')
+        err(\"'issueCommentProgress' must be 'true' or 'false', got '\" + v + \"'\");
+      else emit('CONFIG_ISSUE_COMMENT_PROGRESS', v);
+    }
+
+    // turnTimeout (non-negative integer)
+    if ('turnTimeout' in data) {
+      const v = data.turnTimeout;
+      if (typeof v !== 'number' || !Number.isInteger(v) || v < 0)
+        err(\"'turnTimeout' must be a non-negative integer (seconds), got '\" + v + \"'\");
+      else emit('CONFIG_TURN_TIMEOUT', v);
+    }
+
+    // promptMode (enum)
+    if ('promptMode' in data) {
+      const v = String(data.promptMode || '');
+      if (!['auto','at-path','inline'].includes(v))
+        err(\"'promptMode' must be 'auto', 'at-path', or 'inline', got '\" + v + \"'\");
+      else emit('CONFIG_PROMPT_MODE', v);
+    }
+
+    // continuous (boolean)
+    if ('continuous' in data) {
+      const v = data.continuous;
+      if (typeof v !== 'boolean')
+        err(\"'continuous' must be 'true' or 'false', got '\" + v + \"'\");
+      else emit('CONFIG_CONTINUOUS', v);
+    }
+
+    // autoCommit (boolean)
+    if ('autoCommit' in data) {
+      const v = data.autoCommit;
+      if (typeof v !== 'boolean')
+        err(\"'autoCommit' must be 'true' or 'false', got '\" + v + \"'\");
+      else emit('CONFIG_AUTO_COMMIT', v);
+    }
+
+    // turns (non-negative integer, 0 = unlimited)
+    if ('turns' in data) {
+      const v = data.turns;
+      if (typeof v !== 'number' || !Number.isInteger(v) || v < 0)
+        err(\"'turns' must be a non-negative integer (0 = unlimited), got '\" + v + \"'\");
+      else emit('CONFIG_TURNS', v);
+    }
+
+    // maxLearnings (non-negative integer, 0 = unlimited)
+    if ('maxLearnings' in data) {
+      const v = data.maxLearnings;
+      if (typeof v !== 'number' || !Number.isInteger(v) || v < 0)
+        err(\"'maxLearnings' must be a non-negative integer (0 = unlimited), got '\" + v + \"'\");
+      else emit('CONFIG_MAX_LEARNINGS', v);
+    }
+
+    // workspaces (object of per-package overrides)
+    if ('workspaces' in data) {
+      const ws = data.workspaces;
+      if (ws === null || typeof ws !== 'object' || Array.isArray(ws)) {
+        const t = ws === null ? 'null' : Array.isArray(ws) ? 'array' : typeof ws;
+        err(\"'workspaces' must be an object, got \" + t);
+      } else {
+        for (const k of Object.keys(ws)) {
+          const entry = ws[k];
+          if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+            const t = entry === null ? 'null' : Array.isArray(entry) ? 'array' : typeof entry;
+            err(\"workspaces['\" + k + \"'] must be an object, got \" + t);
+          }
+          if (entry && 'feedbackCommands' in entry) {
+            const fc = entry.feedbackCommands;
+            if (!Array.isArray(fc) && typeof fc !== 'string')
+              err(\"workspaces['\" + k + \"'].feedbackCommands must be an array of strings or a comma-separated string, got \" + typeof fc);
+          }
+        }
+        emit('CONFIG_WORKSPACES_JSON', JSON.stringify(ws));
+      }
+    }
+  " "$config_path" 2>/dev/null); then
+    echo "ERROR: $config_path: failed to parse config"
     exit 1
   fi
 
-  # Must be a JSON object
-  local json_type
-  json_type=$(_json_q "const t=typeof data; console.log(data===null?'null':Array.isArray(data)?'array':t)" "$config_path")
-  if [[ "$json_type" != "object" ]]; then
-    echo "ERROR: $config_path: expected a JSON object, got $json_type"
-    exit 1
-  fi
-
-  # Check for unknown keys
-  local unknown_keys
-  unknown_keys=$(_json_q "
-    const allowed = ['agentCommand','feedbackCommands','baseBranch','maxStuck','mode','issueSource','issueLabel','issueInProgressLabel','issueRepo','issueCommentProgress','turnTimeout','promptMode','continuous','autoCommit','turns','maxLearnings','workspaces'];
-    Object.keys(data).filter(k => !allowed.includes(k)).forEach(k => console.log(k));
-  " "$config_path")
-  if [[ -n "$unknown_keys" ]]; then
-    local first_unknown
-    first_unknown=$(echo "$unknown_keys" | head -1)
-    echo "WARNING: $config_path: ignoring unknown config key '$first_unknown'"
-  fi
-
-  # Helper: read a string value from JSON (returns empty if key is missing or null)
-  _json_str() {
-    _json_q "const v = data[process.argv[2]]; console.log(v == null ? '' : String(v))" "$config_path" "$1"
-  }
-
-  # Helper: read a raw value (preserves type info for validation)
-  _json_raw() {
-    _json_q "const v = data[process.argv[2]]; console.log(v === undefined ? '' : String(v))" "$config_path" "$1"
-  }
-
-  # Helper: check if key exists
-  _json_has() {
-    _json_q "process.exit(process.argv[2] in data ? 0 : 1)" "$config_path" "$1"
-  }
-
-  local value
-
-  # --- agentCommand (string, non-empty) ---
-  if _json_has "agentCommand"; then
-    value=$(_json_str "agentCommand")
-    if [[ -z "$value" ]]; then
-      echo "ERROR: $config_path: 'agentCommand' must be a non-empty string"
-      exit 1
-    fi
-    CONFIG_AGENT_COMMAND="$value"
-  fi
-
-  # --- feedbackCommands (array of strings or comma-separated string) ---
-  if _json_has "feedbackCommands"; then
-    local fc_type
-    fc_type=$(_json_q "const v = data.feedbackCommands; console.log(Array.isArray(v) ? 'array' : typeof v)" "$config_path")
-    if [[ "$fc_type" == "array" ]]; then
-      # Join array elements with commas (matches internal format)
-      value=$(_json_q "console.log(data.feedbackCommands.join(','))" "$config_path")
-      validate_comma_list "$value" "$config_path: 'feedbackCommands' array"
-    elif [[ "$fc_type" == "string" ]]; then
-      value=$(_json_str "feedbackCommands")
-      validate_comma_list "$value" "$config_path: 'feedbackCommands'"
-    else
-      echo "ERROR: $config_path: 'feedbackCommands' must be an array of strings or a comma-separated string, got $fc_type"
-      exit 1
-    fi
-    CONFIG_FEEDBACK_COMMANDS="$value"
-  fi
-
-  # --- baseBranch (string, non-empty, no spaces) ---
-  if _json_has "baseBranch"; then
-    value=$(_json_str "baseBranch")
-    if [[ -z "$value" ]]; then
-      echo "ERROR: $config_path: 'baseBranch' must be a non-empty branch name"
-      exit 1
-    fi
-    if [[ "$value" =~ [[:space:]] ]]; then
-      echo "ERROR: $config_path: 'baseBranch' must be a single token without spaces, got '$value'"
-      exit 1
-    fi
-    CONFIG_BASE_BRANCH="$value"
-  fi
-
-  # --- maxStuck (positive integer) ---
-  if _json_has "maxStuck"; then
-    value=$(_json_raw "maxStuck")
-    validate_positive_int "$value" "$config_path: 'maxStuck'"
-    CONFIG_MAX_STUCK="$value"
-  fi
-
-  # --- mode ("branch", "pr", or "patch") ---
-  if _json_has "mode"; then
-    value=$(_json_str "mode")
-    validate_enum "$value" "$config_path: 'mode'" "branch" "pr" "patch"
-    CONFIG_MODE="$value"
-  fi
-
-  # --- issueSource ("none" or "github") ---
-  if _json_has "issueSource"; then
-    value=$(_json_str "issueSource")
-    validate_enum "$value" "$config_path: 'issueSource'" "none" "github"
-    CONFIG_ISSUE_SOURCE="$value"
-  fi
-
-  # --- issueLabel (string, non-empty) ---
-  if _json_has "issueLabel"; then
-    value=$(_json_str "issueLabel")
-    if [[ -z "$value" ]]; then
-      echo "ERROR: $config_path: 'issueLabel' must be a non-empty label name"
-      exit 1
-    fi
-    CONFIG_ISSUE_LABEL="$value"
-  fi
-
-  # --- issueInProgressLabel (string, non-empty) ---
-  if _json_has "issueInProgressLabel"; then
-    value=$(_json_str "issueInProgressLabel")
-    if [[ -z "$value" ]]; then
-      echo "ERROR: $config_path: 'issueInProgressLabel' must be a non-empty label name"
-      exit 1
-    fi
-    CONFIG_ISSUE_IN_PROGRESS_LABEL="$value"
-  fi
-
-  # --- issueRepo (string, can be empty) ---
-  if _json_has "issueRepo"; then
-    value=$(_json_str "issueRepo")
-    CONFIG_ISSUE_REPO="$value"
-  fi
-
-  # --- issueCommentProgress (boolean) ---
-  if _json_has "issueCommentProgress"; then
-    value=$(_json_raw "issueCommentProgress")
-    validate_boolean "$value" "$config_path: 'issueCommentProgress'"
-    CONFIG_ISSUE_COMMENT_PROGRESS="$value"
-  fi
-
-  # --- turnTimeout (non-negative integer) ---
-  if _json_has "turnTimeout"; then
-    value=$(_json_raw "turnTimeout")
-    validate_nonneg_int "$value" "$config_path: 'turnTimeout'" "seconds"
-    CONFIG_TURN_TIMEOUT="$value"
-  fi
-
-  # --- promptMode ("auto", "at-path", or "inline") ---
-  if _json_has "promptMode"; then
-    value=$(_json_str "promptMode")
-    validate_enum "$value" "$config_path: 'promptMode'" "auto" "at-path" "inline"
-    CONFIG_PROMPT_MODE="$value"
-  fi
-
-  # --- continuous (boolean) ---
-  if _json_has "continuous"; then
-    value=$(_json_raw "continuous")
-    validate_boolean "$value" "$config_path: 'continuous'"
-    CONFIG_CONTINUOUS="$value"
-  fi
-
-
-  # --- autoCommit (boolean) ---
-  if _json_has "autoCommit"; then
-    value=$(_json_raw "autoCommit")
-    validate_boolean "$value" "$config_path: 'autoCommit'"
-    CONFIG_AUTO_COMMIT="$value"
-  fi
-
-  # --- turns (non-negative integer, 0 = unlimited) ---
-  if _json_has "turns"; then
-    value=$(_json_raw "turns")
-    validate_nonneg_int "$value" "$config_path: 'turns'" "0 = unlimited"
-    CONFIG_TURNS="$value"
-  fi
-
-  # --- maxLearnings (non-negative integer, 0 = unlimited) ---
-  if _json_has "maxLearnings"; then
-    value=$(_json_raw "maxLearnings")
-    validate_nonneg_int "$value" "$config_path: 'maxLearnings'" "0 = unlimited"
-    CONFIG_MAX_LEARNINGS="$value"
-  fi
-
-  # --- workspaces (object of per-package overrides) ---
-  if _json_has "workspaces"; then
-    local ws_type
-    ws_type=$(_json_q "const v = data.workspaces; console.log(v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v)" "$config_path")
-    if [[ "$ws_type" != "object" ]]; then
-      echo "ERROR: $config_path: 'workspaces' must be an object, got $ws_type"
-      exit 1
-    fi
-    # Validate each workspace entry is an object with valid feedbackCommands
-    local ws_keys
-    ws_keys=$(_json_q "Object.keys(data.workspaces).forEach(k => console.log(k))" "$config_path")
-    while IFS= read -r ws_key; do
-      [[ -z "$ws_key" ]] && continue
-      local ws_entry_type
-      ws_entry_type=$(_json_q "const v = data.workspaces[process.argv[2]]; console.log(v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v)" "$config_path" "$ws_key")
-      if [[ "$ws_entry_type" != "object" ]]; then
-        echo "ERROR: $config_path: workspaces['$ws_key'] must be an object, got $ws_entry_type"
+  # Process the node output line by line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    case "$line" in
+      ERROR:*)
+        echo "${line#ERROR:}"
         exit 1
-      fi
-      # Validate feedbackCommands if present
-      if _json_q "process.exit('feedbackCommands' in data.workspaces[process.argv[2]] ? 0 : 1)" "$config_path" "$ws_key"; then
-        local ws_fc_type
-        ws_fc_type=$(_json_q "const v = data.workspaces[process.argv[2]].feedbackCommands; console.log(Array.isArray(v) ? 'array' : typeof v)" "$config_path" "$ws_key")
-        if [[ "$ws_fc_type" != "array" && "$ws_fc_type" != "string" ]]; then
-          echo "ERROR: $config_path: workspaces['$ws_key'].feedbackCommands must be an array of strings or a comma-separated string, got $ws_fc_type"
-          exit 1
-        fi
-      fi
-    done <<< "$ws_keys"
-    # Store the raw JSON for later queries at scope-resolution time
-    CONFIG_WORKSPACES=$(_json_q "console.log(JSON.stringify(data.workspaces))" "$config_path")
-  fi
+        ;;
+      WARNING:*)
+        echo "${line#WARNING:}"
+        ;;
+      CONFIG_AGENT_COMMAND=*)       CONFIG_AGENT_COMMAND="${line#CONFIG_AGENT_COMMAND=}" ;;
+      CONFIG_FEEDBACK_COMMANDS=*)   CONFIG_FEEDBACK_COMMANDS="${line#CONFIG_FEEDBACK_COMMANDS=}" ;;
+      CONFIG_BASE_BRANCH=*)         CONFIG_BASE_BRANCH="${line#CONFIG_BASE_BRANCH=}" ;;
+      CONFIG_MAX_STUCK=*)           CONFIG_MAX_STUCK="${line#CONFIG_MAX_STUCK=}" ;;
+      CONFIG_MODE=*)                CONFIG_MODE="${line#CONFIG_MODE=}" ;;
+      CONFIG_ISSUE_SOURCE=*)        CONFIG_ISSUE_SOURCE="${line#CONFIG_ISSUE_SOURCE=}" ;;
+      CONFIG_ISSUE_LABEL=*)         CONFIG_ISSUE_LABEL="${line#CONFIG_ISSUE_LABEL=}" ;;
+      CONFIG_ISSUE_IN_PROGRESS_LABEL=*) CONFIG_ISSUE_IN_PROGRESS_LABEL="${line#CONFIG_ISSUE_IN_PROGRESS_LABEL=}" ;;
+      CONFIG_ISSUE_REPO=*)          CONFIG_ISSUE_REPO="${line#CONFIG_ISSUE_REPO=}" ;;
+      CONFIG_ISSUE_COMMENT_PROGRESS=*) CONFIG_ISSUE_COMMENT_PROGRESS="${line#CONFIG_ISSUE_COMMENT_PROGRESS=}" ;;
+      CONFIG_TURN_TIMEOUT=*)        CONFIG_TURN_TIMEOUT="${line#CONFIG_TURN_TIMEOUT=}" ;;
+      CONFIG_PROMPT_MODE=*)         CONFIG_PROMPT_MODE="${line#CONFIG_PROMPT_MODE=}" ;;
+      CONFIG_CONTINUOUS=*)          CONFIG_CONTINUOUS="${line#CONFIG_CONTINUOUS=}" ;;
+      CONFIG_AUTO_COMMIT=*)         CONFIG_AUTO_COMMIT="${line#CONFIG_AUTO_COMMIT=}" ;;
+      CONFIG_TURNS=*)               CONFIG_TURNS="${line#CONFIG_TURNS=}" ;;
+      CONFIG_MAX_LEARNINGS=*)       CONFIG_MAX_LEARNINGS="${line#CONFIG_MAX_LEARNINGS=}" ;;
+      CONFIG_WORKSPACES_JSON=*)     CONFIG_WORKSPACES="${line#CONFIG_WORKSPACES_JSON=}" ;;
+    esac
+  done <<< "$node_output"
 }
 
 # --- Apply config file settings ---

--- a/runner/lib/scope.sh
+++ b/runner/lib/scope.sh
@@ -72,9 +72,18 @@ _detect_pm_from_lockfiles() {
 # Usage: _rewrite_command <pm> <package_name> <command>
 # For the "node" ecosystem, rewrites PM-based workspace filters.
 # For "dotnet", appends the project path to dotnet commands.
+# In mixed repos (node primary with dotnet feedback), dotnet commands are
+# also scoped when the ecosystem is "node".
 # Other ecosystems and non-matching commands pass through unchanged.
 _rewrite_command() {
   local pm="$1" pkg_name="$2" cmd="$3"
+
+  # Dotnet commands are scoped regardless of the primary ecosystem,
+  # since detectProject() merges dotnet feedback into node in mixed repos.
+  if [[ "$cmd" == "dotnet "* ]]; then
+    echo "$cmd $PLAN_SCOPE"
+    return
+  fi
 
   case "${_RALPHAI_ECOSYSTEM:-unknown}" in
     node)
@@ -99,15 +108,6 @@ _rewrite_command() {
         bun)  echo "bun --filter $pkg_name $rest" ;;
         *)    echo "$cmd" ;;
       esac
-      ;;
-
-    dotnet)
-      # Rewrite "dotnet build" → "dotnet build <scope>" etc.
-      if [[ "$cmd" == "dotnet "* ]]; then
-        echo "$cmd $PLAN_SCOPE"
-      else
-        echo "$cmd"
-      fi
       ;;
 
     *)
@@ -156,24 +156,22 @@ resolve_scoped_feedback() {
     return 0
   fi
 
-  # For dotnet, we can scope directly using PLAN_SCOPE as the project path.
   # For node, we need the package name from the scoped directory's package.json.
+  # For dotnet (or dotnet commands in mixed repos), _rewrite_command handles
+  # scoping via PLAN_SCOPE directly — no package name needed.
   local pkg_name=""
   local pm=""
 
   if [[ "$_RALPHAI_ECOSYSTEM" == "node" ]]; then
     local pkg_json="$PLAN_SCOPE/package.json"
-    if [[ ! -f "$pkg_json" ]]; then
-      # No package.json in scope directory — can't derive scoped commands
-      return 0
+    if [[ -f "$pkg_json" ]]; then
+      pkg_name=$(_json_q "if (data.name) console.log(data.name)" "$pkg_json" 2>/dev/null) || pkg_name=""
+      if [[ -n "$pkg_name" ]]; then
+        pm=$(_detect_pm_from_lockfiles)
+      fi
     fi
-
-    pkg_name=$(_json_q "if (data.name) console.log(data.name)" "$pkg_json" 2>/dev/null) || pkg_name=""
-    if [[ -z "$pkg_name" ]]; then
-      return 0
-    fi
-
-    pm=$(_detect_pm_from_lockfiles)
+    # When no package.json (e.g., .NET sub-project in a mixed repo), fall
+    # through to the rewrite loop — _rewrite_command still scopes dotnet cmds.
   fi
 
   # Rewrite each feedback command

--- a/src/dotnet-monorepo.test.ts
+++ b/src/dotnet-monorepo.test.ts
@@ -220,7 +220,7 @@ describe("detectWorkspaces for .NET", () => {
     expect(detectWorkspaces(ctx.dir)).toEqual([]);
   });
 
-  it("prefers Node workspaces over .sln when both exist", () => {
+  it("merges Node workspaces and .sln projects when both exist", () => {
     // Node workspace setup
     writeFileSync(
       join(ctx.dir, "package.json"),
@@ -237,8 +237,31 @@ describe("detectWorkspaces for .NET", () => {
     writeFileSync(join(ctx.dir, "App.sln"), slnText);
 
     const workspaces = detectWorkspaces(ctx.dir);
-    // Node workspaces should win (checked first)
-    expect(workspaces).toEqual([{ name: "@org/web", path: "packages/web" }]);
+    // Node workspaces listed first, .NET projects appended
+    expect(workspaces).toEqual([
+      { name: "@org/web", path: "packages/web" },
+      { name: "Api", path: "src/Api" },
+    ]);
+  });
+
+  it("deduplicates by path when Node and .sln overlap", () => {
+    // A workspace path that appears in both Node and .sln
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["src/*"] }),
+    );
+    mkdirSync(join(ctx.dir, "src", "Api"), { recursive: true });
+    writeFileSync(
+      join(ctx.dir, "src", "Api", "package.json"),
+      JSON.stringify({ name: "@org/api" }),
+    );
+
+    const slnText = slnContent([{ name: "Api", path: "src\\Api\\Api.csproj" }]);
+    writeFileSync(join(ctx.dir, "App.sln"), slnText);
+
+    const workspaces = detectWorkspaces(ctx.dir);
+    // Should appear only once (Node version wins)
+    expect(workspaces).toEqual([{ name: "@org/api", path: "src/Api" }]);
   });
 });
 
@@ -437,6 +460,48 @@ echo "\$FEEDBACK_COMMANDS"
 
       expect(result).toBe("dotnet build src/MyProject,make lint");
     });
+
+    it("scopes dotnet commands in a mixed node+dotnet repo", () => {
+      // Node markers so _detect_ecosystem returns "node"
+      writeFileSync(
+        join(ctx.dir, "package.json"),
+        JSON.stringify({ name: "root" }),
+      );
+      writeFileSync(join(ctx.dir, "pnpm-lock.yaml"), "lockfileVersion: 9\n");
+      // .sln also present
+      writeFileSync(join(ctx.dir, "Foo.sln"), "");
+      // Scope target is a dotnet project (no package.json inside)
+      const scopeDir = join(ctx.dir, "src/Api");
+      mkdirSync(scopeDir, { recursive: true });
+
+      const result = runBash(
+        `
+source ${JSON.stringify(join(LIB_DIR, "defaults.sh"))}
+
+DETECTED_AGENT_TYPE="claude"
+AGENT_COMMAND="claude -p"
+detect_agent_type() { DETECTED_AGENT_TYPE="claude"; }
+
+source ${JSON.stringify(join(LIB_DIR, "prompt.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "json.sh"))}
+source ${JSON.stringify(join(LIB_DIR, "scope.sh"))}
+
+PLAN_SCOPE="src/Api"
+FEEDBACK_COMMANDS="pnpm build,pnpm test,dotnet build,dotnet test"
+CONFIG_WORKSPACES=""
+
+resolve_scoped_feedback
+echo "\$FEEDBACK_COMMANDS"
+`,
+        ctx.dir,
+      ).trim();
+
+      // dotnet commands get scoped; pnpm commands pass through unchanged
+      // (no package.json in scope dir, so pnpm can't be rewritten)
+      expect(result).toBe(
+        "pnpm build,pnpm test,dotnet build src/Api,dotnet test src/Api",
+      );
+    });
   },
 );
 
@@ -485,5 +550,51 @@ describe("init --yes dotnet monorepo", () => {
     expect(config.feedbackCommands).toContain("pnpm test");
     expect(config.feedbackCommands).toContain("dotnet build");
     expect(config.feedbackCommands).toContain("dotnet test");
+  });
+
+  it("init --yes does not write workspaces to config for .NET monorepo", () => {
+    const content = slnContent([
+      { name: "Api", path: "src\\Api\\Api.csproj" },
+      { name: "Domain", path: "src\\Domain\\Domain.csproj" },
+      { name: "Tests", path: "test\\Tests\\Tests.csproj" },
+    ]);
+    writeFileSync(join(ctx.dir, "MySolution.sln"), content);
+
+    runCliOutput(["init", "--yes"], ctx.dir);
+
+    const config = JSON.parse(
+      readFileSync(join(ctx.dir, "ralphai.json"), "utf-8"),
+    );
+    expect(config.workspaces).toBeUndefined();
+  });
+
+  it("init --yes with mixed repo shows all workspaces from both ecosystems", () => {
+    // Node workspace setup
+    writeFileSync(join(ctx.dir, "pnpm-lock.yaml"), "lockfileVersion: 9\n");
+    writeFileSync(
+      join(ctx.dir, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+    );
+    const webDir = join(ctx.dir, "packages", "web");
+    mkdirSync(webDir, { recursive: true });
+    writeFileSync(
+      join(webDir, "package.json"),
+      JSON.stringify({ name: "@org/web" }),
+    );
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "root", scripts: { build: "tsc" } }),
+    );
+
+    // .sln setup with distinct projects
+    const slnText = slnContent([{ name: "Api", path: "src\\Api\\Api.csproj" }]);
+    writeFileSync(join(ctx.dir, "MyApp.sln"), slnText);
+
+    const output = stripLogo(runCliOutput(["init", "--yes"], ctx.dir));
+
+    // Should mention both Node and .NET workspaces
+    expect(output).toContain("2 packages");
+    expect(output).toContain("@org/web");
+    expect(output).toContain("Api");
   });
 });

--- a/src/project-detection.ts
+++ b/src/project-detection.ts
@@ -200,6 +200,8 @@ function expandWorkspaceGlobs(
  * Returns an array of { name, path } for each discovered package.
  */
 export function detectWorkspaces(cwd: string): WorkspacePackage[] {
+  let nodeWorkspaces: WorkspacePackage[] = [];
+
   // 1. pnpm-workspace.yaml
   const pnpmWsPath = join(cwd, "pnpm-workspace.yaml");
   if (existsSync(pnpmWsPath)) {
@@ -207,46 +209,61 @@ export function detectWorkspaces(cwd: string): WorkspacePackage[] {
       const content = readFileSync(pnpmWsPath, "utf-8");
       const globs = parsePnpmWorkspaceGlobs(content);
       if (globs.length > 0) {
-        return expandWorkspaceGlobs(cwd, globs);
+        nodeWorkspaces = expandWorkspaceGlobs(cwd, globs);
       }
     } catch {
       // Fall through
     }
   }
 
-  // 2. package.json workspaces field
-  const pkgPath = join(cwd, "package.json");
-  if (existsSync(pkgPath)) {
-    try {
-      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-      const workspaces = pkg.workspaces;
-      if (Array.isArray(workspaces)) {
-        return expandWorkspaceGlobs(cwd, workspaces);
+  // 2. package.json workspaces field (only if pnpm didn't find anything)
+  if (nodeWorkspaces.length === 0) {
+    const pkgPath = join(cwd, "package.json");
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+        const workspaces = pkg.workspaces;
+        if (Array.isArray(workspaces)) {
+          nodeWorkspaces = expandWorkspaceGlobs(cwd, workspaces);
+        } else if (workspaces && Array.isArray(workspaces.packages)) {
+          // Yarn also supports { packages: [...] } object form
+          nodeWorkspaces = expandWorkspaceGlobs(cwd, workspaces.packages);
+        }
+      } catch {
+        // Fall through
       }
-      // Yarn also supports { packages: [...] } object form
-      if (workspaces && Array.isArray(workspaces.packages)) {
-        return expandWorkspaceGlobs(cwd, workspaces.packages);
-      }
-    } catch {
-      // Fall through
     }
   }
 
-  // 3. .sln file — parse Project entries to discover .csproj sub-projects
+  // 3. .sln file — parse Project entries to discover .csproj sub-projects.
+  //    Merged with Node workspaces when both exist (mixed repos).
+  let dotnetWorkspaces: WorkspacePackage[] = [];
   const slnFiles = findSlnFiles(cwd);
   if (slnFiles.length > 0) {
     try {
       const content = readFileSync(join(cwd, slnFiles[0]!), "utf-8");
       const projects = parseSolutionProjects(content);
       if (projects.length > 0) {
-        return projects;
+        dotnetWorkspaces = projects;
       }
     } catch {
       // Fall through
     }
   }
 
-  return [];
+  // Merge and deduplicate by path (Node workspaces listed first)
+  if (nodeWorkspaces.length === 0) return dotnetWorkspaces;
+  if (dotnetWorkspaces.length === 0) return nodeWorkspaces;
+
+  const seen = new Set(nodeWorkspaces.map((ws) => ws.path));
+  const merged = [...nodeWorkspaces];
+  for (const ws of dotnetWorkspaces) {
+    if (!seen.has(ws.path)) {
+      seen.add(ws.path);
+      merged.push(ws);
+    }
+  }
+  return merged;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -18,18 +18,11 @@ import { RESET, DIM, TEXT } from "./utils.ts";
 import { runSelfUpdate } from "./self-update.ts";
 import { extractScope } from "./frontmatter.ts";
 import {
-  detectPackageManager,
   detectFeedbackCommands,
   detectWorkspaces,
-  deriveScopedFeedback,
-  deriveDotnetScopedFeedback,
   detectProject,
 } from "./project-detection.ts";
-import type {
-  DetectedPM,
-  DetectedProject,
-  WorkspacePackage,
-} from "./project-detection.ts";
+import type { DetectedProject, WorkspacePackage } from "./project-detection.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1465,47 +1458,18 @@ async function runRalphaiInit(
     }
     answers = wizardResult;
 
-    // Workspace detection for interactive mode
+    // Workspace detection for interactive mode — show summary, no config generation.
+    // Scoped feedback is auto-derived at runtime; the workspaces config key is an
+    // escape hatch users add manually when they need custom overrides.
     const workspaces = detectWorkspaces(cwd);
     if (workspaces.length > 0) {
       const names = workspaces.map((ws) => ws.name).join(", ");
       clack.log.info(
         `Detected ${workspaces.length} workspace packages: ${names}`,
       );
-
-      const addWorkspaces = await clack.confirm({
-        message:
-          "Add workspace-specific feedback commands to config? (recommended for large monorepos)",
-      });
-
-      if (!clack.isCancel(addWorkspaces) && addWorkspaces) {
-        const pm = detectPackageManager(cwd);
-        const rootCommands = answers.feedbackCommands
-          .split(",")
-          .map((c) => c.trim())
-          .filter((c) => c.length > 0);
-
-        const wsConfig: Record<string, { feedbackCommands: string[] }> = {};
-        for (const ws of workspaces) {
-          if (rootCommands.length === 0) {
-            wsConfig[ws.path] = { feedbackCommands: [] };
-          } else if (pm) {
-            wsConfig[ws.path] = {
-              feedbackCommands: deriveScopedFeedback(pm, rootCommands, ws.name),
-            };
-          } else if (rootCommands.some((c) => c.startsWith("dotnet "))) {
-            wsConfig[ws.path] = {
-              feedbackCommands: deriveDotnetScopedFeedback(
-                rootCommands,
-                ws.path,
-              ),
-            };
-          } else {
-            wsConfig[ws.path] = { feedbackCommands: [] };
-          }
-        }
-        answers.workspaces = wsConfig;
-      }
+      clack.log.info(
+        "Feedback commands will be auto-filtered by scope at runtime. Add custom overrides to the workspaces key in ralphai.json if needed.",
+      );
     }
   }
 

--- a/src/runner-config.test.ts
+++ b/src/runner-config.test.ts
@@ -303,7 +303,7 @@ ${cleanupFile}
 
     const config = readFileSync(join(templateLib, "config.sh"), "utf-8");
     // Config file loader reads promptMode from JSON
-    expect(config).toContain('"promptMode"');
+    expect(config).toContain("'promptMode' in data");
     expect(config).toContain("CONFIG_PROMPT_MODE=");
     // Env var override
     expect(config).toContain("RALPHAI_PROMPT_MODE");
@@ -478,7 +478,7 @@ echo "$PROMPT_MODE"
 
     const config = readFileSync(join(templateLib, "config.sh"), "utf-8");
     // Config file loader reads continuous from JSON
-    expect(config).toContain('"continuous"');
+    expect(config).toContain("'continuous' in data");
     expect(config).toContain("CONFIG_CONTINUOUS=");
     // Env var override
     expect(config).toContain("RALPHAI_CONTINUOUS");
@@ -655,7 +655,7 @@ echo "$CONTINUOUS"
 
     const config = readFileSync(join(templateLib, "config.sh"), "utf-8");
     // Config file loader reads autoCommit from JSON
-    expect(config).toContain('"autoCommit"');
+    expect(config).toContain("'autoCommit' in data");
     expect(config).toContain("CONFIG_AUTO_COMMIT=");
     // Env var override
     expect(config).toContain("RALPHAI_AUTO_COMMIT");
@@ -901,9 +901,7 @@ echo "$AUTO_COMMIT"
       join(__dirname, "..", "runner", "lib", "config.sh"),
       "utf-8",
     );
-    expect(config).toContain(
-      'validate_enum "$value" "$config_path: \'mode\'" "branch" "pr" "patch"',
-    );
+    expect(config).toContain("!['branch','pr','patch'].includes(v)");
   });
 
   it("scaffolded config.sh validates RALPHAI_MODE env var as branch|pr|patch", () => {


### PR DESCRIPTION
## Summary

- **Remove workspace prompt from init.** The interactive and `--yes` init flows no longer generate a `workspaces` key in `ralphai.json`. The runner already auto-derives scoped feedback at runtime, so writing per-package overrides was pure bloat (463 identical entries in large .NET monorepos). The `workspaces` key remains supported as a manual escape hatch.
- **Fix mixed-repo workspace detection.** `detectWorkspaces()` now merges Node and .NET workspaces instead of early-returning on the first ecosystem match. Duplicates are removed by path.
- **Fix dotnet command scoping in mixed repos.** `_rewrite_command()` now scopes dotnet commands regardless of primary ecosystem. `resolve_scoped_feedback()` no longer bails when the scope directory lacks a `package.json` (common for .NET sub-projects in a Node-primary repo).
- **Consolidate config loading into a single Node.js call.** `load_config()` previously spawned ~35 separate `node -e` processes (one per config key check). On Windows, V8 startup cost accumulated to 15-30s, causing the patch-mode test to flake at its 30s timeout. Now uses a single `node -e` invocation that validates and extracts all config values at once.

## Test results

All 261 tests pass. Patch-mode test dropped from 30s timeout to ~5s (isolated) / ~21s (under full suite load).

## Files changed

| File | Change |
|------|--------|
| `src/ralphai.ts` | Remove workspace prompt from init, remove unused imports |
| `src/project-detection.ts` | Merge Node + .NET workspaces, deduplicate by path |
| `runner/lib/config.sh` | Consolidate `load_config()` from ~35 node calls to 1 |
| `runner/lib/scope.sh` | Scope dotnet cmds in mixed repos, don't bail on missing package.json |
| `src/dotnet-monorepo.test.ts` | Update + add tests for mixed-repo detection, init, and scoping |
| `src/runner-config.test.ts` | Update scaffolding assertions for new config.sh structure |
| `README.md`, `docs/cli-reference.md`, `docs/how-ralphai-works.md` | Sync docs with behavior changes |