### PR TITLE
feat: improve PR descriptions with agent-generated summaries

### DIFF
--- a/src/pr-description.test.ts
+++ b/src/pr-description.test.ts
@@ -7,7 +7,6 @@ import {
   categorizeCommits,
   formatCommitsByCategory,
   buildCommitLog,
-  buildDiffStat,
   buildPrBody,
   buildContinuousPrBodyStructured,
 } from "./pr-description.ts";
@@ -185,37 +184,13 @@ describe("buildCommitLog", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildDiffStat (integration with git)
-// ---------------------------------------------------------------------------
-
-describe("buildDiffStat", () => {
-  const ctx = useTempDir();
-
-  it("returns diffstat between base and head", () => {
-    initRepo(ctx.dir);
-    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
-    commitFile(ctx.dir, "new-file.txt", "content\n", "feat: add new file");
-
-    const stat = buildDiffStat("main", "feature", ctx.dir);
-    expect(stat).toContain("new-file.txt");
-    expect(stat).toMatch(/\d+ file/);
-  });
-
-  it("returns empty string when no diff", () => {
-    initRepo(ctx.dir);
-    const stat = buildDiffStat("main", "main", ctx.dir);
-    expect(stat).toBe("");
-  });
-});
-
-// ---------------------------------------------------------------------------
 // buildPrBody
 // ---------------------------------------------------------------------------
 
 describe("buildPrBody", () => {
   const ctx = useTempDir();
 
-  it("includes summary, changes, and files changed sections", () => {
+  it("leads with description and includes changes section", () => {
     initRepo(ctx.dir);
     execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
     commitFile(
@@ -237,24 +212,50 @@ describe("buildPrBody", () => {
       "feature",
       ctx.dir,
     );
-    expect(body).toContain("## Summary");
-    expect(body).toContain("Add authentication system");
+    // Description is the first thing in the body
+    expect(body.startsWith("Add authentication system")).toBe(true);
+    // No ## Summary heading
+    expect(body).not.toContain("## Summary");
+    // No ## Files Changed section
+    expect(body).not.toContain("## Files Changed");
+    // Changes section present
     expect(body).toContain("## Changes");
     expect(body).toContain("### Features");
     expect(body).toContain("- add user login");
     expect(body).toContain("### Bug Fixes");
     expect(body).toContain("- resolve crash on startup");
-    expect(body).toContain("## Files Changed");
-    expect(body).toContain("login.ts");
-    expect(body).toContain("bug.ts");
   });
 
-  it("omits Files Changed section when no diff", () => {
+  it("uses agent summary when provided", () => {
     initRepo(ctx.dir);
-    const body = buildPrBody("Empty plan", "main", "main", ctx.dir);
-    expect(body).toContain("## Summary");
-    expect(body).toContain("Empty plan");
-    expect(body).not.toContain("## Files Changed");
+    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
+    commitFile(ctx.dir, "a.txt", "a", "feat: add feature");
+
+    const body = buildPrBody("Plan description", "main", "feature", ctx.dir, {
+      summary:
+        "Implement JWT auth with bcrypt hashing, replacing cookie sessions.",
+    });
+    expect(
+      body.startsWith(
+        "Implement JWT auth with bcrypt hashing, replacing cookie sessions.",
+      ),
+    ).toBe(true);
+    // Plan description should NOT appear when summary is provided
+    expect(body).not.toContain("Plan description");
+  });
+
+  it("falls back to plan description when no summary", () => {
+    initRepo(ctx.dir);
+    execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
+    commitFile(ctx.dir, "a.txt", "a", "feat: add feature");
+
+    const body = buildPrBody(
+      "Add authentication system",
+      "main",
+      "feature",
+      ctx.dir,
+    );
+    expect(body.startsWith("Add authentication system")).toBe(true);
   });
 
   it("handles non-conventional commits in Other category", () => {
@@ -267,7 +268,7 @@ describe("buildPrBody", () => {
     expect(body).toContain("- random commit message");
   });
 
-  it("renders PRD line when prd and issueRepo are provided", () => {
+  it("renders PRD line after description", () => {
     initRepo(ctx.dir);
     execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
     commitFile(ctx.dir, "a.txt", "a", "feat: add feature");
@@ -282,13 +283,12 @@ describe("buildPrBody", () => {
         issueRepo: "org/repo",
       },
     );
-    expect(body).toContain("## Summary");
     expect(body).toContain("**PRD:** org/repo#30");
     expect(body).toContain("Fix widget validation");
-    // PRD line should appear before the plan description
-    const prdIdx = body.indexOf("**PRD:**");
+    // Description should appear before PRD line
     const descIdx = body.indexOf("Fix widget validation");
-    expect(prdIdx).toBeLessThan(descIdx);
+    const prdIdx = body.indexOf("**PRD:**");
+    expect(descIdx).toBeLessThan(prdIdx);
   });
 
   it("omits PRD line when prd is not provided", () => {
@@ -311,7 +311,7 @@ describe("buildPrBody", () => {
     expect(body).not.toContain("**PRD:**");
   });
 
-  it("includes Closes #N when issueNumber is provided (same-repo)", () => {
+  it("includes Closes #N after description (same-repo)", () => {
     initRepo(ctx.dir);
     execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
     commitFile(ctx.dir, "a.txt", "a", "feat: add feature");
@@ -320,10 +320,13 @@ describe("buildPrBody", () => {
       issueNumber: 42,
     });
     expect(body).toContain("Closes #42");
-    // Closes line should appear before Summary
+    // Description should appear before Closes
+    const descIdx = body.indexOf("Fix login bug");
     const closesIdx = body.indexOf("Closes #42");
-    const summaryIdx = body.indexOf("## Summary");
-    expect(closesIdx).toBeLessThan(summaryIdx);
+    expect(descIdx).toBeLessThan(closesIdx);
+    // Closes should appear before Changes
+    const changesIdx = body.indexOf("## Changes");
+    expect(closesIdx).toBeLessThan(changesIdx);
   });
 
   it("omits Closes line for manual plans (no issueNumber)", () => {
@@ -363,7 +366,7 @@ describe("buildPrBody", () => {
     expect(body).not.toContain("Closes org/repo#42");
   });
 
-  it("includes both Closes #N and PRD reference when both are provided", () => {
+  it("includes description, Closes, and PRD in correct order", () => {
     initRepo(ctx.dir);
     execSync("git checkout -b feature", { cwd: ctx.dir, stdio: "ignore" });
     commitFile(ctx.dir, "a.txt", "a", "feat: add feature");
@@ -382,12 +385,14 @@ describe("buildPrBody", () => {
     );
     expect(body).toContain("Closes #42");
     expect(body).toContain("**PRD:** org/repo#30");
-    // Closes should appear before Summary, PRD should appear within Summary
-    const closesIdx = body.indexOf("Closes #42");
-    const summaryIdx = body.indexOf("## Summary");
+    // Order: description -> PRD -> Closes -> Changes
+    const descIdx = body.indexOf("Implement feature from PRD");
     const prdIdx = body.indexOf("**PRD:**");
-    expect(closesIdx).toBeLessThan(summaryIdx);
-    expect(summaryIdx).toBeLessThan(prdIdx);
+    const closesIdx = body.indexOf("Closes #42");
+    const changesIdx = body.indexOf("## Changes");
+    expect(descIdx).toBeLessThan(prdIdx);
+    expect(prdIdx).toBeLessThan(closesIdx);
+    expect(closesIdx).toBeLessThan(changesIdx);
   });
 });
 
@@ -417,7 +422,8 @@ describe("buildContinuousPrBodyStructured", () => {
     expect(body).toContain("## Changes");
     expect(body).toContain("### Features");
     expect(body).toContain("- implement plan A");
-    expect(body).toContain("## Files Changed");
+    // No Files Changed section
+    expect(body).not.toContain("## Files Changed");
   });
 
   it("shows placeholders when no plans completed", () => {
@@ -488,5 +494,57 @@ describe("buildContinuousPrBodyStructured", () => {
     expect(body2).toContain("Closes #146");
     expect(body2).toContain("- [x] plan-a");
     expect(body2).toContain("- [x] plan-b");
+  });
+
+  it("leads with summary when provided", () => {
+    initRepo(ctx.dir);
+    const body = buildContinuousPrBodyStructured(
+      ["plan-a"],
+      [],
+      "main",
+      "main",
+      ctx.dir,
+      {
+        prdNumber: 146,
+        summary: "Add a complete metrics dashboard with real-time tracking.",
+      },
+    );
+    expect(
+      body.startsWith(
+        "Add a complete metrics dashboard with real-time tracking.",
+      ),
+    ).toBe(true);
+    // Summary should appear before Closes and Completed Plans
+    const summaryIdx = body.indexOf("Add a complete metrics dashboard");
+    const closesIdx = body.indexOf("Closes #146");
+    const plansIdx = body.indexOf("## Completed Plans");
+    expect(summaryIdx).toBeLessThan(closesIdx);
+    expect(closesIdx).toBeLessThan(plansIdx);
+  });
+
+  it("omits summary paragraph when not provided", () => {
+    initRepo(ctx.dir);
+    const body = buildContinuousPrBodyStructured(
+      ["plan-a"],
+      [],
+      "main",
+      "main",
+      ctx.dir,
+      { prdNumber: 146 },
+    );
+    // Body should start with Closes (no summary paragraph)
+    expect(body.trimStart().startsWith("Closes #146")).toBe(true);
+  });
+
+  it("starts with Completed Plans when no summary and no Closes", () => {
+    initRepo(ctx.dir);
+    const body = buildContinuousPrBodyStructured(
+      ["manual-task.md"],
+      [],
+      "main",
+      "main",
+      ctx.dir,
+    );
+    expect(body.trimStart().startsWith("## Completed Plans")).toBe(true);
   });
 });

--- a/src/pr-description.ts
+++ b/src/pr-description.ts
@@ -1,12 +1,14 @@
 /**
  * PR description builders: structured, human-readable PR bodies.
  *
- * Parses conventional commits into categories, builds file-change
- * summaries, and assembles formatted PR descriptions for both
- * single-plan and continuous modes.
+ * Parses conventional commits into categories and assembles formatted
+ * PR descriptions for both single-plan and continuous modes.
+ *
+ * PR body structure leads with a plain-language description (from the
+ * agent's `<pr-summary>` block or the plan description as fallback),
+ * followed by issue references and a technical changes breakdown.
  */
 import { execSync } from "child_process";
-import { basename } from "path";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,13 +48,6 @@ export function buildCommitLog(
 ): string {
   return (
     execQuiet(`git log "${base}".."${head}" --oneline --no-decorate`, cwd) ?? ""
-  );
-}
-
-/** File-change diffstat between two refs. */
-export function buildDiffStat(base: string, head: string, cwd: string): string {
-  return (
-    execQuiet(`git diff "${base}".."${head}" --stat --stat-width=72`, cwd) ?? ""
   );
 }
 
@@ -212,10 +207,9 @@ export function formatCommitsByCategory(commits: CategorizedCommits): string {
 /**
  * Build a structured PR body for a single-plan PR.
  *
- * Sections:
- *   ## Summary         – plan description (with optional PRD reference)
- *   ## Changes         – commits grouped by type
- *   ## Files Changed   – diffstat
+ * Leads with a human-friendly description (agent-generated summary
+ * when available, falling back to plan description), followed by
+ * issue references and a technical changes breakdown.
  */
 export function buildPrBody(
   planDescription: string,
@@ -227,14 +221,21 @@ export function buildPrBody(
     issueRepo?: string;
     issueNumber?: number;
     prRepo?: string;
+    summary?: string;
   },
 ): string {
   const commitLog = buildCommitLog(baseBranch, headBranch, cwd);
   const categorized = categorizeCommits(commitLog);
   const formattedCommits = formatCommitsByCategory(categorized);
-  const diffStat = buildDiffStat(baseBranch, headBranch, cwd);
 
   const parts: string[] = [];
+
+  // Lead with the human-friendly description
+  parts.push((options?.summary ?? planDescription) + "\n");
+
+  if (options?.prd !== undefined && options.issueRepo) {
+    parts.push(`**PRD:** ${options.issueRepo}#${options.prd}\n`);
+  }
 
   // Emit Closes #N when the plan is from a GitHub issue
   if (options?.issueNumber) {
@@ -248,17 +249,7 @@ export function buildPrBody(
     }
   }
 
-  parts.push(`## Summary\n`);
-
-  if (options?.prd !== undefined && options.issueRepo) {
-    parts.push(`**PRD:** ${options.issueRepo}#${options.prd}\n`);
-  }
-
-  parts.push(`${planDescription}\n`, `## Changes\n`, formattedCommits);
-
-  if (diffStat) {
-    parts.push("", `## Files Changed\n`, "```", diffStat, "```");
-  }
+  parts.push(`## Changes\n`, formattedCommits);
 
   return parts.join("\n");
 }
@@ -266,11 +257,9 @@ export function buildPrBody(
 /**
  * Build a structured PR body for continuous-mode PRs.
  *
- * Sections:
- *   ## Completed Plans  – checked items
- *   ## Remaining Plans  – unchecked items
- *   ## Changes          – commits grouped by type
- *   ## Files Changed    – diffstat
+ * Leads with an optional human-friendly summary (agent-generated on
+ * completion), followed by issue references, plan checklists, and a
+ * technical changes breakdown.
  */
 export function buildContinuousPrBodyStructured(
   completedPlans: string[],
@@ -278,9 +267,19 @@ export function buildContinuousPrBodyStructured(
   baseBranch: string,
   headBranch: string,
   cwd: string,
-  options?: { prdNumber?: number; issueRepo?: string; prRepo?: string },
+  options?: {
+    prdNumber?: number;
+    issueRepo?: string;
+    prRepo?: string;
+    summary?: string;
+  },
 ): string {
   const parts: string[] = [];
+
+  // Lead with agent-generated summary when available
+  if (options?.summary) {
+    parts.push(options.summary + "\n");
+  }
 
   const childIssues = extractIssueNumbersFromPlans(completedPlans);
   const closesBlock = buildClosesBlock({
@@ -310,13 +309,8 @@ export function buildContinuousPrBodyStructured(
   const commitLog = buildCommitLog(baseBranch, headBranch, cwd);
   const categorized = categorizeCommits(commitLog);
   const formattedCommits = formatCommitsByCategory(categorized);
-  const diffStat = buildDiffStat(baseBranch, headBranch, cwd);
 
   parts.push("\n## Changes\n", formattedCommits);
-
-  if (diffStat) {
-    parts.push("", "## Files Changed\n", "```", diffStat, "```");
-  }
 
   return parts.join("\n");
 }

--- a/src/pr-lifecycle.ts
+++ b/src/pr-lifecycle.ts
@@ -41,6 +41,8 @@ export interface CreatePrOptions {
   issueRepo?: string;
   issueCommentProgress?: boolean;
   prd?: number;
+  /** Agent-generated PR description from `<pr-summary>` block. */
+  summary?: string;
 }
 
 export interface ContinuousPrOptions {
@@ -53,6 +55,8 @@ export interface ContinuousPrOptions {
   prd?: { number: number; title: string };
   /** Repository that owns the issues (e.g. "org/repo"). */
   issueRepo?: string;
+  /** Agent-generated PR description from `<pr-summary>` block. */
+  summary?: string;
 }
 
 export interface ArchiveRunOptions {
@@ -181,6 +185,7 @@ export function createPr(options: CreatePrOptions): CreatePrResult {
     issueRepo: options.issueRepo,
     issueNumber: isGitHub ? options.issueNumber : undefined,
     prRepo,
+    summary: options.summary,
   });
   const esc = (s: string) => s.replace(/"/g, '\\"');
 
@@ -226,7 +231,12 @@ export function buildContinuousPrBody(
   baseBranch: string,
   headBranch: string,
   cwd: string,
-  options?: { prdNumber?: number; issueRepo?: string; prRepo?: string },
+  options?: {
+    prdNumber?: number;
+    issueRepo?: string;
+    prRepo?: string;
+    summary?: string;
+  },
 ): string {
   const remaining = collectBacklogPlans(backlogDir).map((p) => basename(p));
   return buildContinuousPrBodyStructured(
@@ -310,7 +320,7 @@ export function updateContinuousPr(
     baseBranch,
     branch,
     cwd,
-    { prdNumber: prd?.number, issueRepo, prRepo },
+    { prdNumber: prd?.number, issueRepo, prRepo, summary: options.summary },
   );
   const esc = (s: string) => s.replace(/"/g, '\\"');
   if (
@@ -338,7 +348,7 @@ export function finalizeContinuousPr(
     baseBranch,
     headBranch,
     cwd,
-    { prdNumber: prd?.number, issueRepo, prRepo },
+    { prdNumber: prd?.number, issueRepo, prRepo, summary: options.summary },
   );
   const esc = (s: string) => s.replace(/"/g, '\\"');
 

--- a/src/pr-summary.test.ts
+++ b/src/pr-summary.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "bun:test";
+import { extractPrSummary } from "./pr-summary.ts";
+
+describe("extractPrSummary", () => {
+  it("extracts content between pr-summary tags", () => {
+    const output =
+      "some agent output\n<pr-summary>\nAdd authentication with JWT tokens.\n</pr-summary>\nmore output";
+    expect(extractPrSummary(output)).toBe(
+      "Add authentication with JWT tokens.",
+    );
+  });
+
+  it("returns null when no pr-summary tags present", () => {
+    expect(extractPrSummary("just regular agent output")).toBeNull();
+  });
+
+  it("returns null when only opening tag present", () => {
+    expect(extractPrSummary("<pr-summary>content without end")).toBeNull();
+  });
+
+  it("returns null when content between tags is empty", () => {
+    expect(extractPrSummary("<pr-summary></pr-summary>")).toBeNull();
+  });
+
+  it("returns null when content is only whitespace", () => {
+    expect(extractPrSummary("<pr-summary>   \n  </pr-summary>")).toBeNull();
+  });
+
+  it("trims whitespace from extracted content", () => {
+    const output = "<pr-summary>\n  Implement rate limiting.  \n</pr-summary>";
+    expect(extractPrSummary(output)).toBe("Implement rate limiting.");
+  });
+
+  it("extracts multi-line summaries", () => {
+    const output = [
+      "<pr-summary>",
+      "Add a complete metrics dashboard with real-time tracking,",
+      "CSV/JSON export, and per-user breakdown views.",
+      "</pr-summary>",
+    ].join("\n");
+    expect(extractPrSummary(output)).toBe(
+      "Add a complete metrics dashboard with real-time tracking,\nCSV/JSON export, and per-user breakdown views.",
+    );
+  });
+
+  it("extracts only the first pr-summary block", () => {
+    const output = [
+      "<pr-summary>First summary.</pr-summary>",
+      "<pr-summary>Second summary.</pr-summary>",
+    ].join("\n");
+    expect(extractPrSummary(output)).toBe("First summary.");
+  });
+
+  it("works alongside other structured blocks", () => {
+    const output = [
+      "<progress>",
+      "- [x] Add login endpoint",
+      "</progress>",
+      "<pr-summary>Implement user authentication with bcrypt.</pr-summary>",
+      "<learnings>",
+      "<entry>",
+      "status: none",
+      "</entry>",
+      "</learnings>",
+    ].join("\n");
+    expect(extractPrSummary(output)).toBe(
+      "Implement user authentication with bcrypt.",
+    );
+  });
+});

--- a/src/pr-summary.ts
+++ b/src/pr-summary.ts
@@ -1,0 +1,28 @@
+/**
+ * PR summary extraction: extracts `<pr-summary>` blocks from agent output.
+ *
+ * The agent is instructed to include a `<pr-summary>` block when it
+ * signals COMPLETE. This provides a human-friendly description for the
+ * pull request, written by the agent that did the work.
+ *
+ * Follows the same extraction pattern as `extractProgressBlock()` in
+ * `src/progress.ts` and `extractLearningsBlock()` in `src/learnings.ts`.
+ */
+
+/**
+ * Extract the first `<pr-summary>...</pr-summary>` block from agent output.
+ * Returns the content between the tags, or null if not found.
+ */
+export function extractPrSummary(text: string): string | null {
+  const startTag = "<pr-summary>";
+  const endTag = "</pr-summary>";
+
+  const startIdx = text.indexOf(startTag);
+  if (startIdx === -1) return null;
+
+  const endIdx = text.indexOf(endTag, startIdx);
+  if (endIdx === -1) return null;
+
+  const content = text.slice(startIdx + startTag.length, endIdx).trim();
+  return content.length > 0 ? content : null;
+}

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -177,6 +177,10 @@ Ralphai extracts this block and appends it to the progress file automatically. D
 ${commitStepNum}. ${commitInstruction}
 Work on the next incomplete task. Complete it fully (including all its subtasks) before ending your response.
 If ${completionRef}, output <promise>COMPLETE</promise> — ${completeInstruction}
+When you output COMPLETE, also include a <pr-summary> block containing a 1-3 sentence plain-language description of what this PR accomplishes. Write it for a human reviewer — explain the purpose and impact, not a list of commits. Example:
+<pr-summary>
+Add JWT-based authentication with login/logout endpoints, replacing the previous cookie-based session system. Includes rate limiting on auth routes and automatic token refresh.
+</pr-summary>
 REQUIRED: At the very end of your response, include a <learnings> block. If you made a mistake or learned something this iteration, use:
 <learnings>
 <entry>

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -29,6 +29,7 @@ import {
 import { processLearnings } from "./learnings.ts";
 import { assemblePrompt } from "./prompt.ts";
 import { extractProgressBlock, appendProgressBlock } from "./progress.ts";
+import { extractPrSummary } from "./pr-summary.ts";
 import { peekGithubIssues, pullGithubIssues } from "./issues.ts";
 import {
   archiveRun,
@@ -484,6 +485,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
   const completedPlans: string[] = [];
   let continuousBranch = "";
   let continuousPrUrl = "";
+  let lastPrSummary: string | undefined;
   const skippedSlugs = new Set<string>();
   let activePidFile: string | null = null;
 
@@ -849,6 +851,10 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
         );
         completedPlans.push(basename(planFile));
 
+        // Extract agent-generated PR description
+        const prSummary = extractPrSummary(output) ?? undefined;
+        if (prSummary) lastPrSummary = prSummary;
+
         // Remove PID file before archiving so it doesn't end up in out/
         try {
           rmSync(pidFile, { force: true });
@@ -876,6 +882,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
               firstPlanDescription: planDesc,
               prd,
               issueRepo,
+              summary: prSummary,
             });
             console.log(prResult.message);
             if (prResult.ok) {
@@ -891,6 +898,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
               prUrl: continuousPrUrl,
               prd,
               issueRepo,
+              summary: prSummary,
             });
             console.log(update.message);
           }
@@ -905,6 +913,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
             issueRepo,
             issueCommentProgress,
             prd: issueFm.prd,
+            summary: prSummary,
           });
           console.log(prResult.message);
         }
@@ -955,6 +964,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
       prUrl: continuousPrUrl,
       prd,
       issueRepo,
+      summary: lastPrSummary,
     });
     console.log(finalize.message);
   }


### PR DESCRIPTION
Replace the technical `## Summary` heading and `## Files Changed` diffstat with a user-friendly description generated by the coding agent via a new `<pr-summary>` XML output block. PR bodies now lead with a plain-language description, followed by GitHub issue references (`Closes #N`), then a `## Changes` breakdown.

## Changes

### New files
- `src/pr-summary.ts` — extraction function for `<pr-summary>` blocks, following the same pattern as `extractProgressBlock()`
- `src/pr-summary.test.ts` — 8 tests covering extraction edge cases

### Modified files
- `src/prompt.ts` — added `<pr-summary>` instruction at completion time
- `src/pr-description.ts` — restructured both body builders (single-plan and continuous), removed `buildDiffStat()` and `## Files Changed`, removed `## Summary` heading
- `src/pr-lifecycle.ts` — threaded `summary` option through all PR interfaces and functions
- `src/runner.ts` — extracts `<pr-summary>` on COMPLETE detection and passes it through the PR lifecycle
- `src/pr-description.test.ts` — rewritten to match new PR body structure (116 tests, 0 failures)