### PR TITLE
feat: add setupCommand config option for worktree dependency setup

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,6 +108,7 @@ What it does:
 --plan=<file>                     Target a specific backlog plan (default: auto-detect)
 --prd=<number>                    Run a PRD-driven session from a GitHub issue
 --agent-command=<command>         Override agent CLI command
+--setup-command=<command>         Command to run in worktree after creation (e.g. 'bun install')
 --feedback-commands=<list>        Comma-separated feedback commands
 --base-branch=<branch>            Override base branch (default: main)
 --continuous                      Keep processing backlog plans after the first completes

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -27,7 +27,10 @@ Run `ralphai run` from the **main repository**, not from inside a worktree.
 
 1. `ralphai run` creates a git worktree with a `ralphai/<plan-slug>` branch.
    It reuses existing worktrees for in-progress plans.
-2. Ralphai runs the agent inside that worktree and keeps the main checkout clean.
+2. If a `setupCommand` is configured, it runs in the worktree directory
+   immediately after creation (e.g. `bun install`). This ensures
+   dependencies are available before the agent starts.
+3. Ralphai runs the agent inside that worktree and keeps the main checkout clean.
 
 Configuration and pipeline data live in global state (`~/.ralphai/repos/<id>/`),
 so they are automatically available in every worktree without symlinks.
@@ -44,3 +47,45 @@ so they are automatically available in every worktree without symlinks.
 **Workaround for unsupported agents:** Set `"promptMode": "inline"` in
 `config.json` to embed pipeline file contents directly in the prompt,
 bypassing the agent's need to access external paths.
+
+## Setup command
+
+Fresh worktrees don't have `node_modules` or other dependency artifacts.
+The `setupCommand` option lets you run a command (e.g. `bun install`) in
+each new worktree before the agent starts, so it doesn't waste iterations
+on missing dependencies.
+
+### Configuration
+
+`ralphai init` auto-detects the setup command from lockfiles:
+
+| Lockfile            | Detected command  |
+| ------------------- | ----------------- |
+| `bun.lock`          | `bun install`     |
+| `pnpm-lock.yaml`    | `pnpm install`    |
+| `yarn.lock`         | `yarn install`    |
+| `package-lock.json` | `npm install`     |
+| `deno.lock`         | `deno install`    |
+| `.csproj` / `.sln`  | `dotnet restore`  |
+| `go.mod`            | `go mod download` |
+
+You can also set it manually:
+
+```json
+{ "setupCommand": "npm install && npm run build" }
+```
+
+Or override per-run:
+
+```bash
+ralphai run --setup-command='pnpm install'
+RALPHAI_SETUP_COMMAND='yarn install' ralphai run
+```
+
+Set to `""` (empty string) to disable.
+
+### Behavior
+
+- Runs **only on fresh worktree creation**, not when reusing an existing one.
+- On failure, Ralphai exits with code 1 and prints the failing command.
+- In `--dry-run` mode, the setup command is not executed.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -205,6 +205,28 @@ describe("parseConfigFile", () => {
     );
   });
 
