### PR TITLE
feat(dashboard): add word-wrapping to detail pane content

### DIFF
--- a/src/dashboard/App.tsx
+++ b/src/dashboard/App.tsx
@@ -63,6 +63,9 @@ export function App() {
     Math.min(Math.floor(termCols * 0.3), Math.floor(termCols * 0.4)),
   );
 
+  // --- Detail pane width (fills remaining space) ---
+  const detailWidth = termCols - leftWidth;
+
   // --- Left panels share vertical space. Pipeline gets most room. ---
   const availableRows = termRows - CHROME_ROWS;
   const reposHeight = Math.max(
@@ -134,6 +137,7 @@ export function App() {
           outputData={outputData}
           contentHeight={contentHeight}
           followTail={followTail}
+          width={detailWidth}
         />
       </Box>
 

--- a/src/dashboard/DetailPane.tsx
+++ b/src/dashboard/DetailPane.tsx
@@ -9,6 +9,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { PlanInfo, DetailTab } from "./types.ts";
+import { wrapText } from "./format.ts";
 
 interface DetailPaneProps {
   plan: PlanInfo | null;
@@ -20,6 +21,7 @@ interface DetailPaneProps {
   outputData: { content: string; totalLines: number; isLive: boolean } | null;
   contentHeight: number;
   followTail: boolean;
+  width: number;
 }
 
 const TABS: DetailTab[] = ["summary", "plan", "progress", "output"];
@@ -249,10 +251,19 @@ export function DetailPane({
   outputData,
   contentHeight,
   followTail,
+  width,
 }: DetailPaneProps) {
+  // Usable content width after paddingLeft={2}
+  const contentWidth = Math.max(1, width - 2);
+
   if (!plan) {
     return (
-      <Box flexDirection="column" paddingLeft={2} flexGrow={1}>
+      <Box
+        flexDirection="column"
+        paddingLeft={2}
+        width={width}
+        overflow="hidden"
+      >
         <Text dimColor>Select a plan to view details.</Text>
         <Text dimColor>
           Navigate to the Pipeline panel and press Enter on a plan.
@@ -262,7 +273,7 @@ export function DetailPane({
   }
 
   return (
-    <Box flexDirection="column" paddingLeft={2} flexGrow={1}>
+    <Box flexDirection="column" paddingLeft={2} width={width} overflow="hidden">
       {/* Plan title + live badge */}
       <Box>
         <Text bold color={focused ? "cyan" : undefined}>
@@ -291,7 +302,7 @@ export function DetailPane({
         {tab === "plan" &&
           (planContent ? (
             <ContentView
-              lines={planContent.split("\n")}
+              lines={wrapText(planContent, contentWidth)}
               scrollOffset={scrollOffset}
               contentHeight={contentHeight}
             />
@@ -302,7 +313,7 @@ export function DetailPane({
         {tab === "progress" &&
           (progressContent ? (
             <ContentView
-              lines={progressContent.split("\n")}
+              lines={wrapText(progressContent, contentWidth)}
               scrollOffset={scrollOffset}
               contentHeight={contentHeight}
             />
@@ -313,7 +324,7 @@ export function DetailPane({
         {tab === "output" &&
           (outputData ? (
             <ContentView
-              lines={outputData.content.split("\n")}
+              lines={wrapText(outputData.content, contentWidth)}
               scrollOffset={scrollOffset}
               contentHeight={contentHeight}
               footer={

--- a/src/dashboard/format.test.ts
+++ b/src/dashboard/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { truncateSlug } from "./format.ts";
+import { truncateSlug, wrapText } from "./format.ts";
 
 describe("truncateSlug", () => {
   it("returns slug unchanged when shorter than maxLen", () => {
@@ -39,5 +39,68 @@ describe("truncateSlug", () => {
     // "-leading-dash" with maxLen 5
     // truncatable = "-lead", lastDash at 0 — but lastDash > 0 is false, so hard-truncate
     expect(truncateSlug("-leading-dash", 5)).toBe("-lea\u2026");
+  });
+});
+
+describe("wrapText", () => {
+  it("returns short lines unchanged", () => {
+    expect(wrapText("hello world", 40)).toEqual(["hello world"]);
+  });
+
+  it("preserves existing newlines", () => {
+    expect(wrapText("line one\nline two\nline three", 40)).toEqual([
+      "line one",
+      "line two",
+      "line three",
+    ]);
+  });
+
+  it("wraps a long line at word boundaries", () => {
+    expect(wrapText("the quick brown fox jumps", 15)).toEqual([
+      "the quick brown",
+      "fox jumps",
+    ]);
+  });
+
+  it("hard-breaks a single word longer than width", () => {
+    expect(wrapText("abcdefghij", 4)).toEqual(["abcd", "efgh", "ij"]);
+  });
+
+  it("handles empty input", () => {
+    expect(wrapText("", 40)).toEqual([""]);
+  });
+
+  it("handles empty lines between content", () => {
+    expect(wrapText("hello\n\nworld", 40)).toEqual(["hello", "", "world"]);
+  });
+
+  it("wraps multi-line text with mixed short and long lines", () => {
+    const input = "short\nthis is a longer line that needs wrapping here";
+    expect(wrapText(input, 20)).toEqual([
+      "short",
+      "this is a longer",
+      "line that needs",
+      "wrapping here",
+    ]);
+  });
+
+  it("handles width of 1", () => {
+    expect(wrapText("ab", 1)).toEqual(["a", "b"]);
+  });
+
+  it("handles width <= 0 gracefully by returning unsplit lines", () => {
+    expect(wrapText("hello\nworld", 0)).toEqual(["hello", "world"]);
+  });
+
+  it("wraps the progress log example correctly", () => {
+    const longLine =
+      "Completed Task 1 (types/hooks) and Task 2 (three left panels + format helpers).";
+    const result = wrapText(longLine, 40);
+    // Every wrapped line should fit within width
+    for (const line of result) {
+      expect(line.length).toBeLessThanOrEqual(40);
+    }
+    // Joined content should match original (minus the space where we broke)
+    expect(result.join(" ")).toBe(longLine);
   });
 });

--- a/src/dashboard/format.ts
+++ b/src/dashboard/format.ts
@@ -19,3 +19,57 @@ export function truncateSlug(slug: string, maxLen: number): string {
 
   return slug.slice(0, maxLen - 1) + "\u2026";
 }
+
+/**
+ * Word-wrap a single line to fit within `width` columns.
+ * Splits at the last space before the limit. If a single word exceeds
+ * `width`, it is hard-broken at the boundary.
+ * Returns an array of wrapped sub-lines.
+ */
+function wrapLine(line: string, width: number): string[] {
+  if (width < 1) return [line];
+  if (line.length <= width) return [line];
+
+  const result: string[] = [];
+  let remaining = line;
+
+  while (remaining.length > width) {
+    // Look for the last space within the allowed width
+    let breakAt = remaining.lastIndexOf(" ", width);
+    if (breakAt <= 0) {
+      // No space found — hard-break at width
+      breakAt = width;
+    }
+    result.push(remaining.slice(0, breakAt));
+    // Skip the space if we broke at one; otherwise keep position
+    remaining = remaining.slice(breakAt).replace(/^ /, "");
+  }
+
+  if (remaining.length > 0) {
+    result.push(remaining);
+  }
+
+  return result;
+}
+
+/**
+ * Word-wrap text content to fit within `width` columns.
+ * Respects existing newlines. Each logical line is independently wrapped.
+ * Returns a flat array of display lines ready for rendering.
+ */
+export function wrapText(text: string, width: number): string[] {
+  if (width < 1) return text.split("\n");
+
+  const lines = text.split("\n");
+  const result: string[] = [];
+
+  for (const line of lines) {
+    if (line.length === 0) {
+      result.push("");
+    } else {
+      result.push(...wrapLine(line, width));
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- **Adds word-wrapping** to the detail pane so long lines in the plan, progress, and output tabs wrap at word boundaries instead of overflowing the terminal.
- **Passes explicit width** from the layout to `DetailPane` and constrains the container with `width` and `overflow="hidden"`.
- **Introduces `wrapText` utility** in `format.ts` that splits text at word boundaries (with hard-break fallback for words longer than the available width).
- **Adds comprehensive tests** for `wrapText` covering short lines, multi-line input, hard breaks, edge cases, and width boundaries.