### PR TITLE
fix: dry-run fails to detect GitHub issues with SSH host aliases

### DIFF
--- a/src/issues.test.ts
+++ b/src/issues.test.ts
@@ -104,9 +104,19 @@ describe("detectIssueRepo", () => {
     expect(detectIssueRepo(ctx.dir)).toBeNull();
   });
 
-  it("returns null for non-GitHub remote", () => {
+  it("auto-detects from non-GitHub HTTPS remote", () => {
     initRepo(ctx.dir, "https://gitlab.com/user/repo.git");
-    expect(detectIssueRepo(ctx.dir)).toBeNull();
+    expect(detectIssueRepo(ctx.dir)).toBe("user/repo");
+  });
+
+  it("auto-detects from SSH remote with host alias", () => {
+    initRepo(ctx.dir, "git@github-work:mfaux/ralphai.git");
+    expect(detectIssueRepo(ctx.dir)).toBe("mfaux/ralphai");
+  });
+
+  it("auto-detects from SSH remote with host alias without .git suffix", () => {
+    initRepo(ctx.dir, "git@my-gh:org/project");
+    expect(detectIssueRepo(ctx.dir)).toBe("org/project");
   });
 
   it("ignores empty configRepo", () => {

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -125,10 +125,11 @@ export function detectIssueRepo(
   const url = execQuiet("git remote get-url origin", cwd);
   if (!url) return null;
 
-  // Handle SSH: git@github.com:owner/repo.git
-  // Handle HTTPS: https://github.com/owner/repo.git
+  // Handle SSH: git@<host>:owner/repo.git  (supports host aliases like github-work)
+  // Handle HTTPS: https://<host>/owner/repo.git
   const cleaned = url
-    .replace(/^(?:git@|https:\/\/)github\.com[:/]/, "")
+    .replace(/^git@[^:]+:/, "")
+    .replace(/^https?:\/\/[^/]+\//, "")
     .replace(/\.git$/, "");
 
   // Validate it looks like owner/repo

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -281,6 +281,34 @@ describe("runRunner — dry-run", () => {
     await runRunner(opts);
   });
 
+  test("dry-run with no plans shows reason in output", async () => {
+    setupGlobalPipeline(dir);
+
+    const opts: RunnerOptions = {
+      config: makeResolvedConfig(),
+      cwd: dir,
+      isWorktree: false,
+      mainWorktree: "",
+      dryRun: true,
+      resume: false,
+      allowDirty: false,
+    };
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+    try {
+      await runRunner(opts);
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join("\n");
+    // issueSource defaults to "none", so peek.message should appear
+    expect(output).toContain("No runnable work found.");
+    expect(output).toContain("not 'github'");
+  });
+
   test("dry-run with a backlog plan prints preview", async () => {
     const { backlogDir } = setupGlobalPipeline(dir);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -347,7 +347,7 @@ function runDryRun(opts: RunnerOptions, dirs: PipelineDirs): void {
         "[dry-run] Run without --dry-run to pull the oldest issue into the backlog.",
       );
     } else {
-      console.log("[dry-run] No runnable work found.");
+      console.log(`[dry-run] No runnable work found. (${peek.message})`);
     }
     return;
   }


### PR DESCRIPTION
## Summary

- **Fix `detectIssueRepo` to handle SSH host aliases.** The regex was hardcoded to `github.com`, so remotes like `git@github-work:owner/repo.git` (using SSH config aliases) caused repo detection to fail silently and `--dry-run` never queried GitHub for issues. Broadened to extract `owner/repo` from any SSH or HTTPS host.
- **Surface `peek.message` in dry-run output when no issues are found.** Previously, when `peekGithubIssues` returned `found: false`, the diagnostic reason (e.g. "Could not detect GitHub repo") was discarded and the user only saw a generic "No runnable work found." Now the message is included so users can see *why* and take action — consistent with the "errors guide recovery" DX principle.