+  it("parses setupCommand", () => {
+    const file = join(ctx.dir, "setup.json");
+    writeFileSync(file, JSON.stringify({ setupCommand: "bun install" }));
+    const result = parseConfigFile(file)!;
+    expect(result.values.setupCommand).toBe("bun install");
+  });
+
+  it("allows empty setupCommand (disabled)", () => {
+    const file = join(ctx.dir, "setup-empty.json");
+    writeFileSync(file, JSON.stringify({ setupCommand: "" }));
+    const result = parseConfigFile(file)!;
+    expect(result.values.setupCommand).toBe("");
+  });
+
+  it("rejects non-string setupCommand", () => {
+    const file = join(ctx.dir, "setup-bad.json");
+    writeFileSync(file, JSON.stringify({ setupCommand: 42 }));
+    expect(() => parseConfigFile(file)).toThrow(
+      "'setupCommand' must be a string",
+    );
+  });
+
   it("parses feedbackCommands as array", () => {
     const file = join(ctx.dir, "fc-array.json");
     writeFileSync(
@@ -327,6 +349,21 @@ describe("applyEnvOverrides", () => {
     expect(result.agentCommand).toBe("claude -p");
   });
 
+  it("extracts setupCommand", () => {
+    const result = applyEnvOverrides({
+      RALPHAI_SETUP_COMMAND: "npm install",
+    });
+    expect(result.setupCommand).toBe("npm install");
+  });
+
+  it("extracts empty setupCommand (disables)", () => {
+    // Empty env vars are ignored by the generic guard, but an explicit
+    // non-empty value should come through. This test documents that
+    // RALPHAI_SETUP_COMMAND="" is treated as "not set" (same as other keys).
+    const result = applyEnvOverrides({ RALPHAI_SETUP_COMMAND: "" });
+    expect(result.setupCommand).toBeUndefined();
+  });
+
   it("extracts baseBranch", () => {
     const result = applyEnvOverrides({ RALPHAI_BASE_BRANCH: "develop" });
     expect(result.baseBranch).toBe("develop");
@@ -374,6 +411,17 @@ describe("parseCLIArgs", () => {
     expect(() => parseCLIArgs(["--agent-command="])).toThrow(
       "requires a non-empty value",
     );
+  });
+
+  it("parses --setup-command=value", () => {
+    const result = parseCLIArgs(["--setup-command=bun install"]);
+    expect(result.overrides.setupCommand).toBe("bun install");
+    expect(result.rawFlags.setupCommand).toBe("--setup-command=bun install");
+  });
+
+  it("parses empty --setup-command= (disables)", () => {
+    const result = parseCLIArgs(["--setup-command="]);
+    expect(result.overrides.setupCommand).toBe("");
   });
 
   it("parses --feedback-commands=value", () => {
@@ -461,6 +509,8 @@ describe("resolveConfig", () => {
     expect(config.baseBranch.source).toBe("default");
     expect(config.maxStuck.value).toBe(3);
     expect(config.maxStuck.source).toBe("default");
+    expect(config.setupCommand.value).toBe("");
+    expect(config.setupCommand.source).toBe("default");
   });
 
   it("config file overrides defaults", () => {
@@ -522,6 +572,35 @@ describe("resolveConfig", () => {
     // continuous: default (nothing overrides)
     expect(config.continuous.value).toBe("false");
     expect(config.continuous.source).toBe("default");
+  });
+
+  it("setupCommand: full precedence chain", () => {
+    const cwd = join(ctx.dir, "repo-setup-prec");
+    mkdirSync(cwd, { recursive: true });
+    writeGlobalConfig(cwd, { setupCommand: "npm install" });
+
+    // Config file wins over default
+    const r1 = resolveConfig({ cwd, envVars: env(), cliArgs: [] });
+    expect(r1.config.setupCommand.value).toBe("npm install");
+    expect(r1.config.setupCommand.source).toBe("config");
+
+    // Env wins over config
+    const r2 = resolveConfig({
+      cwd,
+      envVars: env({ RALPHAI_SETUP_COMMAND: "pnpm install" }),
+      cliArgs: [],
+    });
+    expect(r2.config.setupCommand.value).toBe("pnpm install");
+    expect(r2.config.setupCommand.source).toBe("env");
+
+    // CLI wins over env
+    const r3 = resolveConfig({
+      cwd,
+      envVars: env({ RALPHAI_SETUP_COMMAND: "pnpm install" }),
+      cliArgs: ["--setup-command=bun install"],
+    });
+    expect(r3.config.setupCommand.value).toBe("bun install");
+    expect(r3.config.setupCommand.source).toBe("cli");
   });
 
   it("propagates config file warnings", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ import { resolveRepoStateDir } from "./global-state.ts";
 /** All recognised config keys. */
 export interface RalphaiConfig {
   agentCommand: string;
+  setupCommand: string;
   feedbackCommands: string;
   baseBranch: string;
   maxStuck: number;
@@ -57,6 +58,7 @@ export type ResolvedConfig = {
 
 export const DEFAULTS: Readonly<RalphaiConfig> = {
   agentCommand: "",
+  setupCommand: "",
   feedbackCommands: "",
   baseBranch: "main",
   maxStuck: 3,
@@ -164,6 +166,7 @@ export function validateCommaList(value: string, label: string): void {
 /** Allowed keys in config.json. */
 const ALLOWED_CONFIG_KEYS = new Set([
   "agentCommand",
+  "setupCommand",
   "feedbackCommands",
   "baseBranch",
   "maxStuck",
@@ -237,6 +240,14 @@ export function parseConfigFile(filePath: string): ParsedConfigFile | null {
     if (typeof v !== "string" || v === "")
       err("'agentCommand' must be a non-empty string");
     values.agentCommand = v;
+  }
+
+  // setupCommand (string, can be empty)
+  if ("setupCommand" in obj) {
+    const v = obj.setupCommand;
+    if (typeof v !== "string")
+      err(`'setupCommand' must be a string, got ${typeof v}`);
+    values.setupCommand = v;
   }
 
   // feedbackCommands (array of strings or comma-separated string)
@@ -418,6 +429,7 @@ const ENV_VAR_MAP: ReadonlyArray<
   [envVar: string, configKey: keyof RalphaiConfig]
 > = [
   ["RALPHAI_AGENT_COMMAND", "agentCommand"],
+  ["RALPHAI_SETUP_COMMAND", "setupCommand"],
   ["RALPHAI_FEEDBACK_COMMANDS", "feedbackCommands"],
   ["RALPHAI_BASE_BRANCH", "baseBranch"],
   ["RALPHAI_MAX_STUCK", "maxStuck"],
@@ -449,6 +461,10 @@ export function applyEnvOverrides(
   // agentCommand
   const agentCmd = get("RALPHAI_AGENT_COMMAND");
   if (agentCmd !== undefined) overrides.agentCommand = agentCmd;
+
+  // setupCommand
+  const setupCmd = get("RALPHAI_SETUP_COMMAND");
+  if (setupCmd !== undefined) overrides.setupCommand = setupCmd;
 
   // feedbackCommands
   const feedbackCmds = get("RALPHAI_FEEDBACK_COMMANDS");
@@ -559,6 +575,10 @@ export function parseCLIArgs(args: readonly string[]): ParsedCLIArgs {
       }
       overrides.agentCommand = v;
       rawFlags.agentCommand = arg;
+    } else if (arg.startsWith("--setup-command=")) {
+      const v = arg.slice("--setup-command=".length);
+      overrides.setupCommand = v;
+      rawFlags.setupCommand = arg;
     } else if (arg.startsWith("--feedback-commands=")) {
       const v = arg.slice("--feedback-commands=".length);
       if (v !== "") validateCommaList(v, "--feedback-commands");

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -82,8 +82,8 @@ describe("init command", () => {
     const config = readFileSync(configPath(), "utf-8");
     const parsed = JSON.parse(config);
 
-    // Verify exactly 12 keys are present (includes repoPath)
-    expect(Object.keys(parsed)).toHaveLength(12);
+    // Verify exactly 13 keys are present (includes repoPath)
+    expect(Object.keys(parsed)).toHaveLength(13);
 
     // Core settings from wizard
     expect(typeof parsed.agentCommand).toBe("string");
@@ -112,7 +112,7 @@ describe("init command", () => {
     const parsed = JSON.parse(config);
     expect(parsed.agentCommand).toBe("claude -p");
     // Other keys should still get defaults
-    expect(Object.keys(parsed)).toHaveLength(12);
+    expect(Object.keys(parsed)).toHaveLength(13);
     expect(parsed.autoCommit).toBe(false);
   });
 

--- a/src/project-detection.ts
+++ b/src/project-detection.ts
@@ -712,6 +712,48 @@ export function detectJavaProject(cwd: string): DetectedProject | null {
 }
 
 // ---------------------------------------------------------------------------
+// Setup command detection
+// ---------------------------------------------------------------------------
+
+/** Install command for each package manager. */
+const PM_INSTALL_COMMANDS: Readonly<Record<PackageManager, string>> = {
+  npm: "npm install",
+  pnpm: "pnpm install",
+  yarn: "yarn install",
+  bun: "bun install",
+  deno: "deno install",
+};
+
+/** Install/restore command for non-Node ecosystems. */
+const ECOSYSTEM_SETUP_COMMANDS: Readonly<Record<string, string>> = {
+  dotnet: "dotnet restore",
+  go: "go mod download",
+};
+
+/**
+ * Detect the appropriate setup command for a project.
+ *
+ * For Node.js projects, maps the detected package manager to its install
+ * command (e.g. `bun install`). For .NET and Go, returns the standard
+ * dependency restore command. Returns an empty string when no setup
+ * command can be inferred (Rust, Java, Python, or unknown projects).
+ */
+export function detectSetupCommand(cwd: string): string {
+  const pm = detectPackageManager(cwd);
+  if (pm) {
+    return PM_INSTALL_COMMANDS[pm.manager] ?? "";
+  }
+
+  // Check non-Node ecosystems
+  const project = detectProject(cwd);
+  if (project) {
+    return ECOSYSTEM_SETUP_COMMANDS[project.ecosystem] ?? "";
+  }
+
+  return "";
+}
+
+// ---------------------------------------------------------------------------
 // Top-level project detection
 // ---------------------------------------------------------------------------
 

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -33,6 +33,7 @@ import {
   detectFeedbackCommands,
   detectWorkspaces,
   detectProject,
+  detectSetupCommand,
 } from "./project-detection.ts";
 import type { DetectedProject, WorkspacePackage } from "./project-detection.ts";
 import { runRunner, type RunnerOptions } from "./runner.ts";
@@ -106,6 +107,7 @@ interface RalphaiOptions {
 
 interface WizardAnswers {
   agentCommand: string;
+  setupCommand: string;
   baseBranch: string;
   feedbackCommands: string;
   autoCommit?: boolean;
@@ -454,6 +456,22 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
     return null;
   }
 
+  // 4. Setup command (runs in worktree before agent starts)
+  const detectedSetup = detectSetupCommand(cwd);
+  const setupCommand = await clack.text({
+    message: detectedSetup
+      ? `Setup command (runs in worktree before agent starts, auto-detected for ${project?.label ?? "project"}):`
+      : "Setup command (runs in worktree before agent starts, or leave empty):",
+    initialValue: detectedSetup || undefined,
+    placeholder: detectedSetup ? undefined : "e.g. npm install",
+    defaultValue: detectedSetup || "",
+  });
+
+  if (clack.isCancel(setupCommand)) {
+    clack.cancel("Setup cancelled.");
+    return null;
+  }
+
   let autoCommit = false;
 
   // 6. GitHub Issues integration
@@ -512,6 +530,7 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
 
   return {
     agentCommand,
+    setupCommand: setupCommand || "",
     baseBranch,
     feedbackCommands: feedbackCommands || "",
     autoCommit,
@@ -648,6 +667,7 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
     agentCommand: answers.agentCommand,
     feedbackCommands,
     baseBranch: answers.baseBranch,
+    setupCommand: answers.setupCommand ?? "",
     autoCommit: answers.autoCommit ?? false,
     iterationTimeout: 0,
     continuous: false,
@@ -1413,9 +1433,11 @@ async function runRalphaiInit(
     const detectedFeedbackStr = detectedProject
       ? detectedProject.feedbackCommands.join(",")
       : "";
+    const detectedSetupStr = detectSetupCommand(cwd);
 
     answers = {
       agentCommand,
+      setupCommand: detectedSetupStr,
       baseBranch: detectBaseBranch(cwd),
       feedbackCommands: detectedFeedbackStr,
       autoCommit: false,
@@ -1426,6 +1448,7 @@ async function runRalphaiInit(
 
     // Print detection summary so users can verify auto-detected values
     const feedbackDisplay = answers.feedbackCommands.trim() || "(none)";
+    const setupDisplay = answers.setupCommand.trim() || "(none)";
     console.log(`${DIM}Detected:${RESET}`);
     console.log(
       `  ${DIM}Agent:${RESET}     ${TEXT}${answers.agentCommand}${RESET}`,
@@ -1434,6 +1457,7 @@ async function runRalphaiInit(
       `  ${DIM}Branch:${RESET}    ${TEXT}${answers.baseBranch}${RESET}`,
     );
     console.log(`  ${DIM}Feedback:${RESET}  ${TEXT}${feedbackDisplay}${RESET}`);
+    console.log(`  ${DIM}Setup:${RESET}     ${TEXT}${setupDisplay}${RESET}`);
     console.log(
       `  ${DIM}Project:${RESET}   ${TEXT}${detectedProject?.label ?? "(none)"}${RESET}`,
     );
@@ -2521,6 +2545,7 @@ const RUN_FLAG_PATTERNS_EXTRA = [/^--plan=/, /^--prd=/];
 /** Patterns for config flags that are parsed by the TS config resolver. */
 const CONFIG_FLAG_PATTERNS = [
   /^--agent-command=/,
+  /^--setup-command=/,
   /^--feedback-commands=/,
   /^--base-branch=/,
   /^--max-stuck=/,
@@ -2566,6 +2591,7 @@ function showRunHelp(): void {
     "  --plan=<file>                    Target a specific backlog plan (default: auto-detect)",
     "  --prd=<number>                   Run a PRD-driven session: fetch the GitHub issue, derive a branch, and run continuously",
     "  --agent-command=<command>        Override agent CLI command (e.g. 'claude -p')",
+    "  --setup-command=<command>        Command to run in worktree after creation (e.g. 'bun install')",
     "  --feedback-commands=<list>       Comma-separated feedback commands (e.g. 'npm test,npm run build')",
     "  --base-branch=<branch>           Override base branch (default: main)",
     "  --continuous                     Keep processing backlog plans after the first completes",
@@ -2583,13 +2609,14 @@ function showRunHelp(): void {
     "  --help, -h                       Show this help message",
     "",
     "Config file: config.json (optional, JSON format, stored in ~/.ralphai/repos/<id>/)",
-    "  Supported keys: agentCommand, feedbackCommands, baseBranch, maxStuck,",
+    "  Supported keys: agentCommand, setupCommand, feedbackCommands, baseBranch, maxStuck,",
     "                  continuous, autoCommit, iterationTimeout, promptMode,",
     "                  issueSource, issueLabel,",
     "                  issueInProgressLabel, issueRepo,",
     "                  issueCommentProgress",
     "",
-    "Env var overrides: RALPHAI_AGENT_COMMAND, RALPHAI_FEEDBACK_COMMANDS,",
+    "Env var overrides: RALPHAI_AGENT_COMMAND, RALPHAI_SETUP_COMMAND,",
+    "                   RALPHAI_FEEDBACK_COMMANDS,",
     "                   RALPHAI_BASE_BRANCH, RALPHAI_MAX_STUCK,",
     "                   RALPHAI_CONTINUOUS,",
     "                   RALPHAI_AUTO_COMMIT,",
@@ -2646,6 +2673,32 @@ function resolveWorktreeInfo(dir: string): {
   return { isWorktree: false, mainWorktree: "" };
 }
 
+/**
+ * Run a setup command inside a freshly-created worktree directory.
+ * Called only when a new worktree is created (not reused).
+ * On failure the process exits with code 1.
+ */
+function executeSetupCommand(setupCommand: string, worktreeDir: string): void {
+  if (!setupCommand) return;
+  console.log(`Running setup command: ${setupCommand}`);
+  try {
+    execSync(setupCommand, {
+      cwd: worktreeDir,
+      stdio: "inherit",
+    });
+  } catch (err: unknown) {
+    const stderr = extractExecStderr(err);
+    console.error(
+      `${TEXT}Error:${RESET} Setup command failed: ${setupCommand}`,
+    );
+    if (stderr) console.error(`  ${stderr}`);
+    console.error(
+      `\nFix the issue and re-run, or set ${TEXT}setupCommand${RESET} to "" in config to disable.`,
+    );
+    process.exit(1);
+  }
+}
+
 async function runRalphaiInManagedWorktree(
   options: RalphaiOptions,
   cwd: string,
@@ -2656,6 +2709,19 @@ async function runRalphaiInManagedWorktree(
   const isDryRun = runArgs.includes("--dry-run") || runArgs.includes("-n");
   const planFlag = runArgs.find((a) => a.startsWith("--plan="));
   const targetPlan = planFlag ? planFlag.slice("--plan=".length) : undefined;
+
+  // Resolve setupCommand from config/env/CLI (read-only, safe for dry-run)
+  let setupCommand = "";
+  try {
+    const cfgResult = resolveConfig({
+      cwd,
+      envVars: process.env as Record<string, string | undefined>,
+      cliArgs: runArgs,
+    });
+    setupCommand = cfgResult.config.setupCommand.value;
+  } catch {
+    // Config resolution may fail if not yet initialised; setup will be skipped
+  }
 
   // --- Parse --prd=<number> ---
   const prdFlag = runArgs.find((a) => a.startsWith("--prd="));
@@ -2810,6 +2876,11 @@ async function runRalphaiInManagedWorktree(
           if (stderr) console.error(`  git: ${stderr}`);
           process.exit(1);
         }
+      }
+
+      // Run setup command in freshly-created worktrees (not reused ones)
+      if (!activeWorktree) {
+        executeSetupCommand(setupCommand, resolvedWorktreeDir);
       }
 
       console.log("Running ralphai in worktree...");
@@ -2979,6 +3050,11 @@ async function runRalphaiInManagedWorktree(
             }
           }
 
+          // Run setup command in freshly-created worktrees (not reused ones)
+          if (!activeWorktree) {
+            executeSetupCommand(setupCommand, resolvedWorktreeDir);
+          }
+
           console.log("Running ralphai in worktree...");
           const shouldResume = activeWorktree !== undefined;
           const hasResumeFlag =
@@ -3113,6 +3189,11 @@ async function runRalphaiInManagedWorktree(
       if (stderr) console.error(`  git: ${stderr}`);
       process.exit(1);
     }
+  }
+
+  // Run setup command in freshly-created worktrees (not reused ones)
+  if (!activeWorktree) {
+    executeSetupCommand(setupCommand, resolvedWorktreeDir);
   }
 
   console.log("Running ralphai in worktree...");

--- a/src/setup-command.test.ts
+++ b/src/setup-command.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync } from "fs";
+import { join } from "path";
+import { useTempDir } from "./test-utils.ts";
+import { detectSetupCommand } from "./project-detection.ts";
+
+describe("detectSetupCommand", () => {
+  const ctx = useTempDir();
+
+  it("returns 'bun install' for bun lockfile", () => {
+    writeFileSync(join(ctx.dir, "bun.lock"), "");
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test" }),
+    );
+    expect(detectSetupCommand(ctx.dir)).toBe("bun install");
+  });
+
+  it("returns 'pnpm install' for pnpm lockfile", () => {
+    writeFileSync(join(ctx.dir, "pnpm-lock.yaml"), "lockfileVersion: 9\n");
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test" }),
+    );
+    expect(detectSetupCommand(ctx.dir)).toBe("pnpm install");
+  });
+
+  it("returns 'yarn install' for yarn lockfile", () => {
+    writeFileSync(join(ctx.dir, "yarn.lock"), "");
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test" }),
+    );
+    expect(detectSetupCommand(ctx.dir)).toBe("yarn install");
+  });
+
+  it("returns 'npm install' for npm lockfile", () => {
+    writeFileSync(join(ctx.dir, "package-lock.json"), "{}");
+    writeFileSync(
+      join(ctx.dir, "package.json"),
+      JSON.stringify({ name: "test" }),
+    );
+    expect(detectSetupCommand(ctx.dir)).toBe("npm install");
+  });
+
+  it("returns 'deno install' for deno lockfile", () => {
+    writeFileSync(join(ctx.dir, "deno.lock"), "{}");
+    writeFileSync(join(ctx.dir, "deno.json"), "{}");
+    expect(detectSetupCommand(ctx.dir)).toBe("deno install");
+  });
+
+  it("returns 'dotnet restore' for .NET project", () => {
+    writeFileSync(join(ctx.dir, "MyApp.csproj"), "<Project />");
+    expect(detectSetupCommand(ctx.dir)).toBe("dotnet restore");
+  });
+
+  it("returns 'go mod download' for Go project", () => {
+    writeFileSync(join(ctx.dir, "go.mod"), "module example.com/m\n");
+    expect(detectSetupCommand(ctx.dir)).toBe("go mod download");
+  });
+
+  it("returns empty string for Rust project (no auto setup)", () => {
+    writeFileSync(join(ctx.dir, "Cargo.toml"), "[package]\nname = 'test'\n");
+    expect(detectSetupCommand(ctx.dir)).toBe("");
+  });
+
+  it("returns empty string for unknown project", () => {
+    expect(detectSetupCommand(ctx.dir)).toBe("");
+  });
+});

--- a/src/show-config.test.ts
+++ b/src/show-config.test.ts
@@ -105,6 +105,7 @@ describe("formatShowConfig", () => {
   it("shows all default values with default sources", () => {
     const output = formatShowConfig(defaultInput());
     expect(output).toContain("  agentCommand       = <none>  (default (none))");
+    expect(output).toContain("  setupCommand       = <none>  (default (none))");
     expect(output).toContain("  feedbackCommands   = <none>  (default (none))");
     expect(output).toContain("  baseBranch         = main  (default)");
     expect(output).toContain("  continuous         = false  (default)");
@@ -113,6 +114,16 @@ describe("formatShowConfig", () => {
     expect(output).toContain("  iterationTimeout   = off  (default)");
     expect(output).toContain("  maxLearnings       = 20  (default)");
     expect(output).toContain("  issueSource        = none  (default)");
+  });
+
+  it("shows setupCommand when configured", () => {
+    const input = defaultInput();
+    input.config = makeResolved({
+      setupCommand: { value: "bun install", source: "config" },
+    });
+    input.configFileExists = true;
+    const output = formatShowConfig(input);
+    expect(output).toContain("  setupCommand       = bun install  (config (");
   });
 
   it("shows <no agentCommand set> when agentCommand is empty", () => {

--- a/src/show-config.ts
+++ b/src/show-config.ts
@@ -42,6 +42,7 @@ export function detectAgentType(agentCommand: string): string {
 /** Env var name for each config key. */
 const CONFIG_KEY_TO_ENV: Readonly<Record<string, string>> = {
   agentCommand: "RALPHAI_AGENT_COMMAND",
+  setupCommand: "RALPHAI_SETUP_COMMAND",
   feedbackCommands: "RALPHAI_FEEDBACK_COMMANDS",
   baseBranch: "RALPHAI_BASE_BRANCH",
   maxStuck: "RALPHAI_MAX_STUCK",
@@ -123,6 +124,16 @@ export function formatShowConfig(input: FormatShowConfigInput): string {
     "none",
   );
   lines.push(`  agentCommand       = ${agentCmdDisplay}  (${agentSrc})`);
+
+  const setupCmd = config.setupCommand.value;
+  const setupCmdDisplay = setupCmd || "<none>";
+  const setupSrc = sourceLabel(
+    "setupCommand",
+    config.setupCommand.source,
+    input,
+    "none",
+  );
+  lines.push(`  setupCommand       = ${setupCmdDisplay}  (${setupSrc})`);
 
   const feedbackCmd = config.feedbackCommands.value;
   const feedbackDisplay = feedbackCmd || "<none>";


### PR DESCRIPTION
## Summary

- Add `setupCommand` config option that runs a command (e.g. `bun install`) in freshly-created worktrees before the agent starts, preventing wasted iterations on missing dependencies
- Auto-detected during `ralphai init` from lockfiles (bun, pnpm, yarn, npm, deno, .NET, Go)
- Full config precedence: default < config file (`setupCommand`) < env var (`RALPHAI_SETUP_COMMAND`) < CLI flag (`--setup-command=`)

## Changes

### Config layer (`src/config.ts`)
- Added `setupCommand: string` to `RalphaiConfig` interface, `DEFAULTS`, `ALLOWED_CONFIG_KEYS`
- Added parsing in `parseConfigFile()` (string type, empty allowed unlike `agentCommand`)
- Added `RALPHAI_SETUP_COMMAND` env var and `--setup-command=` CLI flag support

### Detection (`src/project-detection.ts`)
- Added `detectSetupCommand()` — maps detected package manager to install command, with .NET/Go ecosystem support

### Execution (`src/ralphai.ts`)
- Added `executeSetupCommand()` helper — runs command in worktree dir, fatal on failure with recovery guidance
- Injected into all 3 worktree creation paths: explicit `--prd=N`, auto-detected PRD, and normal plan flow
- Runs only on fresh worktree creation (not reused ones)
- Added to `scaffold()`, wizard flow, `--yes` auto-detection, `CONFIG_FLAG_PATTERNS`, and `showRunHelp()`

### Display (`src/show-config.ts`)
- Added `setupCommand` to `--show-config` output

### Tests
- `src/config.test.ts` — parseConfigFile, applyEnvOverrides, parseCLIArgs, resolveConfig precedence
- `src/setup-command.test.ts` — detectSetupCommand for all ecosystems (new file, existing test file was near 500-line limit)
- `src/show-config.test.ts` — setupCommand in default and configured output
- `src/init.test.ts` — updated config key count (12 → 13)

### Docs
- `docs/worktrees.md` — documented feature with lockfile detection table, config examples, behavior notes
- `docs/cli-reference.md` — added `--setup-command` flag to `ralphai run` reference