### PR TITLE
fix: initialize missing resume progress logs

### DIFF
--- a/src/fetch-prd-issue.test.ts
+++ b/src/fetch-prd-issue.test.ts
@@ -4,7 +4,11 @@
  * Uses mock.module to control `child_process.execSync` so we can test the
  * 0, 1, and multiple-result paths without requiring a real GitHub repo.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const realChildProcess = require("child_process");
+const realExecSync =
+  realChildProcess.execSync as typeof import("child_process").execSync;
 
 // ---------------------------------------------------------------------------
 // Mock child_process.execSync
@@ -13,8 +17,15 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 const mockExecSync = mock();
 
 mock.module("child_process", () => ({
-  ...require("child_process"),
-  execSync: (...args: unknown[]) => mockExecSync(...args),
+  ...realChildProcess,
+  execSync: (...args: Parameters<typeof realExecSync>) => {
+    const [cmd, options] = args;
+    if (typeof cmd === "string" && cmd.startsWith("gh ")) {
+      return mockExecSync(...args);
+    }
+
+    return realExecSync(cmd, options as Parameters<typeof realExecSync>[1]);
+  },
 }));
 
 // Import AFTER mocking so the module picks up the mock

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -12,9 +12,11 @@ import type { AssemblePromptOptions } from "./prompt.ts";
 describe("formatFileRef", () => {
   const ctx = useTempDir();
 
-  it("returns @path when file does not exist", () => {
+  it("returns inline placeholder XML when file does not exist", () => {
     const result = formatFileRef("/nonexistent/file.md");
-    expect(result).toBe("@/nonexistent/file.md");
+    expect(result).toBe(
+      `<file path="/nonexistent/file.md">\n(No content yet.)\n</file>`,
+    );
   });
 
   it("wraps file contents in XML tags", () => {
@@ -52,10 +54,15 @@ describe("assemblePrompt", () => {
     };
   }
 
-  it("includes plan and progress file references", () => {
+  it("includes inline plan and progress file references even when files are missing", () => {
     const prompt = assemblePrompt(baseOptions());
-    expect(prompt).toContain("@plan.md");
-    expect(prompt).toContain("@progress.md");
+    expect(prompt).toContain(
+      `<file path="plan.md">\n(No content yet.)\n</file>`,
+    );
+    expect(prompt).toContain(
+      `<file path="progress.md">\n(No content yet.)\n</file>`,
+    );
+    expect(prompt).not.toContain("@progress.md");
   });
 
   it("includes numbered instruction steps", () => {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -44,7 +44,7 @@ export interface AssemblePromptOptions {
  * path so that agents running inside a sandbox never see absolute paths
  * outside the repository and do not attempt to re-read them.
  *
- * Falls back to `@<label>` if the file does not exist.
+ * Falls back to an inline placeholder block if the file does not exist.
  */
 export function formatFileRef(filepath: string, label?: string): string {
   const tag = label ?? filepath;
@@ -52,8 +52,7 @@ export function formatFileRef(filepath: string, label?: string): string {
     const content = readFileSync(filepath, "utf8");
     return `<file path="${tag}">\n${content}\n</file>`;
   }
-  // File doesn't exist — fall back to at-path reference
-  return `@${tag}`;
+  return `<file path="${tag}">\n(No content yet.)\n</file>`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runner-resume.test.ts
+++ b/src/runner-resume.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execSync } from "child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { type ResolvedConfig } from "./config.ts";
+import { getRepoPipelineDirs } from "./global-state.ts";
+import { runRunner, type RunnerOptions } from "./runner.ts";
+
+function createTmpGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "runner-resume-test-"));
+  execSync("git init -b main", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  execSync('git add -A && git commit -m "init"', { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+function createManagedWorktree(mainDir: string, slug: string): string {
+  const worktreeDir = join(tmpdir(), `runner-resume-wt-${slug}-${Date.now()}`);
+  execSync(`git worktree add "${worktreeDir}" -b "ralphai/${slug}" HEAD`, {
+    cwd: mainDir,
+    stdio: "pipe",
+  });
+  return worktreeDir;
+}
+
+function setupGlobalPipeline(cwd: string): {
+  backlogDir: string;
+  wipDir: string;
+  archiveDir: string;
+} {
+  const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
+  process.env.RALPHAI_HOME = ralphaiHome;
+  return getRepoPipelineDirs(cwd);
+}
+
+function makeResolvedConfig(
+  overrides: Partial<Record<string, unknown>> = {},
+): ResolvedConfig {
+  const defaults: Record<string, unknown> = {
+    agentCommand: "echo",
+    feedbackCommands: "",
+    baseBranch: "main",
+    maxStuck: 3,
+    issueSource: "none",
+    issueLabel: "ralphai",
+    issueInProgressLabel: "ralphai:in-progress",
+    issueDoneLabel: "ralphai:done",
+    issueRepo: "",
+    issueCommentProgress: "true",
+    iterationTimeout: 0,
+    continuous: "false",
+    autoCommit: "false",
+    workspaces: null,
+    ...overrides,
+  };
+
+  const resolved: Record<string, { value: unknown; source: string }> = {};
+  for (const [key, value] of Object.entries(defaults)) {
+    resolved[key] = { value, source: "default" };
+  }
+  return resolved as unknown as ResolvedConfig;
+}
+
+describe("runRunner — resume", () => {
+  let dir: string;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.RALPHAI_HOME;
+    dir = createTmpGitRepo();
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.RALPHAI_HOME;
+    else process.env.RALPHAI_HOME = savedHome;
+  });
+
+  test("resume initializes a missing progress log before the first iteration", async () => {
+    const { wipDir, archiveDir } = setupGlobalPipeline(dir);
+    const slug = "resume-missing-progress";
+    const worktreeDir = createManagedWorktree(dir, slug);
+    const planDir = join(wipDir, slug);
+    const planFile = join(planDir, `${slug}.md`);
+    const progressFile = join(planDir, "progress.md");
+
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(
+      planFile,
+      "# Plan: Resume Missing Progress\n\n## Implementation Tasks\n\n### Task 1: Complete resume fix\n",
+    );
+
+    const agentScript = `bash -c 'if [ ! -f "${progressFile}" ]; then echo "missing progress file" >&2; exit 11; fi; printf "<promise>COMPLETE</promise>\n<learnings>none</learnings>\n"'`;
+
+    const opts: RunnerOptions = {
+      config: makeResolvedConfig({
+        agentCommand: agentScript,
+        autoCommit: "true",
+      }),
+      cwd: worktreeDir,
+      isWorktree: true,
+      mainWorktree: dir,
+      dryRun: false,
+      resume: true,
+      allowDirty: false,
+    };
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+    try {
+      await runRunner(opts);
+    } finally {
+      console.log = origLog;
+    }
+
+    const archivedProgressFile = join(archiveDir, slug, "progress.md");
+    expect(existsSync(progressFile)).toBe(false);
+    expect(existsSync(archivedProgressFile)).toBe(true);
+    expect(readFileSync(archivedProgressFile, "utf-8")).toBe(
+      "## Progress Log\n\n",
+    );
+
+    const output = logs.join("\n");
+    expect(output).toContain(`Resuming on existing branch: ralphai/${slug}`);
+    expect(output).toContain(`Initialized ${progressFile}`);
+    expect(output).not.toContain(`Resuming — keeping existing ${progressFile}`);
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -130,6 +130,17 @@ function rollbackPlan(planFile: string, backlogDir: string): void {
   console.log(`Rolled back: moved plan to ${dest}`);
 }
 
+function ensureProgressFile(progressFile: string): void {
+  if (existsSync(progressFile)) {
+    console.log(`Resuming — keeping existing ${progressFile}`);
+    return;
+  }
+
+  mkdirSync(dirname(progressFile), { recursive: true });
+  writeFileSync(progressFile, "## Progress Log\n\n");
+  console.log(`Initialized ${progressFile}`);
+}
+
 /**
  * Spawn the agent command, capture its output, and apply a timeout.
  *
@@ -666,15 +677,13 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
         continuousBranch = branch;
       }
       console.log(`Resuming on existing branch: ${branch}`);
-      console.log(`Resuming — keeping existing ${progressFile}`);
+      ensureProgressFile(progressFile);
     } else if (continuous && continuousBranch) {
       // Continuous mode, subsequent plan: reuse the existing branch
       branch = continuousBranch;
       console.log(`Continuous mode: continuing on branch '${branch}'`);
 
-      mkdirSync(dirname(progressFile), { recursive: true });
-      writeFileSync(progressFile, "## Progress Log\n\n");
-      console.log(`Initialized ${progressFile}`);
+      ensureProgressFile(progressFile);
 
       initReceipt(receiptFile, {
         worktree_path: isWorktree ? cwd : undefined,
@@ -701,9 +710,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
         continuousBranch = branch;
       }
 
-      mkdirSync(dirname(progressFile), { recursive: true });
-      writeFileSync(progressFile, "## Progress Log\n\n");
-      console.log(`Initialized ${progressFile}`);
+      ensureProgressFile(progressFile);
 
       initReceipt(receiptFile, {
         worktree_path: cwd,


### PR DESCRIPTION
## Summary

- Ensure `progress.md` is created on resume when the prior run was interrupted before the first iteration completed
- Change `formatFileRef` fallback from `@path` references to inline XML placeholder blocks so agents never attempt to read non-existent files
- Extract `ensureProgressFile` helper to deduplicate initialization across all three branch strategy paths

Closes #200