### PR TITLE
feat(pr): generate structured PR descriptions with categorized commits and diffstat

### DIFF
--- a/src/pr-description.test.ts
+++ b/src/pr-description.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from "vitest";
+import { execSync } from "child_process";
+import { writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { useTempDir } from "./test-utils.ts";
+import {
+  categorizeCommits,
+  formatCommitsByCategory,
+  buildCommitLog,
+  buildDiffStat,
+  buildPrBody,
+  buildContinuousPrBodyStructured,
+} from "./pr-description.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function initRepo(dir: string): void {
+  execSync("git init -b main", { cwd: dir, stdio: "ignore" });
+  execSync('git config user.email "test@test.com"', {
+    cwd: dir,
+    stdio: "ignore",
+  });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "ignore" });
+  writeFileSync(join(dir, "init.txt"), "init\n");
+  execSync('git add -A && git commit -m "init"', {
+    cwd: dir,
+    stdio: "ignore",
+  });
+}
+
+function commitFile(
+  dir: string,
+  filename: string,
+  content: string,
+  message: string,
+): void {
+  writeFileSync(join(dir, filename), content);
+  execSync(`git add -A && git commit -m "${message}"`, {
+    cwd: dir,
+    stdio: "ignore",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// categorizeCommits
+// ---------------------------------------------------------------------------
+
+describe("categorizeCommits", () => {
+  it("groups conventional commits by type", () => {
+    const log = [
+      "abc1234 feat: add user login",
+      "def5678 fix: resolve null pointer",
+      "aab9012 refactor(core): simplify logic",
+      "bbc3456 test: add unit tests",
+      "ccd7890 docs: update README",
+      "eef1234 chore: bump deps",
+    ].join("\n");
+
+    const result = categorizeCommits(log);
+    expect(result.features).toEqual(["add user login"]);
+    expect(result.fixes).toEqual(["resolve null pointer"]);
+    expect(result.refactors).toEqual(["simplify logic"]);
+    expect(result.tests).toEqual(["add unit tests"]);
+    expect(result.docs).toEqual(["update README"]);
+    expect(result.chores).toEqual(["bump deps"]);
+    expect(result.other).toEqual([]);
+  });
+
+  it("puts non-conventional commits in other", () => {
+    const log = "abc1234 random commit message";
+    const result = categorizeCommits(log);
+    expect(result.other).toEqual(["random commit message"]);
+    expect(result.features).toEqual([]);
+  });
+
+  it("handles scoped conventional commits", () => {
+    const log = "abc1234 feat(parser): add JSON support";
+    const result = categorizeCommits(log);
+    expect(result.features).toEqual(["add JSON support"]);
+  });
+
+  it("handles breaking change indicator", () => {
+    const log = "abc1234 feat!: drop Node 14 support";
+    const result = categorizeCommits(log);
+    expect(result.features).toEqual(["drop Node 14 support"]);
+  });
+
+  it("maps perf and style to refactors", () => {
+    const log = [
+      "abc1234 perf: optimize hot path",
+      "def5678 style: fix indentation",
+    ].join("\n");
+    const result = categorizeCommits(log);
+    expect(result.refactors).toEqual(["optimize hot path", "fix indentation"]);
+  });
+
+  it("maps ci, build, revert to chores", () => {
+    const log = [
+      "abc1234 ci: add GitHub Actions",
+      "def5678 build: update webpack",
+      "aab9012 revert: undo bad change",
+    ].join("\n");
+    const result = categorizeCommits(log);
+    expect(result.chores).toEqual([
+      "add GitHub Actions",
+      "update webpack",
+      "undo bad change",
+    ]);
+  });
+
+  it("returns empty categories for empty input", () => {
+    const result = categorizeCommits("");
+    expect(result.features).toEqual([]);
+    expect(result.fixes).toEqual([]);
+    expect(result.other).toEqual([]);
+  });
+
+  it("is case-insensitive for commit types", () => {
+    const log = "abc1234 FEAT: uppercase feature";
+    const result = categorizeCommits(log);
+    expect(result.features).toEqual(["uppercase feature"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCommitsByCategory
+// ---------------------------------------------------------------------------
+
+describe("formatCommitsByCategory", () => {
+  it("formats non-empty categories with headings", () => {
+    const commits = categorizeCommits(
+      [
+        "abc1234 feat: add login",
+        "def5678 fix: fix crash",
+        "aab9012 test: add tests",
+      ].join("\n"),
+    );
+    const formatted = formatCommitsByCategory(commits);
+    expect(formatted).toContain("### Features");
+    expect(formatted).toContain("- add login");
+    expect(formatted).toContain("### Bug Fixes");
+    expect(formatted).toContain("- fix crash");
+    expect(formatted).toContain("### Tests");
+    expect(formatted).toContain("- add tests");
+  });
+
+  it("omits empty categories", () => {
+    const commits = categorizeCommits("abc1234 feat: only a feature");
+    const formatted = formatCommitsByCategory(commits);
+    expect(formatted).toContain("### Features");
+    expect(formatted).not.toContain("### Bug Fixes");
+    expect(formatted).not.toContain("### Refactoring");
+  });
+
+  it("returns placeholder when no commits", () => {
+    const commits = categorizeCommits("");
+    const formatted = formatCommitsByCategory(commits);
+    expect(formatted).toBe("_No commits._");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCommitLog (integration with git)
+// ---------------------------------------------------------------------------
+
+describe("buildCommitLog", () => {
+  const ctx = useTempDir();
+
+  it("returns commits between base and head", () => {
+    initRepo(ctx.dir);
+    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
+    commitFile(ctx.dir, "a.txt", "a", "feat: add feature A");
+
+    const log = buildCommitLog("main", "feature", ctx.dir);
+    expect(log).toContain("feat: add feature A");
+  });
+
+  it("returns empty string when no commits between refs", () => {
+    initRepo(ctx.dir);
+    const log = buildCommitLog("main", "main", ctx.dir);
+    expect(log).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDiffStat (integration with git)
+// ---------------------------------------------------------------------------
+
+describe("buildDiffStat", () => {
+  const ctx = useTempDir();
+
+  it("returns diffstat between base and head", () => {
+    initRepo(ctx.dir);
+    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
+    commitFile(ctx.dir, "new-file.txt", "content\n", "feat: add new file");
+
+    const stat = buildDiffStat("main", "feature", ctx.dir);
+    expect(stat).toContain("new-file.txt");
+    expect(stat).toMatch(/\d+ file/);
+  });
+
+  it("returns empty string when no diff", () => {
+    initRepo(ctx.dir);
+    const stat = buildDiffStat("main", "main", ctx.dir);
+    expect(stat).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPrBody
+// ---------------------------------------------------------------------------
+
+describe("buildPrBody", () => {
+  const ctx = useTempDir();
+
+  it("includes summary, changes, and files changed sections", () => {
+    initRepo(ctx.dir);
+    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
+    commitFile(
+      ctx.dir,
+      "login.ts",
+      "export function login() {}",
+      "feat: add user login",
+    );
+    commitFile(
+      ctx.dir,
+      "bug.ts",
+      "export function fix() {}",
+      "fix: resolve crash on startup",
+    );
+
+    const body = buildPrBody(
+      "Add authentication system",
+      "main",
+      "feature",
+      ctx.dir,
+    );
+    expect(body).toContain("## Summary");
+    expect(body).toContain("Add authentication system");
+    expect(body).toContain("## Changes");
+    expect(body).toContain("### Features");
+    expect(body).toContain("- add user login");
+    expect(body).toContain("### Bug Fixes");
+    expect(body).toContain("- resolve crash on startup");
+    expect(body).toContain("## Files Changed");
+    expect(body).toContain("login.ts");
+    expect(body).toContain("bug.ts");
+  });
+
+  it("omits Files Changed section when no diff", () => {
+    initRepo(ctx.dir);
+    const body = buildPrBody("Empty plan", "main", "main", ctx.dir);
+    expect(body).toContain("## Summary");
+    expect(body).toContain("Empty plan");
+    expect(body).not.toContain("## Files Changed");
+  });
+
+  it("handles non-conventional commits in Other category", () => {
+    initRepo(ctx.dir);
+    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
+    commitFile(ctx.dir, "file.txt", "data", "random commit message");
+
+    const body = buildPrBody("Test plan", "main", "feature", ctx.dir);
+    expect(body).toContain("### Other");
+    expect(body).toContain("- random commit message");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildContinuousPrBodyStructured
+// ---------------------------------------------------------------------------
+
+describe("buildContinuousPrBodyStructured", () => {
+  const ctx = useTempDir();
+
+  it("includes all sections", () => {
+    initRepo(ctx.dir);
+    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
+    commitFile(ctx.dir, "a.txt", "a", "feat: implement plan A");
+
+    const body = buildContinuousPrBodyStructured(
+      ["plan-a"],
+      ["plan-b.md"],
+      "main",
+      "feature",
+      ctx.dir,
+    );
+    expect(body).toContain("## Completed Plans");
+    expect(body).toContain("- [x] plan-a");
+    expect(body).toContain("## Remaining Plans");
+    expect(body).toContain("- [ ] plan-b.md");
+    expect(body).toContain("## Changes");
+    expect(body).toContain("### Features");
+    expect(body).toContain("- implement plan A");
+    expect(body).toContain("## Files Changed");
+  });
+
+  it("shows placeholders when no plans completed", () => {
+    initRepo(ctx.dir);
+    const body = buildContinuousPrBodyStructured(
+      [],
+      [],
+      "main",
+      "main",
+      ctx.dir,
+    );
+    expect(body).toContain("_None yet._");
+    expect(body).toContain("_Backlog empty");
+  });
+});

--- a/src/pr-description.ts
+++ b/src/pr-description.ts
@@ -1,0 +1,231 @@
+/**
+ * PR description builders: structured, human-readable PR bodies.
+ *
+ * Parses conventional commits into categories, builds file-change
+ * summaries, and assembles formatted PR descriptions for both
+ * single-plan and continuous modes.
+ */
+import { execSync } from "child_process";
+import { basename } from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CategorizedCommits {
+  features: string[];
+  fixes: string[];
+  refactors: string[];
+  tests: string[];
+  docs: string[];
+  chores: string[];
+  other: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers (read-only)
+// ---------------------------------------------------------------------------
+
+function execQuiet(cmd: string, cwd: string): string | null {
+  try {
+    return execSync(cmd, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Raw one-line commit log between two refs. */
+export function buildCommitLog(
+  base: string,
+  head: string,
+  cwd: string,
+): string {
+  return (
+    execQuiet(`git log "${base}".."${head}" --oneline --no-decorate`, cwd) ?? ""
+  );
+}
+
+/** File-change diffstat between two refs. */
+export function buildDiffStat(base: string, head: string, cwd: string): string {
+  return (
+    execQuiet(`git diff "${base}".."${head}" --stat --stat-width=72`, cwd) ?? ""
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Conventional commit parsing
+// ---------------------------------------------------------------------------
+
+const CC_PATTERN =
+  /^[0-9a-f]{4,}\s+(feat|fix|refactor|test|docs|chore|ci|build|perf|style|revert)(?:\([^)]*\))?!?:\s+(.+)$/i;
+
+/** Parse a line of `git log --oneline` into {type, description}. */
+function parseCommitLine(
+  line: string,
+): { type: string; description: string } | null {
+  const m = line.match(CC_PATTERN);
+  if (!m) return null;
+  return { type: m[1]!.toLowerCase(), description: m[2]!.trim() };
+}
+
+/** Group commit lines by conventional-commit type. */
+export function categorizeCommits(commitLog: string): CategorizedCommits {
+  const result: CategorizedCommits = {
+    features: [],
+    fixes: [],
+    refactors: [],
+    tests: [],
+    docs: [],
+    chores: [],
+    other: [],
+  };
+  if (!commitLog) return result;
+
+  for (const line of commitLog.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parsed = parseCommitLine(trimmed);
+    if (!parsed) {
+      result.other.push(trimmed.replace(/^[0-9a-f]+\s+/, ""));
+      continue;
+    }
+    switch (parsed.type) {
+      case "feat":
+        result.features.push(parsed.description);
+        break;
+      case "fix":
+        result.fixes.push(parsed.description);
+        break;
+      case "refactor":
+      case "perf":
+      case "style":
+        result.refactors.push(parsed.description);
+        break;
+      case "test":
+        result.tests.push(parsed.description);
+        break;
+      case "docs":
+        result.docs.push(parsed.description);
+        break;
+      case "chore":
+      case "ci":
+      case "build":
+      case "revert":
+        result.chores.push(parsed.description);
+        break;
+      default:
+        result.other.push(parsed.description);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Body builders
+// ---------------------------------------------------------------------------
+
+/** Format categorized commits as a bullet list grouped by type. */
+export function formatCommitsByCategory(commits: CategorizedCommits): string {
+  const sections: string[] = [];
+  const map: [string, string[]][] = [
+    ["Features", commits.features],
+    ["Bug Fixes", commits.fixes],
+    ["Refactoring", commits.refactors],
+    ["Tests", commits.tests],
+    ["Documentation", commits.docs],
+    ["Maintenance", commits.chores],
+    ["Other", commits.other],
+  ];
+
+  for (const [label, items] of map) {
+    if (items.length === 0) continue;
+    sections.push(`### ${label}\n`);
+    for (const item of items) {
+      sections.push(`- ${item}`);
+    }
+    sections.push("");
+  }
+
+  return sections.length > 0 ? sections.join("\n").trimEnd() : "_No commits._";
+}
+
+/**
+ * Build a structured PR body for a single-plan PR.
+ *
+ * Sections:
+ *   ## Summary         – plan description
+ *   ## Changes         – commits grouped by type
+ *   ## Files Changed   – diffstat
+ */
+export function buildPrBody(
+  planDescription: string,
+  baseBranch: string,
+  headBranch: string,
+  cwd: string,
+): string {
+  const commitLog = buildCommitLog(baseBranch, headBranch, cwd);
+  const categorized = categorizeCommits(commitLog);
+  const formattedCommits = formatCommitsByCategory(categorized);
+  const diffStat = buildDiffStat(baseBranch, headBranch, cwd);
+
+  const parts: string[] = [
+    `## Summary\n`,
+    `${planDescription}\n`,
+    `## Changes\n`,
+    formattedCommits,
+  ];
+
+  if (diffStat) {
+    parts.push("", `## Files Changed\n`, "```", diffStat, "```");
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Build a structured PR body for continuous-mode PRs.
+ *
+ * Sections:
+ *   ## Completed Plans  – checked items
+ *   ## Remaining Plans  – unchecked items
+ *   ## Changes          – commits grouped by type
+ *   ## Files Changed    – diffstat
+ */
+export function buildContinuousPrBodyStructured(
+  completedPlans: string[],
+  remainingPlans: string[],
+  baseBranch: string,
+  headBranch: string,
+  cwd: string,
+): string {
+  const parts: string[] = ["## Completed Plans\n"];
+  if (completedPlans.length > 0) {
+    parts.push(...completedPlans.map((p) => `- [x] ${p}`));
+  } else {
+    parts.push("_None yet._");
+  }
+
+  parts.push("\n## Remaining Plans\n");
+  if (remainingPlans.length > 0) {
+    parts.push(...remainingPlans.map((r) => `- [ ] ${r}`));
+  } else {
+    parts.push("_Backlog empty — all plans processed._");
+  }
+
+  const commitLog = buildCommitLog(baseBranch, headBranch, cwd);
+  const categorized = categorizeCommits(commitLog);
+  const formattedCommits = formatCommitsByCategory(categorized);
+  const diffStat = buildDiffStat(baseBranch, headBranch, cwd);
+
+  parts.push("\n## Changes\n", formattedCommits);
+
+  if (diffStat) {
+    parts.push("", "## Files Changed\n", "```", diffStat, "```");
+  }
+
+  return parts.join("\n");
+}

--- a/src/pr-lifecycle.test.ts
+++ b/src/pr-lifecycle.test.ts
@@ -238,7 +238,7 @@ describe("buildContinuousPrBody", () => {
     expect(body).toContain("_Backlog empty");
   });
 
-  it("includes commit log section", () => {
+  it("includes changes section", () => {
     initRepo(ctx.dir);
     const body = buildContinuousPrBody(
       [],
@@ -247,8 +247,7 @@ describe("buildContinuousPrBody", () => {
       "main",
       ctx.dir,
     );
-    expect(body).toContain("## Commits");
-    expect(body).toContain("```");
+    expect(body).toContain("## Changes");
   });
 
   it("includes commits between base and head branch", () => {

--- a/src/pr-lifecycle.ts
+++ b/src/pr-lifecycle.ts
@@ -11,6 +11,10 @@ import { basename, dirname, join } from "path";
 import { extractIssueFrontmatter } from "./frontmatter.ts";
 import { checkGhAvailable, detectIssueRepo } from "./issues.ts";
 import { collectBacklogPlans } from "./plan-detection.ts";
+import {
+  buildPrBody,
+  buildContinuousPrBodyStructured,
+} from "./pr-description.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -67,12 +71,6 @@ function execQuiet(cmd: string, cwd: string): string | null {
   } catch {
     return null;
   }
-}
-
-function buildCommitLog(base: string, head: string, cwd: string): string {
-  return (
-    execQuiet(`git log "${base}".."${head}" --oneline --no-decorate`, cwd) ?? ""
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -169,8 +167,7 @@ export function createPr(options: CreatePrOptions): CreatePrResult {
   const push = pushBranch(branch, cwd, true);
   if (!push.ok) return { ok: false, prUrl: "", message: push.message };
 
-  const commitLog = buildCommitLog(baseBranch, branch, cwd);
-  const prBody = `## Summary\n\n${planDescription}\n\n## Commits\n\n\`\`\`\n${commitLog || "_No commits._"}\n\`\`\``;
+  const prBody = buildPrBody(planDescription, baseBranch, branch, cwd);
   const esc = (s: string) => s.replace(/"/g, '\\"');
 
   const prUrl = execQuiet(
@@ -216,24 +213,14 @@ export function buildContinuousPrBody(
   headBranch: string,
   cwd: string,
 ): string {
-  const parts: string[] = ["## Completed Plans\n"];
-  if (completedPlans.length > 0) {
-    parts.push(...completedPlans.map((p) => `- [x] ${p}`));
-  } else {
-    parts.push("_None yet._");
-  }
-
   const remaining = collectBacklogPlans(backlogDir).map((p) => basename(p));
-  parts.push("\n## Remaining Plans\n");
-  if (remaining.length > 0) {
-    parts.push(...remaining.map((r) => `- [ ] ${r}`));
-  } else {
-    parts.push("_Backlog empty — all plans processed._");
-  }
-
-  const commitLog = buildCommitLog(baseBranch, headBranch, cwd);
-  parts.push("\n## Commits\n", "```", commitLog || "_No commits._", "```");
-  return parts.join("\n");
+  return buildContinuousPrBodyStructured(
+    completedPlans,
+    remaining,
+    baseBranch,
+    headBranch,
+    cwd,
+  );
 }
 
 /** Create draft PR for continuous mode. Matches `create_continuous_pr()`. */


### PR DESCRIPTION
## Summary

- Replace the minimal PR body (plan heading + raw `git log --oneline`) with structured descriptions that group conventional commits by type and append a file-change diffstat
- Extract PR body building into a new `pr-description` module, keeping `pr-lifecycle` focused on lifecycle actions

## Before

```
## Summary

Plan: Add OpenCode as a Transpilation Target

## Commits

abc1234 feat: add transpilation support
def5678 fix: resolve config edge case
```

## After

```
## Summary

Add OpenCode as a Transpilation Target

## Changes

### Features

- add transpilation support

### Bug Fixes

- resolve config edge case

## Files Changed

 src/transpiler.ts | 45 ++++++++++++
 src/config.ts     |  3 +-
 2 files changed, 46 insertions(+), 2 deletions(-)
```

## Details

- New `src/pr-description.ts` (231 lines): `categorizeCommits()`, `formatCommitsByCategory()`, `buildDiffStat()`, `buildPrBody()`, `buildContinuousPrBodyStructured()`
- Simplified `src/pr-lifecycle.ts` to delegate body building to the new module
- 20 new tests in `src/pr-description.test.ts`; 1 existing test updated
- All 757 tests pass, TypeScript compiles cleanly