### PR TITLE
feat(run): add --plan flag to target a specific backlog plan

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -54,6 +54,7 @@ In monorepo projects, `init` detects workspace packages from `pnpm-workspace.yam
 --dry-run, -n                     Preview what would happen without changing anything
 --resume, -r                      Auto-commit dirty state and continue
 --allow-dirty                     Skip the clean working tree check
+--plan=<file>                     Target a specific backlog plan (default: auto-detect)
 --agent-command=<command>         Override agent CLI command
 --feedback-commands=<list>        Comma-separated feedback commands
 --base-branch=<branch>            Override base branch (default: main)

--- a/src/plan-detection.ts
+++ b/src/plan-detection.ts
@@ -31,7 +31,7 @@ export interface DetectedPlan {
 }
 
 /** Reason why no plan was detected. */
-export type DetectFailReason = "empty-backlog" | "all-blocked";
+export type DetectFailReason = "empty-backlog" | "all-blocked" | "target-not-found";
 
 /** Blocked plan info returned when detection finds no runnable plans. */
 export interface BlockedPlanInfo {
@@ -312,8 +312,10 @@ export function detectPlan(opts: {
   dryRun?: boolean;
   /** Plan slugs to skip (e.g., branch/PR collision). */
   skippedSlugs?: Set<string>;
+  /** Target a specific backlog plan by filename (e.g. "my-plan.md"). */
+  targetPlan?: string;
 }): DetectPlanResult {
-  const { dirs, worktreeBranch, dryRun = false, skippedSlugs } = opts;
+  const { dirs, worktreeBranch, dryRun = false, skippedSlugs, targetPlan } = opts;
 
   // --- 1. Check for in-progress plans ---
   const inProgressPlans: string[] = [];
@@ -358,6 +360,25 @@ export function detectPlan(opts: {
       backlogCount: 0,
       blocked: [],
     };
+  }
+
+  // --- 2b. Filter to targeted plan if --plan was specified ---
+  if (targetPlan) {
+    const normalized = targetPlan.endsWith(".md")
+      ? targetPlan
+      : `${targetPlan}.md`;
+    const match = backlogPlans.find((f) => basename(f) === normalized);
+    if (!match) {
+      return {
+        detected: false,
+        reason: "target-not-found",
+        backlogCount: backlogPlans.length,
+        blocked: [],
+      };
+    }
+    // Replace backlogPlans with just the targeted plan for the readiness check
+    backlogPlans.length = 0;
+    backlogPlans.push(match);
   }
 
   // --- 3. Filter by dependency readiness ---

--- a/src/plan-target.test.ts
+++ b/src/plan-target.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { detectPlan, type PipelineDirs } from "./plan-detection.ts";
+
+function makeDirs(base: string): PipelineDirs {
+  const wipDir = join(base, "in-progress");
+  const backlogDir = join(base, "backlog");
+  const archiveDir = join(base, "out");
+  mkdirSync(wipDir, { recursive: true });
+  mkdirSync(backlogDir, { recursive: true });
+  mkdirSync(archiveDir, { recursive: true });
+  return { wipDir, backlogDir, archiveDir };
+}
+
+describe("detectPlan with targetPlan", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ralphai-target-plan-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("selects the targeted plan from backlog", () => {
+    const dirs = makeDirs(tmpDir);
+    writeFileSync(join(dirs.backlogDir, "a-first.md"), "# A\n");
+    writeFileSync(join(dirs.backlogDir, "b-second.md"), "# B\n");
+
+    const result = detectPlan({ dirs, targetPlan: "b-second.md" });
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("b-second");
+    }
+  });
+
+  it("selects targeted plan without .md extension", () => {
+    const dirs = makeDirs(tmpDir);
+    writeFileSync(join(dirs.backlogDir, "my-plan.md"), "# My Plan\n");
+
+    const result = detectPlan({ dirs, targetPlan: "my-plan" });
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("my-plan");
+    }
+  });
+
+  it("returns target-not-found when plan does not exist", () => {
+    const dirs = makeDirs(tmpDir);
+    writeFileSync(join(dirs.backlogDir, "other.md"), "# Other\n");
+
+    const result = detectPlan({ dirs, targetPlan: "missing.md" });
+    expect(result.detected).toBe(false);
+    if (!result.detected) {
+      expect(result.reason).toBe("target-not-found");
+      expect(result.backlogCount).toBe(1);
+    }
+  });
+
+  it("returns target-not-found when backlog is empty", () => {
+    const dirs = makeDirs(tmpDir);
+
+    const result = detectPlan({ dirs, targetPlan: "anything.md" });
+    expect(result.detected).toBe(false);
+    if (!result.detected) {
+      expect(result.reason).toBe("empty-backlog");
+    }
+  });
+
+  it("still resumes in-progress plans regardless of targetPlan", () => {
+    const dirs = makeDirs(tmpDir);
+    // In-progress plan exists
+    const slugDir = join(dirs.wipDir, "active");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "active.md"), "# Active\n");
+    // Targeted plan also exists in backlog
+    writeFileSync(join(dirs.backlogDir, "new-plan.md"), "# New\n");
+
+    const result = detectPlan({ dirs, targetPlan: "new-plan.md" });
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      // In-progress takes priority over targetPlan
+      expect(result.plan.planSlug).toBe("active");
+      expect(result.plan.resumed).toBe(true);
+    }
+  });
+
+  it("respects dependency readiness for targeted plan", () => {
+    const dirs = makeDirs(tmpDir);
+    writeFileSync(
+      join(dirs.backlogDir, "blocked.md"),
+      "---\ndepends-on: [prerequisite.md]\n---\n# Blocked\n",
+    );
+    writeFileSync(join(dirs.backlogDir, "ready.md"), "# Ready\n");
+
+    const result = detectPlan({ dirs, targetPlan: "blocked.md" });
+    expect(result.detected).toBe(false);
+    if (!result.detected) {
+      expect(result.reason).toBe("all-blocked");
+    }
+  });
+
+  it("promotes targeted plan to in-progress", () => {
+    const dirs = makeDirs(tmpDir);
+    writeFileSync(join(dirs.backlogDir, "target.md"), "# Target\n");
+
+    const result = detectPlan({ dirs, targetPlan: "target.md" });
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("target");
+      expect(result.plan.resumed).toBe(false);
+      expect(existsSync(join(dirs.wipDir, "target", "target.md"))).toBe(true);
+      expect(existsSync(join(dirs.backlogDir, "target.md"))).toBe(false);
+    }
+  });
+
+  it("does not modify filesystem in dry-run mode", () => {
+    const dirs = makeDirs(tmpDir);
+    writeFileSync(join(dirs.backlogDir, "target.md"), "# Target\n");
+
+    const result = detectPlan({ dirs, targetPlan: "target.md", dryRun: true });
+    expect(result.detected).toBe(true);
+    // File should still be in backlog
+    expect(existsSync(join(dirs.backlogDir, "target.md"))).toBe(true);
+  });
+
+  it("without targetPlan picks first ready plan (default behavior)", () => {
+    const dirs = makeDirs(tmpDir);
+    writeFileSync(join(dirs.backlogDir, "a-plan.md"), "# A\n");
+    writeFileSync(join(dirs.backlogDir, "b-plan.md"), "# B\n");
+
+    const result = detectPlan({ dirs });
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("a-plan");
+    }
+  });
+});

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -2713,6 +2713,9 @@ const KNOWN_RUN_FLAGS = new Set([
   "-h",
 ]);
 
+/** Patterns for run flags parsed directly (not by config resolver). */
+const RUN_FLAG_PATTERNS_EXTRA = [/^--plan=/];
+
 /** Patterns for config flags that are parsed by the TS config resolver. */
 const CONFIG_FLAG_PATTERNS = [
   /^--turns=/,
@@ -2737,6 +2740,7 @@ const CONFIG_FLAG_PATTERNS = [
 
 function isRecognizedRunFlag(arg: string): boolean {
   if (KNOWN_RUN_FLAGS.has(arg)) return true;
+  if (RUN_FLAG_PATTERNS_EXTRA.some((p) => p.test(arg))) return true;
   return CONFIG_FLAG_PATTERNS.some((p) => p.test(arg));
 }
 
@@ -2754,6 +2758,7 @@ function showRunHelp(): void {
     "  --dry-run, -n                    Preview what Ralphai would do without mutating state",
     "  --resume, -r                     Auto-commit dirty state and continue",
     "  --allow-dirty                    Skip the clean working tree check",
+    "  --plan=<file>                    Target a specific backlog plan (default: auto-detect)",
     "  --agent-command=<command>        Override agent CLI command (e.g. 'claude -p')",
     "  --feedback-commands=<list>       Comma-separated feedback commands (e.g. 'npm test,npm run build')",
     "  --base-branch=<branch>           Override base branch (default: main)",
@@ -2887,6 +2892,8 @@ async function runRalphaiRunner(
   let hasAllowDirty = runArgs.includes("--allow-dirty");
   const hasResume = runArgs.includes("--resume") || runArgs.includes("-r");
   const hasShowConfig = runArgs.includes("--show-config");
+  const planFlag = runArgs.find((a) => a.startsWith("--plan="));
+  const targetPlan = planFlag ? planFlag.slice("--plan=".length) : undefined;
 
   // --- Resolve config: defaults -> file -> env -> CLI ---
   const configFilePath = join(ralphaiRoot, "ralphai.json");
@@ -2984,6 +2991,7 @@ async function runRalphaiRunner(
     dryRun: isDryRun,
     resume: hasResume,
     allowDirty: hasAllowDirty,
+    plan: targetPlan,
   };
 
   await runRunner(runnerOpts);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -73,6 +73,8 @@ export interface RunnerOptions {
   resume: boolean;
   /** Whether --allow-dirty was passed. */
   allowDirty: boolean;
+  /** Target a specific backlog plan by filename (e.g. "my-plan.md"). */
+  plan?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -418,7 +420,7 @@ function runDryRun(opts: RunnerOptions, dirs: PipelineDirs): void {
  * Run the Ralphai autonomous loop.
  */
 export async function runRunner(opts: RunnerOptions): Promise<void> {
-  const { config, cwd, isWorktree, mainWorktree, dryRun, resume } = opts;
+  const { config, cwd, isWorktree, mainWorktree, dryRun, resume, plan } = opts;
 
   // Unpack config values
   const mode = config.mode.value;
@@ -538,6 +540,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
         : undefined,
       dryRun: false,
       skippedSlugs,
+      targetPlan: plan,
     });
 
     if (!detectResult.detected) {
@@ -578,6 +581,14 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
             "Nothing to do — backlog is empty and no in-progress work. Add plans to .ralphai/pipeline/backlog/<slug>.md — see .ralphai/PLANNING.md",
           );
         }
+        break;
+      }
+
+      // Target plan not found
+      if (detectResult.reason === "target-not-found") {
+        console.log(
+          `Plan '${plan}' not found in backlog (${detectResult.backlogCount} plan(s) available).`,
+        );
         break;
       }
 


### PR DESCRIPTION
## Summary

Add `--plan=<file>` flag to `ralphai run` so users can target a specific plan from the backlog instead of relying on auto-detection.

### Motivation

Currently `--plan` only works with `ralphai worktree`. When running in normal (non-worktree) mode, Ralphai always auto-detects the next plan from the backlog. This change lets users explicitly select which plan to execute.

### Changes

- **plan-detection.ts** — Add `targetPlan` option to `detectPlan()`, new `target-not-found` fail reason, filter backlog to the matched plan before readiness checks
- **runner.ts** — Wire `plan` option through `RunnerOptions` to `detectPlan()`, handle `target-not-found` with a user-friendly message
- **ralphai.ts** — Parse `--plan=<file>` from run args, add to `RUN_FLAG_PATTERNS_EXTRA`, update help text
- **docs/cli-reference.md** — Add `--plan` to General Options
- **plan-target.test.ts** — 9 test cases covering: exact match, match without extension, not found, empty backlog, in-progress priority, dependency blocking, promotion to in-progress, dry-run safety, default behavior without flag