### PR TITLE
feat(dashboard): add animated braille spinners for active plans

### DIFF
--- a/src/dashboard/DetailPane.tsx
+++ b/src/dashboard/DetailPane.tsx
@@ -11,6 +11,7 @@ import { Box, Text } from "ink";
 import type { PlanInfo, DetailTab } from "./types.ts";
 import { wrapText } from "./format.ts";
 import { PanelBox } from "./PanelBox.tsx";
+import { useSpinner } from "./hooks.ts";
 
 interface DetailPaneProps {
   plan: PlanInfo | null;
@@ -78,6 +79,7 @@ function ProgressBar({
 }
 
 function SummaryView({ plan }: { plan: PlanInfo }) {
+  const spinner = useSpinner(plan.state === "in-progress");
   const stateColor =
     plan.state === "in-progress"
       ? "green"
@@ -86,7 +88,7 @@ function SummaryView({ plan }: { plan: PlanInfo }) {
         : "gray";
   const stateBadge =
     plan.state === "in-progress"
-      ? "\u25CF"
+      ? spinner
       : plan.state === "backlog"
         ? "\u25CB"
         : "\u2713";
@@ -257,6 +259,9 @@ export function DetailPane({
   // Usable content width after border chrome (2 columns)
   const contentWidth = Math.max(1, width - 2);
 
+  const isLive = tab === "output" && (outputData?.isLive ?? false);
+  const liveSpinner = useSpinner(isLive);
+
   if (!plan) {
     return (
       <PanelBox title="Details" active={focused} width={width}>
@@ -270,7 +275,7 @@ export function DetailPane({
 
   const planTitle =
     plan.slug +
-    (tab === "output" && outputData?.isLive ? "  \u25CF LIVE" : "") +
+    (isLive ? `  ${liveSpinner} LIVE` : "") +
     (tab === "output" && followTail ? " [follow]" : "") +
     (plan.state === "completed" ? "  \u2713 done" : "");
 

--- a/src/dashboard/PipelinePanel.tsx
+++ b/src/dashboard/PipelinePanel.tsx
@@ -11,6 +11,7 @@ import { Box, Text } from "ink";
 import type { PlanInfo } from "./types.ts";
 import { truncateSlug } from "./format.ts";
 import { PanelBox } from "./PanelBox.tsx";
+import { useSpinner } from "./hooks.ts";
 
 interface PipelinePanelProps {
   plans: PlanInfo[];
@@ -66,6 +67,53 @@ function ProgressIndicator({ plan, width }: { plan: PlanInfo; width: number }) {
   );
 }
 
+/** State badge character for non-active states. */
+function stateBadge(state: PlanInfo["state"]): string {
+  switch (state) {
+    case "backlog":
+      return "\u25CB";
+    case "completed":
+      return "\u2713";
+    default:
+      return "";
+  }
+}
+
+function PlanRow({
+  plan,
+  selected,
+  panelActive,
+  maxSlugLen,
+  width,
+}: {
+  plan: PlanInfo;
+  selected: boolean;
+  panelActive: boolean;
+  maxSlugLen: number;
+  width: number;
+}) {
+  const spinner = useSpinner(plan.state === "in-progress");
+  const pointer = selected ? "\u27A4" : " ";
+  const badge = plan.state === "in-progress" ? spinner : stateBadge(plan.state);
+  const truncated = truncateSlug(plan.slug, maxSlugLen);
+
+  return (
+    <Box key={plan.slug + plan.state}>
+      <Text
+        color={
+          selected && panelActive ? "cyan" : selected ? "white" : undefined
+        }
+        bold={selected}
+      >
+        {pointer}
+        {badge ? ` ${badge}` : ""} {truncated}
+      </Text>
+      {width >= 35 && plan.scope && <Text dimColor> [{plan.scope}]</Text>}
+      <ProgressIndicator plan={plan} width={width} />
+    </Box>
+  );
+}
+
 export function PipelinePanel({
   plans,
   cursor,
@@ -116,24 +164,16 @@ export function PipelinePanel({
           const items = group.map((plan) => {
             const idx = flatIndex++;
             const selected = idx === cursor;
-            const pointer = selected ? "\u27A4" : " ";
-            const truncated = truncateSlug(plan.slug, maxSlugLen);
 
             return (
-              <Box key={plan.slug + plan.state}>
-                <Text
-                  color={
-                    selected && active ? "cyan" : selected ? "white" : undefined
-                  }
-                  bold={selected}
-                >
-                  {pointer} {truncated}
-                </Text>
-                {width >= 35 && plan.scope && (
-                  <Text dimColor> [{plan.scope}]</Text>
-                )}
-                <ProgressIndicator plan={plan} width={width} />
-              </Box>
+              <PlanRow
+                key={plan.slug + plan.state}
+                plan={plan}
+                selected={selected}
+                panelActive={active}
+                maxSlugLen={maxSlugLen}
+                width={width}
+              />
             );
           });
 

--- a/src/dashboard/hooks.test.ts
+++ b/src/dashboard/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { filterPlans } from "./hooks.ts";
+import { filterPlans, SPINNER_FRAMES } from "./hooks.ts";
 import type { PlanInfo } from "./types.ts";
 
 /** Helper to build a minimal PlanInfo for testing. */
@@ -129,5 +129,37 @@ describe("filterPlans", () => {
     const result = filterPlans(plans, "scope:backend");
     // update-readme has no scope, so it should not appear
     expect(result.find((p) => p.slug === "update-readme")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SPINNER_FRAMES
+// ---------------------------------------------------------------------------
+
+describe("SPINNER_FRAMES", () => {
+  it("contains 10 braille dot characters", () => {
+    expect(SPINNER_FRAMES).toHaveLength(10);
+  });
+
+  it("every frame is a single non-empty character", () => {
+    for (const frame of SPINNER_FRAMES) {
+      expect(frame).toHaveLength(1);
+      expect(frame.trim()).not.toBe("");
+    }
+  });
+
+  it("contains the expected braille sequence", () => {
+    expect([...SPINNER_FRAMES]).toEqual([
+      "\u280B",
+      "\u2819",
+      "\u2839",
+      "\u2838",
+      "\u283C",
+      "\u2834",
+      "\u2826",
+      "\u2827",
+      "\u2807",
+      "\u280F",
+    ]);
   });
 });

--- a/src/dashboard/hooks.ts
+++ b/src/dashboard/hooks.ts
@@ -114,6 +114,44 @@ export function filterPlans(plans: PlanInfo[], query: string): PlanInfo[] {
 }
 
 // ---------------------------------------------------------------------------
+// useSpinner
+// ---------------------------------------------------------------------------
+
+/** Braille dot animation frames. */
+export const SPINNER_FRAMES = [
+  "\u280B",
+  "\u2819",
+  "\u2839",
+  "\u2838",
+  "\u283C",
+  "\u2834",
+  "\u2826",
+  "\u2827",
+  "\u2807",
+  "\u280F",
+] as const;
+
+/**
+ * Animated braille-dot spinner hook. When `active` is true, cycles through
+ * SPINNER_FRAMES at ~100ms. Returns the current frame character, or an
+ * empty string when inactive.
+ */
+export function useSpinner(active: boolean): string {
+  const [frame, setFrame] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => {
+      setFrame((prev) => (prev + 1) % SPINNER_FRAMES.length);
+    }, 100);
+    return () => clearInterval(id);
+  }, [active]);
+
+  if (!active) return "";
+  return SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!;
+}
+
+// ---------------------------------------------------------------------------
 // usePanelNavigation
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `useSpinner` hook with braille-dot frame animation (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) cycling at ~100 ms, independent of the 3-second data refresh
- Extract `PlanRow` component in PipelinePanel so each active plan gets its own spinner instance; show `○` for backlog and `✓` for completed
- Animate the LIVE indicator in the detail pane title bar and the state badge in SummaryView for in-progress plans
- Add `SPINNER_FRAMES` unit tests

## Changed files

```
 src/dashboard/DetailPane.tsx    |  9 ++++--
 src/dashboard/PipelinePanel.tsx | 72 ++++++++++++++++++++++++++++++---
 src/dashboard/hooks.test.ts    | 34 +++++++++++++++-
 src/dashboard/hooks.ts         | 38 ++++++++++++++++++
 4 files changed, 134 insertions(+), 19 deletions(-)
```