### PR TITLE
fix(runner): close agent stdin to prevent hang

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -170,6 +170,10 @@ export function spawnAgent(
       return;
     }
 
+    // Close stdin so the agent knows no input is coming.
+    // Without this, agents that read or wait for stdin EOF will hang.
+    child.stdin?.end();
+
     const chunks: Buffer[] = [];
 
     child.stdout?.on("data", (data: Buffer) => {


### PR DESCRIPTION
## Problem

`spawnAgent()` spawns the agent with `stdio: ["pipe", "pipe", "pipe"]` but never closes `child.stdin`. Agents that read from stdin or wait for EOF (e.g. `opencode run`) block indefinitely, causing the runner to hang after printing the turn header.

## Fix

Close `child.stdin` immediately after spawning. This signals to the agent that no input is coming, so it proceeds with the prompt passed via CLI arguments.

## Testing

All 23 existing runner tests pass.