### PR TITLE
fix: prevent orphaned _path-* state directories from accumulating

### DIFF
--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -179,6 +179,7 @@ describe("CLI help and flags", () => {
 
   it("backlog-dir prints a directory path", () => {
     const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home") };
+    runCli(["init", "--yes"], ctx.dir, env);
     const result = runCli(["backlog-dir"], ctx.dir, env);
     expect(result.exitCode).toBe(0);
     expect(result.stdout.trim()).toContain("pipeline");

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
-import { getRepoStateDir } from "./global-state.ts";
+import { resolveRepoStateDir } from "./global-state.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -404,7 +404,7 @@ export function getConfigFilePath(
   cwd: string,
   env?: Record<string, string | undefined>,
 ): string {
-  return join(getRepoStateDir(cwd, env), "config.json");
+  return join(resolveRepoStateDir(cwd, env), "config.json");
 }
 
 /**

--- a/src/global-state.test.ts
+++ b/src/global-state.test.ts
@@ -7,7 +7,8 @@ import { useTempDir, useTempGitDir } from "./test-utils.ts";
 import {
   getRalphaiHome,
   getRepoId,
-  getRepoStateDir,
+  resolveRepoStateDir,
+  ensureRepoStateDir,
   getRepoPipelineDirs,
   getRepoLearningsPath,
   getRepoCandidatesPath,
@@ -108,19 +109,30 @@ describe("getRepoId", () => {
   });
 });
 
-describe("getRepoStateDir", () => {
+describe("resolveRepoStateDir", () => {
+  const ctx = useTempDir();
+
+  it("returns a path under RALPHAI_HOME without creating it", () => {
+    const home = join(ctx.dir, "ralphai-home-resolve");
+    const dir = resolveRepoStateDir(ctx.dir, { RALPHAI_HOME: home });
+    expect(dir).toContain(join("repos", "_path-"));
+    expect(existsSync(dir)).toBe(false);
+  });
+});
+
+describe("ensureRepoStateDir", () => {
   const ctx = useTempDir();
 
   it("creates the repo state directory under RALPHAI_HOME", () => {
     const home = join(ctx.dir, "ralphai-home");
-    const dir = getRepoStateDir(ctx.dir, { RALPHAI_HOME: home });
+    const dir = ensureRepoStateDir(ctx.dir, { RALPHAI_HOME: home });
     expect(dir).toMatch(new RegExp(`^${home.replace(/[/\\]/g, ".")}`));
     expect(existsSync(dir)).toBe(true);
   });
 
   it("nests under repos/<repoId>", () => {
     const home = join(ctx.dir, "ralphai-home");
-    const dir = getRepoStateDir(ctx.dir, { RALPHAI_HOME: home });
+    const dir = ensureRepoStateDir(ctx.dir, { RALPHAI_HOME: home });
     expect(dir).toContain(join("repos", "_path-"));
   });
 
@@ -146,8 +158,8 @@ describe("getRepoStateDir", () => {
 
     const home = join(ctx.dir, "ralphai-home");
     try {
-      expect(getRepoStateDir(worktreeDir, { RALPHAI_HOME: home })).toBe(
-        getRepoStateDir(repoDir, { RALPHAI_HOME: home }),
+      expect(ensureRepoStateDir(worktreeDir, { RALPHAI_HOME: home })).toBe(
+        ensureRepoStateDir(repoDir, { RALPHAI_HOME: home }),
       );
     } finally {
       execSync(`git worktree remove "${worktreeDir}" --force`, {

--- a/src/global-state.ts
+++ b/src/global-state.ts
@@ -44,13 +44,25 @@ export function getRepoId(cwd: string): string {
 }
 
 /**
- * Returns `<ralphaiHome>/repos/<repoId>`, creating it if missing.
+ * Computes `<ralphaiHome>/repos/<repoId>` without creating the directory.
+ * Use this for read-only checks (e.g., "does the config file exist?").
  */
-export function getRepoStateDir(
+export function resolveRepoStateDir(
   cwd: string,
   env?: Record<string, string | undefined>,
 ): string {
-  const dir = join(getRalphaiHome(env), "repos", getRepoId(cwd));
+  return join(getRalphaiHome(env), "repos", getRepoId(cwd));
+}
+
+/**
+ * Returns `<ralphaiHome>/repos/<repoId>`, creating it if missing.
+ * Use this only when you intend to write state (config, plans, learnings).
+ */
+export function ensureRepoStateDir(
+  cwd: string,
+  env?: Record<string, string | undefined>,
+): string {
+  const dir = resolveRepoStateDir(cwd, env);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
@@ -65,7 +77,7 @@ export function getRepoPipelineDirs(
   cwd: string,
   env?: Record<string, string | undefined>,
 ): { backlogDir: string; wipDir: string; archiveDir: string } {
-  const base = join(getRepoStateDir(cwd, env), "pipeline");
+  const base = join(ensureRepoStateDir(cwd, env), "pipeline");
   const backlogDir = join(base, "backlog");
   const wipDir = join(base, "in-progress");
   const archiveDir = join(base, "out");
@@ -86,7 +98,7 @@ export function getRepoLearningsPath(
   cwd: string,
   env?: Record<string, string | undefined>,
 ): string {
-  return join(getRepoStateDir(cwd, env), "LEARNINGS.md");
+  return join(resolveRepoStateDir(cwd, env), "LEARNINGS.md");
 }
 
 /**
@@ -96,7 +108,7 @@ export function getRepoCandidatesPath(
   cwd: string,
   env?: Record<string, string | undefined>,
 ): string {
-  return join(getRepoStateDir(cwd, env), "LEARNING_CANDIDATES.md");
+  return join(resolveRepoStateDir(cwd, env), "LEARNING_CANDIDATES.md");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -24,7 +24,7 @@ import {
   countCompletedTasks,
 } from "./plan-detection.ts";
 import { parseReceipt, checkReceiptSource, type Receipt } from "./receipt.ts";
-import { getRepoPipelineDirs, getRepoStateDir } from "./global-state.ts";
+import { getRepoPipelineDirs, resolveRepoStateDir } from "./global-state.ts";
 import {
   detectFeedbackCommands,
   detectWorkspaces,
@@ -493,7 +493,7 @@ async function teardownRalphai(
     return;
   }
 
-  const stateDir = getRepoStateDir(cwd);
+  const stateDir = resolveRepoStateDir(cwd);
 
   if (!options.yes) {
     clack.intro("Tearing down Ralphai");
@@ -1604,6 +1604,14 @@ function showBacklogDirHelp(): void {
 }
 
 function runBacklogDir(cwd: string): void {
+  const configPath = getConfigFilePath(cwd);
+  if (!existsSync(configPath)) {
+    console.log(
+      `${TEXT}Ralphai is not set up in this project (no config found).${RESET}`,
+    );
+    console.log(`${DIM}Run ${TEXT}ralphai init${DIM} first.${RESET}`);
+    return;
+  }
   const { backlogDir } = getRepoPipelineDirs(cwd);
   console.log(backlogDir);
 }

--- a/src/teardown-reset.test.ts
+++ b/src/teardown-reset.test.ts
@@ -10,7 +10,7 @@ import {
   useTempGitDir,
 } from "./test-utils.ts";
 import { getConfigFilePath } from "./config.ts";
-import { getRepoPipelineDirs, getRepoStateDir } from "./global-state.ts";
+import { getRepoPipelineDirs, resolveRepoStateDir } from "./global-state.ts";
 
 describe("teardown command", () => {
   const ctx = useTempGitDir();
@@ -32,8 +32,8 @@ describe("teardown command", () => {
 
     expect(output).toContain("Ralphai torn down");
     // Global state should be removed
-    const stateDir = getRepoStateDir(ctx.dir, testEnv());
-    // getRepoStateDir auto-creates, so check the config file specifically
+    const stateDir = resolveRepoStateDir(ctx.dir, testEnv());
+    // resolveRepoStateDir does not auto-create, so check the config file specifically
     expect(existsSync(configPath)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- **Split `getRepoStateDir` into two functions**: `resolveRepoStateDir` (read-only path computation) and `ensureRepoStateDir` (creates the directory), so that config-existence checks no longer create empty state directories as a side effect.
- **Add missing config-exists guard to `backlog-dir`** command, which previously created state directories unconditionally.

## Problem

Running any ralphai command (e.g., `ralphai status`, `ralphai doctor`, `ralphai backlog-dir`) from a directory without a git remote would silently create an orphaned `_path-<hash>` directory under `~/.ralphai/repos/`. This happened because `getConfigFilePath()` called `getRepoStateDir()`, which unconditionally created the directory as a side effect of computing the path. Over time this led to dozens of empty, meaningless state directories accumulating.

## Changes

| File | Change |
|---|---|
| `src/global-state.ts` | Replace `getRepoStateDir` with `resolveRepoStateDir` (no side effects) + `ensureRepoStateDir` (creates dirs). `getRepoPipelineDirs` uses `ensureRepoStateDir`; `getRepoLearningsPath`/`getRepoCandidatesPath` use `resolveRepoStateDir`. |
| `src/config.ts` | `getConfigFilePath` now uses `resolveRepoStateDir` so config-existence checks are read-only. |
| `src/ralphai.ts` | Update import; `teardownRalphai` uses `resolveRepoStateDir`; add config-exists guard to `runBacklogDir`. |
| `src/global-state.test.ts` | Add `resolveRepoStateDir` test (verifies no directory creation); rename existing tests to `ensureRepoStateDir`. |
| `src/teardown-reset.test.ts` | Update import to `resolveRepoStateDir`. |
| `src/cli-help.test.ts` | `backlog-dir` test now calls `init --yes` first since the command now requires initialization. |