### PR TITLE
chore: enable --thinking flag for opencode agent output

### DIFF
--- a/ralphai.json
+++ b/ralphai.json
@@ -1,5 +1,5 @@
 {
-  "agentCommand": "opencode run --agent build",
+  "agentCommand": "opencode run --agent build --thinking",
   "feedbackCommands": [
     "bun run build",
     "bun test",


### PR DESCRIPTION
Adds `--thinking` to the OpenCode agent command so model reasoning is streamed to the terminal during Ralphai runs. Without this flag, `opencode run` produces no visible output, making it appear hung.