### PR TITLE
feat: add ralphai check command for config setup detection

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,6 +16,7 @@ ralphai <command> [options]
 | `purge`        | Delete archived artifacts from `pipeline/out/`                         |
 | `repos`        | List all known repos with pipeline summaries                           |
 | `doctor`       | Check your Ralphai setup for problems                                  |
+| `check`        | Verify whether Ralphai is configured for a repo                        |
 | `backlog-dir`  | Print the path to the plan backlog directory                           |
 | `update [tag]` | Update Ralphai to the latest (or specified) version                    |
 | `teardown`     | Remove Ralphai from your project                                       |
@@ -40,7 +41,7 @@ ralphai doctor --repo=~/work/api
 ralphai backlog-dir --repo=my-app
 ```
 
-Works with: `status`, `reset`, `purge`, `teardown`, `backlog-dir`, `doctor`.
+Works with: `status`, `reset`, `purge`, `teardown`, `backlog-dir`, `doctor`, `check`.
 
 Blocked for: `run`, `worktree`, `init`.
 
@@ -186,6 +187,24 @@ Deletes all archived plan artifacts from `pipeline/out/`.
 9. No orphaned receipts in `in-progress/`
 
 When a `workspaces` config key exists, doctor also validates per-workspace feedback commands. Workspace failures produce warnings, not hard errors.
+
+## Check
+
+`ralphai check` verifies whether Ralphai is configured for the current repo. It prints a single line of plain text (no ANSI color codes) and exits 0 on success or 1 on failure.
+
+```
+--repo=<name>     Check config for a different repo
+```
+
+Output:
+
+| Condition            | stdout                              | Exit code |
+| -------------------- | ----------------------------------- | --------- |
+| Config is valid      | `configured`                        | 0         |
+| No config file       | `not configured — run ralphai init` | 1         |
+| Malformed or invalid | `invalid config — <detail>`         | 1         |
+
+Does not require a git repository. Useful for CI scripts and setup verification.
 
 ## Teardown
 

--- a/src/check.test.ts
+++ b/src/check.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { join, dirname } from "path";
+import { mkdirSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
+import { fileURLToPath } from "url";
+import { runCli, useTempGitDir, useTempDir } from "./test-utils.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("ralphai check", () => {
+  const ctx = useTempGitDir();
+
+  // -----------------------------------------------------------------------
+  // AC: exits 0 and prints "configured" when config exists and is valid
+  // -----------------------------------------------------------------------
+
+  it("prints 'configured' and exits 0 when config is valid", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home") };
+    runCli(["init", "--yes"], ctx.dir, env);
+
+    const result = runCli(["check"], ctx.dir, env);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("configured");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC: exits 1 and prints "not configured" when no config file exists
+  // -----------------------------------------------------------------------
+
+  it("prints 'not configured' and exits 1 when no config", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home-empty") };
+    const result = runCli(["check"], ctx.dir, env);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.trim()).toBe("not configured — run ralphai init");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC: exits 1 and prints "invalid config — <detail>" for malformed JSON
+  // -----------------------------------------------------------------------
+
+  it("prints 'invalid config' and exits 1 for malformed JSON", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home-bad") };
+    // First init to create the directory structure, then corrupt the file
+    runCli(["init", "--yes"], ctx.dir, env);
+    const configPath = join(env.RALPHAI_HOME, "repos");
+    // Find the repo dir (there should be exactly one)
+    const { readdirSync } = require("fs");
+    const repoDirs = readdirSync(configPath);
+    expect(repoDirs.length).toBeGreaterThan(0);
+    const configFile = join(configPath, repoDirs[0], "config.json");
+    writeFileSync(configFile, "{ this is not valid json }");
+
+    const result = runCli(["check"], ctx.dir, env);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.trim()).toMatch(/^invalid config — /);
+    expect(result.stdout).toContain("invalid JSON");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC: exits 1 and prints "invalid config — <detail>" for invalid values
+  // -----------------------------------------------------------------------
+
+  it("prints 'invalid config' and exits 1 for invalid config values", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home-invalid") };
+    runCli(["init", "--yes"], ctx.dir, env);
+    const configPath = join(env.RALPHAI_HOME, "repos");
+    const { readdirSync } = require("fs");
+    const repoDirs = readdirSync(configPath);
+    const configFile = join(configPath, repoDirs[0], "config.json");
+    // Write valid JSON but with an invalid value
+    writeFileSync(
+      configFile,
+      JSON.stringify({ issueSource: "invalid-source" }),
+    );
+
+    const result = runCli(["check"], ctx.dir, env);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.trim()).toMatch(/^invalid config — /);
+    expect(result.stdout).toContain("issueSource");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC: --help prints usage information
+  // -----------------------------------------------------------------------
+
+  it("check --help prints usage", () => {
+    const result = runCli(["check", "--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage:");
+    expect(result.stdout).toContain("ralphai check");
+    expect(result.stdout).toContain("configured");
+    expect(result.stdout).toContain("not configured");
+    expect(result.stdout).toContain("invalid config");
+    expect(result.stdout).toContain("--repo");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC: --unknown-flag exits 1 with "Unknown flag" (strict parsing)
+  // -----------------------------------------------------------------------
+
+  it("check --unknown-flag exits 1 with Unknown flag error", () => {
+    const result = runCli(["check", "--unknown-flag"], ctx.dir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Unknown flag");
+    expect(result.stderr).toContain("--unknown-flag");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC: ralphai --help lists the check command
+  // -----------------------------------------------------------------------
+
+  it("ralphai --help lists check command", () => {
+    const result = runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("check");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC: Output contains no ANSI escape codes
+  // -----------------------------------------------------------------------
+
+  it("check output contains no ANSI escape codes (configured)", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home-ansi") };
+    runCli(["init", "--yes"], ctx.dir, env);
+
+    const cliPath = join(__dirname, "cli.ts");
+    const raw = execFileSync(
+      "node",
+      ["--experimental-strip-types", cliPath, "check"],
+      {
+        encoding: "utf-8",
+        cwd: ctx.dir,
+        env: { ...process.env, ...env },
+      },
+    );
+    expect(raw).not.toMatch(/\x1b\[/);
+    expect(raw.trim()).toBe("configured");
+  });
+
+  it("check output contains no ANSI escape codes (not configured)", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home-ansi-no") };
+    const cliPath = join(__dirname, "cli.ts");
+    try {
+      execFileSync("node", ["--experimental-strip-types", cliPath, "check"], {
+        encoding: "utf-8",
+        cwd: ctx.dir,
+        env: { ...process.env, ...env },
+      });
+      // Should not reach here (exit 1)
+      expect.unreachable("expected process to exit with code 1");
+    } catch (error: any) {
+      expect(error.stdout).not.toMatch(/\x1b\[/);
+      expect(error.stdout.trim()).toBe("not configured — run ralphai init");
+    }
+  });
+});
+
+// -----------------------------------------------------------------------
+// AC: works without being inside a git repo (no git repo requirement)
+// -----------------------------------------------------------------------
+
+describe("ralphai check outside git repo", () => {
+  const ctx = useTempDir();
+
+  it("works outside a git repo (not configured)", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home") };
+    const result = runCli(["check"], ctx.dir, env);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.trim()).toBe("not configured — run ralphai init");
+  });
+});
+
+// -----------------------------------------------------------------------
+// AC: --repo=<name> checks config for the specified repo
+// -----------------------------------------------------------------------
+
+describe("ralphai check --repo", () => {
+  const ctx = useTempGitDir();
+
+  it("check --repo=<name> checks config for the specified repo", () => {
+    const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home-repo") };
+    // Init the repo first so it is registered
+    runCli(["init", "--yes"], ctx.dir, env);
+
+    // Now use --repo with the repo path
+    const result = runCli(["check", `--repo=${ctx.dir}`], ctx.dir, env);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("configured");
+  });
+});

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,0 +1,76 @@
+/**
+ * check command — verify whether ralphai is configured for a repo.
+ *
+ * Output contract: single line of plain text to stdout (no ANSI codes).
+ * Exit 0 on success, exit 1 on failure.
+ */
+
+import { existsSync } from "fs";
+import { getConfigFilePath, parseConfigFile, ConfigError } from "./config.ts";
+import { RESET, DIM, TEXT } from "./utils.ts";
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export function runCheck(cwd: string): void {
+  const configPath = getConfigFilePath(cwd);
+
+  // Case 1: no config file
+  if (!existsSync(configPath)) {
+    console.log("not configured — run ralphai init");
+    process.exit(1);
+  }
+
+  // Case 2: config exists — validate it
+  try {
+    const parsed = parseConfigFile(configPath);
+
+    // parseConfigFile returns null when the file doesn't exist, but we
+    // already checked that above, so parsed should never be null here.
+    if (!parsed) {
+      console.log("not configured — run ralphai init");
+      process.exit(1);
+    }
+
+    // Valid config
+    console.log("configured");
+  } catch (err) {
+    // Case 3: malformed JSON or invalid values
+    if (err instanceof ConfigError) {
+      console.log(`invalid config — ${err.message}`);
+    } else {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`invalid config — ${msg}`);
+    }
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+export function showCheckHelp(): void {
+  console.log(`${TEXT}Usage:${RESET} ralphai check [options]`);
+  console.log();
+  console.log(
+    `${DIM}Verify whether ralphai is configured for the current repo.${RESET}`,
+  );
+  console.log();
+  console.log(`${TEXT}Output:${RESET}`);
+  console.log(
+    `  ${TEXT}configured${RESET}                 ${DIM}Config exists and is valid (exit 0)${RESET}`,
+  );
+  console.log(
+    `  ${TEXT}not configured${RESET}             ${DIM}No config file found (exit 1)${RESET}`,
+  );
+  console.log(
+    `  ${TEXT}invalid config — <detail>${RESET}  ${DIM}Config exists but is malformed (exit 1)${RESET}`,
+  );
+  console.log();
+  console.log(`${TEXT}Options:${RESET}`);
+  console.log(
+    `  ${TEXT}--repo=<name>${RESET}   ${DIM}Check config for a different repo${RESET}`,
+  );
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ ${BOLD}Commands:${RESET}
   teardown     Remove Ralphai from your project
   uninstall    Remove all global state and uninstall the CLI
   doctor       Check your ralphai setup for problems
+  check        Verify whether ralphai is configured for a repo
   backlog-dir  Print the path to the plan backlog directory
   repos        List all known repos with pipeline summaries
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -46,6 +46,7 @@ import {
 import { formatShowConfig } from "./show-config.ts";
 import { runUninstall, showUninstallHelp } from "./uninstall.ts";
 import { runRepos, showReposHelp } from "./repos.ts";
+import { runCheck, showCheckHelp } from "./check.ts";
 import {
   AGENTS_MD_HEADER,
   AGENTS_MD_RALPHAI_SECTION,
@@ -68,6 +69,7 @@ type RalphaiSubcommand =
   | "doctor"
   | "backlog-dir"
   | "repos"
+  | "check"
   | "seed";
 
 type WorktreeSubcommand = "run" | "list" | "clean";
@@ -161,6 +163,7 @@ const SUBCOMMANDS = new Set<RalphaiSubcommand>([
   "doctor",
   "backlog-dir",
   "repos",
+  "check",
   "seed", // hidden — not listed in showRalphaiHelp()
 ]);
 
@@ -1035,6 +1038,9 @@ function showRalphaiHelp(): void {
     `  ${TEXT}doctor${RESET}      ${DIM}Check your ralphai setup for problems${RESET}`,
   );
   console.log(
+    `  ${TEXT}check${RESET}       ${DIM}Verify whether ralphai is configured for a repo${RESET}`,
+  );
+  console.log(
     `  ${TEXT}backlog-dir${RESET} ${DIM}Print the path to the plan backlog directory${RESET}`,
   );
   console.log(
@@ -1117,6 +1123,7 @@ export async function runRalphai(args: string[]): Promise<void> {
     "doctor",
     "backlog-dir",
     "repos",
+    "check",
   ]);
   if (
     options.subcommand &&
@@ -1233,6 +1240,13 @@ export async function runRalphai(args: string[]): Promise<void> {
         return;
       }
       runRepos({ clean: options.clean });
+      break;
+    case "check":
+      if (helpRequested) {
+        showCheckHelp();
+        return;
+      }
+      runCheck(cwd);
       break;
     case "seed":
       runSeed(cwd);


### PR DESCRIPTION
Add a new `ralphai check` subcommand that verifies whether ralphai is configured for the current repo (or one specified via --repo). Prints plain text (no ANSI codes) and exits 0 on success or 1 on failure:

- `configured` (exit 0) when config exists and is valid
- `not configured — run ralphai init` (exit 1) when no config
- `invalid config — <detail>` (exit 1) for malformed/invalid config

Wired into strict flag parsing, help text, and docs. Works outside a git repo. Includes 11 integration tests covering all acceptance criteria.

Closes #143