### PR TITLE
fix(init): qualify Node.js detection and truncate workspace display

### DIFF
--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -257,7 +257,9 @@ scope: packages/web
 
 ### Multi-Ecosystem Detection
 
-When a repository contains markers for multiple ecosystems (e.g., a `.sln` file alongside a `package.json`), Ralphai detects all of them and merges their feedback commands into a single list. The primary ecosystem (Node.js when present, otherwise the first detected) determines the project type, and secondary ecosystems contribute additional feedback commands.
+When a repository contains markers for multiple ecosystems (e.g., a `.sln` file alongside a `package.json`), Ralphai detects all of them and merges their feedback commands into a single list. The primary ecosystem is the first detected with sufficient substance; secondary ecosystems contribute additional feedback commands.
+
+A bare `package.json` with no lock file, no `scripts`, and no `workspaces` field is treated as a tooling artifact (e.g., used only for `npm install <tool>`) and does not claim Node.js as the primary ecosystem. This prevents stub `package.json` files from masking the real project type in .NET-primary or other non-Node repos.
 
 ### Scoped Feedback
 
@@ -303,6 +305,36 @@ When automatic derivation is insufficient, use the `workspaces` config key in `r
 ```
 
 Workspace overrides take precedence over automatic derivation. Plans without a scope use the top-level feedback commands unchanged.
+
+### Independent Sub-Projects
+
+Some repos contain Node.js (or other) sub-projects that are not connected to the root by any workspace configuration. Each sub-project has its own lock file and dependency tree. Common examples: an Nx frontend app inside a .NET monorepo, standalone documentation sites, or Playwright E2E test suites.
+
+Automatic scope rewriting uses workspace filters (`npm -w`, `pnpm --filter`), which require the root package manager to know about the sub-project. Independent sub-projects are not discoverable this way, so plans that target them need manual `workspaces` overrides with commands that run from the repo root:
+
+```json
+{
+  "feedbackCommands": ["dotnet build", "dotnet test"],
+  "workspaces": {
+    "ui": {
+      "feedbackCommands": ["cd ui && npm run build", "cd ui && npm test"]
+    },
+    "docs": {
+      "feedbackCommands": ["cd docs && npm run build"]
+    }
+  }
+}
+```
+
+Then target the sub-project from a plan's frontmatter:
+
+```yaml
+---
+scope: ui
+---
+```
+
+The runner will use the overridden feedback commands for that scope instead of the root-level ones.
 
 ## Learnings System
 

--- a/runner/lib/scope.sh
+++ b/runner/lib/scope.sh
@@ -5,14 +5,30 @@
 # --- Detect the project ecosystem ---
 # Sets _RALPHAI_ECOSYSTEM to: node, dotnet, go, rust, java, python, or unknown.
 # Uses the same priority order as the TypeScript detectProject() function.
+# A bare package.json (no lock file, no scripts, no workspaces) is NOT enough
+# to claim "node" — it may be a tooling artifact (e.g. for npm install <tool>).
 _detect_ecosystem() {
-  # Node.js — check JS lockfiles and package.json first (highest priority)
+  # Node.js — lock files or Deno config are unambiguous signals
   if [[ -f "pnpm-lock.yaml" || -f "pnpm-workspace.yaml" || \
         -f "yarn.lock" || -f "bun.lockb" || -f "bun.lock" || \
-        -f "package-lock.json" || -f "deno.json" || -f "deno.jsonc" || \
-        -f "package.json" ]]; then
+        -f "package-lock.json" || -f "deno.json" || -f "deno.jsonc" ]]; then
     _RALPHAI_ECOSYSTEM="node"
     return
