### PR TITLE
feat(dashboard): enhance status bar with progress summary and elapsed time

### DIFF
--- a/src/dashboard/App.tsx
+++ b/src/dashboard/App.tsx
@@ -153,6 +153,8 @@ export function App() {
         toast={toast}
         repoName={selectedRepo?.id ?? null}
         planCount={plans.length}
+        selectedPlan={selectedPlan}
+        hasActiveRunners={plans.some((p) => p.state === "in-progress")}
       />
 
       {/* Overlays — rendered inside a full-screen backdrop to prevent

--- a/src/dashboard/StatusBar.tsx
+++ b/src/dashboard/StatusBar.tsx
@@ -8,18 +8,24 @@
  * - filter: type to filter · Enter apply · Esc clear
  * - help:   ? or Esc to close
  *
- * Toast messages appear right-aligned and auto-expire.
+ * When a plan is in-progress the right side shows an animated spinner,
+ * plan slug, mini progress summary (tasks/turns), and elapsed time.
+ * Toast messages still override the right-side content when present.
  */
 
 import React from "react";
 import { Box, Text } from "ink";
-import type { FocusTarget } from "./types.ts";
+import type { FocusTarget, PlanInfo } from "./types.ts";
+import { useSpinner } from "./hooks.ts";
+import { formatElapsed } from "./format.ts";
 
 interface StatusBarProps {
   focus: FocusTarget;
   toast: string | null;
   repoName: string | null;
   planCount: number;
+  selectedPlan: PlanInfo | null;
+  hasActiveRunners: boolean;
 }
 
 const HINTS: Record<FocusTarget, string> = {
@@ -32,30 +38,73 @@ const HINTS: Record<FocusTarget, string> = {
   help: "? or Esc to close",
 };
 
+/** Build the mini progress string (e.g. "tasks 3/7 · turns 4/6"). */
+function buildProgressSummary(plan: PlanInfo): string {
+  const parts: string[] = [];
+  if (plan.tasksCompleted != null && plan.totalTasks != null) {
+    parts.push(`tasks ${plan.tasksCompleted}/${plan.totalTasks}`);
+  }
+  if (plan.turnsCompleted != null && plan.turnsBudget != null) {
+    parts.push(`turns ${plan.turnsCompleted}/${plan.turnsBudget}`);
+  }
+  return parts.join(" \u00B7 ");
+}
+
 export function StatusBar({
   focus,
   toast,
   repoName,
   planCount,
+  selectedPlan,
+  hasActiveRunners,
 }: StatusBarProps) {
   const hint = HINTS[focus];
+  const isSelectedInProgress = selectedPlan?.state === "in-progress";
+  const spinnerChar = useSpinner(hasActiveRunners);
+
+  // Build right-side content (priority order: toast > active progress > idle runner > default)
+  const renderRight = () => {
+    // 1. Toast overrides everything
+    if (toast) {
+      return <Text color="yellow">{toast}</Text>;
+    }
+
+    // 2. Selected plan is in-progress: spinner + slug + progress + elapsed
+    if (isSelectedInProgress && selectedPlan) {
+      const progress = buildProgressSummary(selectedPlan);
+      const elapsed = formatElapsed(selectedPlan.startedAt);
+      const segments = [selectedPlan.slug, progress, elapsed].filter(Boolean);
+      return (
+        <Text>
+          <Text color="green">{spinnerChar} </Text>
+          <Text dimColor>{segments.join(" \u00B7 ")}</Text>
+        </Text>
+      );
+    }
+
+    // 3. Runner active but selected plan is not in-progress
+    if (hasActiveRunners) {
+      return <Text dimColor>{spinnerChar} runner active</Text>;
+    }
+
+    // 4. Default: repo name and plan count
+    if (repoName) {
+      return (
+        <Text dimColor>
+          {repoName} {"\u00B7"} {planCount} plan{planCount !== 1 ? "s" : ""}
+        </Text>
+      );
+    }
+
+    return null;
+  };
 
   return (
     <Box height={1}>
       <Box flexGrow={1}>
         <Text dimColor>{hint}</Text>
       </Box>
-      {toast ? (
-        <Box>
-          <Text color="yellow">{toast}</Text>
-        </Box>
-      ) : repoName ? (
-        <Box>
-          <Text dimColor>
-            {repoName} \u00B7 {planCount} plan{planCount !== 1 ? "s" : ""}
-          </Text>
-        </Box>
-      ) : null}
+      <Box flexShrink={1}>{renderRight()}</Box>
     </Box>
   );
 }

--- a/src/dashboard/format.ts
+++ b/src/dashboard/format.ts
@@ -21,6 +21,31 @@ export function truncateSlug(slug: string, maxLen: number): string {
 }
 
 /**
+ * Format an ISO timestamp as a compact elapsed-time string relative to now.
+ * Returns `""` for undefined/invalid input.
+ * Accepts an optional `now` timestamp (ms) for deterministic testing.
+ */
+export function formatElapsed(
+  startedAt: string | undefined,
+  now?: number,
+): string {
+  if (!startedAt) return "";
+  const start = new Date(startedAt).getTime();
+  if (Number.isNaN(start)) return "";
+  const diffMs = (now ?? Date.now()) - start;
+  if (diffMs < 0) return "";
+
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return "< 1m";
+}
+
+/**
  * Word-wrap a single line to fit within `width` columns.
  * Splits at the last space before the limit. If a single word exceeds
  * `width`, it is hard-broken at the boundary.

--- a/src/dashboard/status-bar.test.ts
+++ b/src/dashboard/status-bar.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { formatElapsed } from "./format.ts";
+
+describe("formatElapsed", () => {
+  it('returns "< 1m" for a timestamp 30 seconds ago', () => {
+    const now = new Date("2025-06-15T12:00:30Z").getTime();
+    expect(formatElapsed("2025-06-15T12:00:00Z", now)).toBe("< 1m");
+  });
+
+  it('returns "2m 34s" for a timestamp 2 minutes 34 seconds ago', () => {
+    const now = new Date("2025-06-15T12:02:34Z").getTime();
+    expect(formatElapsed("2025-06-15T12:00:00Z", now)).toBe("2m 34s");
+  });
+
+  it('returns "1h 5m" for a timestamp 1 hour 5 minutes ago', () => {
+    const now = new Date("2025-06-15T13:05:00Z").getTime();
+    expect(formatElapsed("2025-06-15T12:00:00Z", now)).toBe("1h 5m");
+  });
+
+  it("returns empty string for undefined input", () => {
+    expect(formatElapsed(undefined)).toBe("");
+  });
+
+  it("returns empty string for invalid date string", () => {
+    expect(formatElapsed("not-a-date")).toBe("");
+  });
+
+  it("returns empty string for empty string input", () => {
+    expect(formatElapsed("")).toBe("");
+  });
+
+  it("returns empty string for a future timestamp", () => {
+    const now = new Date("2025-06-15T12:00:00Z").getTime();
+    expect(formatElapsed("2025-06-15T13:00:00Z", now)).toBe("");
+  });
+
+  it('exactly 60 seconds shows "1m 0s"', () => {
+    const now = new Date("2025-06-15T12:01:00Z").getTime();
+    expect(formatElapsed("2025-06-15T12:00:00Z", now)).toBe("1m 0s");
+  });
+});


### PR DESCRIPTION
## Summary

- **Enhanced status bar** to show an animated spinner, plan slug, mini progress summary (tasks/turns), and elapsed time for in-progress plans
- Toast messages still override the right-side content; a dim "runner active" indicator is shown when a runner is active but the selected plan is not in-progress
- Added `formatElapsed` helper in `format.ts` with a deterministic `now` parameter for testing, plus 8 unit tests covering edge cases

## Changes

- `src/dashboard/App.tsx` — Pass `selectedPlan` and `hasActiveRunners` props to `StatusBar`
- `src/dashboard/StatusBar.tsx` — Refactor right-side rendering with priority: toast > active progress > idle runner > default repo/plan count
- `src/dashboard/format.ts` — Add `formatElapsed()` for compact elapsed-time strings
- `src/dashboard/status-bar.test.ts` — New test file with 8 tests for `formatElapsed`