### PR TITLE
feat(init): copy plan template guides into .ralphai/plans/ on init

### DIFF
--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -33,6 +33,17 @@ describe("init command", () => {
     expect(existsSync(join(ctx.dir, ".ralphai", "ralphai.sh"))).toBe(false);
     expect(existsSync(join(ctx.dir, ".ralphai", "lib"))).toBe(false);
 
+    // Plan template guides
+    expect(existsSync(join(ctx.dir, ".ralphai", "plans", "feature.md"))).toBe(
+      true,
+    );
+    expect(existsSync(join(ctx.dir, ".ralphai", "plans", "bugfix.md"))).toBe(
+      true,
+    );
+    expect(existsSync(join(ctx.dir, ".ralphai", "plans", "refactor.md"))).toBe(
+      true,
+    );
+
     // Pipeline subdirectories (no .gitkeep — .ralphai/ is fully gitignored)
     expect(existsSync(join(ctx.dir, ".ralphai", "pipeline", "backlog"))).toBe(
       true,
@@ -67,6 +78,20 @@ describe("init command", () => {
     expect(learnings).toContain("# Ralphai Learnings");
     expect(learnings).toContain("gitignored");
     expect(learnings).toContain("AGENTS.md");
+  });
+
+  it("init --yes copies plan template guides from source templates", () => {
+    runCliOutput(["init", "--yes"], ctx.dir);
+
+    const templatesDir = join(__dirname, "..", "templates", "ralphai", "plans");
+    for (const guide of ["feature.md", "bugfix.md", "refactor.md"]) {
+      const source = readFileSync(join(templatesDir, guide), "utf-8");
+      const scaffolded = readFileSync(
+        join(ctx.dir, ".ralphai", "plans", guide),
+        "utf-8",
+      );
+      expect(scaffolded).toBe(source);
+    }
   });
 
   it("init --yes generates config with auto-detected or default agent command", () => {
@@ -189,6 +214,7 @@ describe("init command", () => {
     expect(output).toContain("ralphai worktree");
     expect(output).toContain("ralphai.json");
     expect(output).toContain("PLANNING.md");
+    expect(output).toContain("plans/");
     expect(output).toContain("LEARNINGS.md");
   });
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -594,6 +594,13 @@ function scaffold(
     join(ralphaiDir, "PLANNING.md"),
   );
 
+  // Copy plan template guides
+  const plansDir = join(ralphaiDir, "plans");
+  mkdirSync(plansDir, { recursive: true });
+  for (const guide of ["feature.md", "bugfix.md", "refactor.md"]) {
+    copyFileSync(join(templatesDir, "plans", guide), join(plansDir, guide));
+  }
+
   // Generate config (JSON format) — all 17 keys with explicit defaults
   const feedbackCommands = answers.feedbackCommands
     ? answers.feedbackCommands
@@ -789,6 +796,9 @@ Project-specific guidance for AI coding agents working in this codebase.
   );
   console.log(`  .ralphai/README.md         ${DIM}Operational docs${RESET}`);
   console.log(`  .ralphai/PLANNING.md       ${DIM}How to write plans${RESET}`);
+  console.log(
+    `  .ralphai/plans/            ${DIM}Plan guides (feature, bugfix, refactor)${RESET}`,
+  );
   console.log(
     `  .ralphai/LEARNINGS.md      ${DIM}Ralphai-specific learnings${RESET}`,
   );

--- a/templates/ralphai/PLANNING.md
+++ b/templates/ralphai/PLANNING.md
@@ -10,7 +10,7 @@ Guide for coding agents writing plan files that Ralphai executes autonomously. P
    - **Bug fix** — something is broken
    - **Refactor** — structural change, no behavior change
 
-   See the [plan templates](https://github.com/mfaux/ralphai/tree/main/templates/ralphai/plans) for detailed templates with examples.
+   See the [plan templates](plans/) for detailed templates with examples.
 
 3. **Explore the codebase.** Before writing anything, find the files, functions, and line numbers relevant to the work. The plan must contain concrete references, not guesses.
 4. **Fill in the template.** Follow the guide's template. Every file path, function name, and line number you include saves Ralphai tokens it would otherwise spend exploring.


### PR DESCRIPTION
## Summary

- **Copies plan template guides** (`feature.md`, `bugfix.md`, `refactor.md`) into `.ralphai/plans/` during `ralphai init`, so they are available locally alongside the other scaffolded docs.
- **Updates the PLANNING.md link** from the GitHub URL to a relative `plans/` path, which resolves correctly in both the source repo and the scaffolded `.ralphai/` directory.
- **Adds tests** verifying the plan guides are scaffolded, match the source templates, and appear in the init output.

## Motivation

The plan templates were only reachable via a GitHub link in PLANNING.md. This meant agents and users needed internet access to reference them, and the templates weren't discoverable alongside the other `.ralphai/` docs. Including them locally makes them immediately available after init.

## Changes

| File | Change |
|---|---|
| `src/ralphai.ts` | Create `.ralphai/plans/` and copy the 3 guide files during scaffold |
| `src/ralphai.ts` | Add `.ralphai/plans/` to the "Created:" success output |
| `templates/ralphai/PLANNING.md` | Change GitHub URL to relative `plans/` path |
| `src/init.test.ts` | Assert plan guides exist, match source, and appear in output |

## Testing

All 42 init tests pass (`npx vitest run src/init.test.ts`), including the new assertions.