+  fi
+
+  # package.json exists but no lock file — only claim node if it has scripts or workspaces
+  if [[ -f "package.json" ]]; then
+    local _has_substance
+    _has_substance=$(node -e "
+      const p = JSON.parse(require('fs').readFileSync('package.json','utf-8'));
+      const s = p.scripts && Object.keys(p.scripts).length > 0;
+      const w = !!p.workspaces;
+      console.log(s || w ? 'yes' : 'no');
+    " 2>/dev/null) || _has_substance="no"
+    if [[ "$_has_substance" == "yes" ]]; then
+      _RALPHAI_ECOSYSTEM="node"
+      return
+    fi
   fi
 
   # .NET — .sln or .csproj

--- a/src/init-multi-language.test.ts
+++ b/src/init-multi-language.test.ts
@@ -107,4 +107,17 @@ describe("init multi-language detection", () => {
     // Node should win over dotnet
     expect(output).toMatch(/Project:.*pnpm/);
   });
+
+  it("init --yes with bare package.json and .sln detects dotnet as primary", () => {
+    // Stub package.json with no scripts, no lock file, no workspaces
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ dependencies: {} }),
+    );
+    writeFileSync(join(ctx.dir, "MyApp.sln"), "");
+    const output = stripLogo(runCliOutput(["init", "--yes"], ctx.dir));
+
+    // Dotnet should win because package.json lacks substance
+    expect(output).toMatch(/Project:.*dotnet/);
+  });
 });

