### PR TITLE
fix(runner): use stdio inherit to prevent output buffering on Windows

### DIFF
--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -3036,14 +3036,17 @@ function runRalphaiRunner(
     // Convert Windows path to a form bash understands (forward slashes)
     const scriptPath = ralphaiSh.replace(/\\/g, "/");
 
+    // Use stdio "inherit" so the child shares the parent's file descriptors
+    // directly.  This avoids pipe-buffering issues that cause output to stall
+    // on Windows (Git Bash / mintty / PowerShell / cmd) where the MSYS2 PTY
+    // layer + Node.js pipe chain can swallow or delay agent output.  Shell-
+    // level redirection (e.g. `ralphai run > log.txt`) still works because it
+    // operates on the inherited file descriptors.
     const child = spawn(bash, [scriptPath, ...args], {
       cwd,
-      stdio: ["inherit", "pipe", "pipe"],
+      stdio: "inherit",
       env: { ...process.env },
     });
-
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
 
     return new Promise((_resolve, _reject) => {
       child.on("close", (code) => {
@@ -3058,16 +3061,13 @@ function runRalphaiRunner(
       });
     });
   } else {
-    // Unix: use async spawn with piped output so users see output in real
-    // time AND parent processes (e.g. test harness) can still capture it.
+    // Unix: inherit stdio so the child writes directly to the terminal,
+    // matching the Windows path and avoiding unnecessary pipe buffering.
     const child = spawn(ralphaiSh, args, {
       cwd,
-      stdio: ["inherit", "pipe", "pipe"],
+      stdio: "inherit",
       env: { ...process.env },
     });
-
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
 
     return new Promise((_resolve, _reject) => {
       child.on("close", (code) => {


### PR DESCRIPTION
## Summary

- Replace `stdio: ["inherit", "pipe", "pipe"]` with `stdio: "inherit"` in `runRalphaiRunner` for both Windows and Unix code paths.
- Remove the now-unnecessary `child.stdout.pipe(process.stdout)` and `child.stderr.pipe(process.stderr)` calls.

## Problem

On Windows (Git Bash / mintty / PowerShell / cmd), the MSYS2 PTY translation layer combined with Node.js pipe streams caused agent output to stall or buffer indefinitely. Users saw the runner's own echo output (turn headers, etc.) but the agent command's output either never appeared or dumped all at once after completion.

The root cause: `stdio: ["inherit", "pipe", "pipe"]` makes Node intercept stdout/stderr as in-process streams, then `.pipe()` them back to the parent's stdout/stderr. This extra pipe layer introduces buffering that interacts poorly with MSYS2's pseudo-terminal emulation on Windows.

## Fix

Use `stdio: "inherit"` so the child process shares the parent's file descriptors directly. This:

- Eliminates the pipe buffering layer entirely
- Works on all shells (Git Bash, PowerShell, cmd, native Unix terminals)
- Preserves shell-level redirection (`ralphai run > log.txt`)
- Has no downside: nothing in the codebase reads from `child.stdout`/`child.stderr` — the only usage was the pass-through `.pipe()` calls

## Verification

- `bun run build` passes
- `bun run type-check` passes
- No tests reference `runRalphaiRunner` or depend on the piped stdio behavior