--- a/src/monorepo-init.test.ts
+++ b/src/monorepo-init.test.ts
@@ -242,3 +242,34 @@ describe("pnpm-workspace.yaml parsing", () => {
     expect(combined).toContain("@org/dashboard");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Workspace display truncation
+// ---------------------------------------------------------------------------
+
+describe("workspace display truncation", () => {
+  const ctx = useTempGitDir();
+
+  it("truncates workspace names when more than 10 are detected", () => {
+    // Create a .sln file with 15 projects to trigger truncation
+    const projectLines: string[] = [];
+    for (let i = 1; i <= 15; i++) {
+      projectLines.push(
+        `Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project${i}", "src\\Project${i}\\Project${i}.csproj", "{00000000-0000-0000-0000-00000000000${String(i).padStart(1, "0")}}"`,
+      );
+    }
+    writeFileSync(join(ctx.dir, "App.sln"), projectLines.join("\n") + "\n");
+
+    const result = runCli(["init", "--yes"], ctx.dir);
+    const combined = result.stdout + result.stderr;
+
+    expect(combined).toContain("15 packages");
+    // First 10 should be visible
+    expect(combined).toContain("Project1");
+    expect(combined).toContain("Project10");
+    // Should show truncation indicator
+    expect(combined).toContain("... and 5 more");
+    // Project11-15 should NOT be in the name list
+    expect(combined).not.toMatch(/Project11[^5]/);
+  });
+});

--- a/src/monorepo-scope.test.ts
+++ b/src/monorepo-scope.test.ts
@@ -406,8 +406,66 @@ echo "$_RALPHAI_ECOSYSTEM"
       return result;
     }
 
-    it("detects node from package.json", () => {
-      expect(detectEcosystem(["package.json"])).toBe("node");
+    /** Create files with specific content, run _detect_ecosystem, then clean up */
+    function detectEcosystemWithContent(
+      files: { path: string; content: string }[],
+    ): string {
+      for (const f of files) {
+        writeFileSync(join(ctx.dir, f.path), f.content);
+      }
+
+      const result = runBash(
+        `
+source ${JSON.stringify(join(LIB_DIR, "scope.sh"))}
+_detect_ecosystem
+echo "$_RALPHAI_ECOSYSTEM"
+`,
+        ctx.dir,
+      ).trim();
+
+      for (const f of files) {
+        try {
+          rmSync(join(ctx.dir, f.path));
+        } catch {
+          /* ignore */
+        }
+      }
+
+      return result;
+    }
+
+    it("detects node from package.json with scripts", () => {
+      expect(
+        detectEcosystemWithContent([
+          {
+            path: "package.json",
+            content: JSON.stringify({ scripts: { build: "tsc" } }),
+          },
+        ]),
+      ).toBe("node");
+    });
+
+    it("does not detect node from bare package.json without substance", () => {
+      expect(
+        detectEcosystemWithContent([
+          {
+            path: "package.json",
+            content: JSON.stringify({ dependencies: {} }),
+          },
+        ]),
+      ).toBe("unknown");
+    });
+
+    it("detects dotnet when bare package.json exists alongside .sln", () => {
+      expect(
+        detectEcosystemWithContent([
+          {
+            path: "package.json",
+            content: JSON.stringify({ dependencies: {} }),
+          },
+          { path: "Foo.sln", content: "" },
+        ]),
+      ).toBe("dotnet");
     });
 
     it("detects node from pnpm-lock.yaml", () => {
@@ -446,8 +504,10 @@ echo "$_RALPHAI_ECOSYSTEM"
       expect(detectEcosystem([])).toBe("unknown");
     });
 
-    it("node wins over dotnet when both present", () => {
-      expect(detectEcosystem(["package.json", "Foo.csproj"])).toBe("node");
+    it("node wins over dotnet when both present with lock file", () => {
+      expect(
+        detectEcosystem(["pnpm-lock.yaml", "package.json", "Foo.csproj"]),
+      ).toBe("node");
     });
   },
 );

--- a/src/project-detection.test.ts
+++ b/src/project-detection.test.ts
@@ -12,6 +12,7 @@ import {
   detectPythonProject,
   detectJavaProject,
   detectFeedbackCommands,
+  hasNodeSubstance,
 } from "./project-detection.ts";
 
 describe("detectPackageManager", () => {
@@ -186,6 +187,126 @@ describe("detectNodeProject", () => {
     expect(project).not.toBeNull();
     expect(project!.feedbackCommands).toEqual([]);
   });
+
+  it("returns null for bare package.json with no lock file, scripts, or workspaces", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ dependencies: {} }),
+    );
+
+    const project = detectNodeProject(ctx.dir);
+    expect(project).toBeNull();
+  });
+
+  it("detects node when package.json has scripts but no lock file", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({
+        name: "test",
+        scripts: { build: "tsc" },
+      }),
+    );
+
+    const project = detectNodeProject(ctx.dir);
+    expect(project).not.toBeNull();
+    expect(project!.ecosystem).toBe("node");
+  });
+
+  it("detects node when package.json has workspaces but no lock file", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({
+        name: "test",
+        workspaces: ["packages/*"],
+      }),
+    );
+
+    const project = detectNodeProject(ctx.dir);
+    expect(project).not.toBeNull();
+    expect(project!.ecosystem).toBe("node");
+  });
+
+  it("detects node when lock file exists but package.json has no scripts", () => {
+    writeFileSync(join(ctx.dir, "package-lock.json"), "{}");
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test" }),
+    );
+
+    const project = detectNodeProject(ctx.dir);
+    expect(project).not.toBeNull();
+    expect(project!.ecosystem).toBe("node");
+  });
+});
+
+describe("hasNodeSubstance", () => {
+  const ctx = useTempDir();
+
+  it("returns false for empty directory", () => {
+    expect(hasNodeSubstance(ctx.dir)).toBe(false);
+  });
+
+  it("returns false for bare package.json with no lock file or scripts", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ dependencies: {} }),
+    );
+    expect(hasNodeSubstance(ctx.dir)).toBe(false);
+  });
+
+  it("returns true when package-lock.json exists", () => {
+    writeFileSync(join(ctx.dir, "package-lock.json"), "{}");
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns true when yarn.lock exists", () => {
+    writeFileSync(join(ctx.dir, "yarn.lock"), "");
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns true when pnpm-lock.yaml exists", () => {
+    writeFileSync(join(ctx.dir, "pnpm-lock.yaml"), "");
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns true when bun.lockb exists", () => {
+    writeFileSync(join(ctx.dir, "bun.lockb"), "");
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns true when pnpm-workspace.yaml exists", () => {
+    writeFileSync(join(ctx.dir, "pnpm-workspace.yaml"), "packages:\n");
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns true when deno.json exists", () => {
+    writeFileSync(join(ctx.dir, "deno.json"), "{}");
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns true when package.json has scripts", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test", scripts: { build: "tsc" } }),
+    );
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns true when package.json has workspaces", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test", workspaces: ["packages/*"] }),
+    );
+    expect(hasNodeSubstance(ctx.dir)).toBe(true);
+  });
+
+  it("returns false when package.json has empty scripts object", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test", scripts: {} }),
+    );
+    expect(hasNodeSubstance(ctx.dir)).toBe(false);
+  });
 });
 
 describe("detectFeedbackCommands", () => {
@@ -266,6 +387,37 @@ describe("detectProject priority", () => {
     expect(project).not.toBeNull();
     expect(project!.ecosystem).toBe("dotnet");
     expect(project!.label).toBe("dotnet (solution)");
+  });
+
+  it("dotnet wins over bare package.json with no substance (ace-like repo)", () => {
+    // Simulate a .NET-primary repo with a stub package.json used only for tooling
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ dependencies: {} }),
+    );
+    writeFileSync(join(ctx.dir, "MyApp.sln"), "");
+
+    const project = detectProject(ctx.dir);
+    expect(project).not.toBeNull();
+    expect(project!.ecosystem).toBe("dotnet");
+    expect(project!.feedbackCommands).toEqual(["dotnet build", "dotnet test"]);
+  });
+
+  it("node still wins when package.json has scripts alongside .sln", () => {
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({
+        name: "test",
+        scripts: { build: "tsc", test: "vitest" },
+      }),
+    );
+    writeFileSync(join(ctx.dir, "MyApp.sln"), "");
+
+    const project = detectProject(ctx.dir);
+    expect(project).not.toBeNull();
+    expect(project!.ecosystem).toBe("node");
+    // Dotnet feedback should be merged as additional ecosystem
+    expect(project!.feedbackCommands).toContain("dotnet build");
   });
 });
 

--- a/src/project-detection.ts
+++ b/src/project-detection.ts
@@ -45,6 +45,50 @@ export interface DetectedProject {
 // ---------------------------------------------------------------------------
 
 /**
+ * Check whether the root directory has enough Node.js "substance" to be
+ * considered a real Node.js project (rather than a tooling artifact like a
+ * bare package.json used only for `npm install <tool>`).
+ *
+ * Requires at least one of:
+ * - A JS lock file at root (package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lock/bun.lockb)
+ * - A pnpm-workspace.yaml at root
+ * - A deno.json or deno.jsonc at root (unambiguous Deno project)
+ * - package.json with a `scripts` field containing at least one entry
+ * - package.json with a `workspaces` field
+ */
+export function hasNodeSubstance(cwd: string): boolean {
+  const has = (file: string) => existsSync(join(cwd, file));
+
+  // Lock files or workspace configs are strong signals
+  if (
+    has("package-lock.json") ||
+    has("yarn.lock") ||
+    has("pnpm-lock.yaml") ||
+    has("bun.lockb") ||
+    has("bun.lock") ||
+    has("pnpm-workspace.yaml") ||
+    has("deno.json") ||
+    has("deno.jsonc")
+  ) {
+    return true;
+  }
+
+  // Check package.json for scripts or workspaces
+  const pkgPath = join(cwd, "package.json");
+  if (has("package.json")) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      if (pkg.scripts && Object.keys(pkg.scripts).length > 0) return true;
+      if (pkg.workspaces) return true;
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  return false;
+}
+
+/**
  * Detect the project's package manager by checking for lock files and config
  * files in priority order. Returns null for non-JS/TS projects.
  */
@@ -422,6 +466,11 @@ export function deriveDotnetScopedFeedback(
 export function detectNodeProject(cwd: string): DetectedProject | null {
   const pm = detectPackageManager(cwd);
   if (!pm) return null;
+
+  // A bare package.json with no lock file, scripts, or workspaces is likely
+  // a tooling artifact (e.g. for installing a dev tool at the repo root).
+  // Don't let it claim primary ecosystem status over the real project.
+  if (!hasNodeSubstance(cwd)) return null;
 
   const feedbackStr = detectFeedbackCommands(cwd);
   const feedbackCommands = feedbackStr

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1449,7 +1449,13 @@ async function runRalphaiInit(
     // Workspace detection for --yes mode
     const workspaces = detectWorkspaces(cwd);
     if (workspaces.length > 0) {
-      const names = workspaces.map((ws) => ws.name).join(", ");
+      const MAX_WS_DISPLAY = 10;
+      const allNames = workspaces.map((ws) => ws.name);
+      const names =
+        allNames.length <= MAX_WS_DISPLAY
+          ? allNames.join(", ")
+          : allNames.slice(0, MAX_WS_DISPLAY).join(", ") +
+            `, ... and ${allNames.length - MAX_WS_DISPLAY} more`;
       console.log(
         `  ${DIM}Workspaces:${RESET} ${TEXT}${workspaces.length} packages${RESET} ${DIM}(${names})${RESET}`,
       );
@@ -1473,7 +1479,13 @@ async function runRalphaiInit(
     // escape hatch users add manually when they need custom overrides.
     const workspaces = detectWorkspaces(cwd);
     if (workspaces.length > 0) {
-      const names = workspaces.map((ws) => ws.name).join(", ");
+      const MAX_WS_DISPLAY = 10;
+      const allNames = workspaces.map((ws) => ws.name);
+      const names =
+        allNames.length <= MAX_WS_DISPLAY
+          ? allNames.join(", ")
+          : allNames.slice(0, MAX_WS_DISPLAY).join(", ") +
+            `, ... and ${allNames.length - MAX_WS_DISPLAY} more`;
       clack.log.info(
         `Detected ${workspaces.length} workspace packages: ${names}`,
       );


### PR DESCRIPTION
## Summary

- **Bare `package.json` no longer claims Node.js as primary ecosystem.** A `package.json` without a lock file, `scripts`, or `workspaces` field is treated as a tooling artifact (e.g., used only for `npm install <tool>`). This fixes detection in .NET-primary repos like Configit Ace where a stub `package.json` at root was masking 501 `.csproj` files.
- **Workspace display capped at 10 names.** Both `--yes` and interactive init paths now show at most 10 workspace package names with a `... and N more` suffix, preventing wall-of-text output on large monorepos.
- **Documents `workspaces` escape hatch for independent sub-projects.** New section in `docs/how-ralphai-works.md` explains how to configure feedback commands for sub-projects (like an Nx frontend inside a .NET monorepo) that aren't connected by workspace configuration.

## Changes

### `src/project-detection.ts`
- New exported `hasNodeSubstance()` function checks for lock files, `pnpm-workspace.yaml`, `deno.json`/`deno.jsonc`, or `package.json` with `scripts`/`workspaces`
- `detectNodeProject()` gates on `hasNodeSubstance()` — returns `null` without it

### `runner/lib/scope.sh`
- `_detect_ecosystem()` split into two checks: lock files (unambiguous), then `package.json` with substance verification via `node -e`

### `src/ralphai.ts`
- Both `--yes` and interactive init paths truncate workspace names at 10

### `docs/how-ralphai-works.md`
- Updated Multi-Ecosystem Detection section
- New "Independent Sub-Projects" section with config examples

### Tests (19 new tests)
- `src/project-detection.test.ts` — 14 new tests for `hasNodeSubstance` and `detectNodeProject`
- `src/init-multi-language.test.ts` — 1 new test (bare `package.json` + `.sln` → dotnet)
- `src/monorepo-init.test.ts` — 1 new test (workspace display truncation)
- `src/monorepo-scope.test.ts` — 3 new tests + updated 2 existing tests for shell-side detection

All 280 tests pass (172 skipped, 1 pre-existing timeout in `patch-mode.test.ts`).