### PR TITLE
PRD sub-issue parser

### DIFF
--- a/src/prd-sub-issue-parser.test.ts
+++ b/src/prd-sub-issue-parser.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "bun:test";
+import { parseSubIssues } from "./prd-sub-issue-parser.ts";
+
+// ---------------------------------------------------------------------------
+// Basic extraction
+// ---------------------------------------------------------------------------
+
+describe("parseSubIssues", () => {
+  it("extracts issue number from #N shorthand", () => {
+    expect(parseSubIssues("- [ ] #11")).toEqual([11]);
+  });
+
+  it("extracts issue number from full GitHub URL", () => {
+    expect(
+      parseSubIssues("- [ ] https://github.com/owner/repo/issues/14"),
+    ).toEqual([14]);
+  });
+
+  it("excludes checked items", () => {
+    expect(parseSubIssues("- [x] #13")).toEqual([]);
+  });
+
+  it("returns empty array for body with no task list items", () => {
+    const body = [
+      "## Overview",
+      "",
+      "This is a PRD with no tasks.",
+      "",
+      "Some more text.",
+    ].join("\n");
+    expect(parseSubIssues(body)).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty / undefined / null input
+  // ---------------------------------------------------------------------------
+
+  it("returns empty array for empty string", () => {
+    expect(parseSubIssues("")).toEqual([]);
+  });
+
+  it("returns empty array for undefined", () => {
+    expect(parseSubIssues(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for null", () => {
+    expect(parseSubIssues(null)).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Mixed checked and unchecked items
+  // ---------------------------------------------------------------------------
+
+  it("returns only unchecked issue numbers from mixed list", () => {
+    const body = [
+      "## Sub-issues",
+      "",
+      "- [x] #10",
+      "- [ ] #11",
+      "- [x] #12",
+      "- [ ] #13",
+      "- [x] #14",
+    ].join("\n");
+    expect(parseSubIssues(body)).toEqual([11, 13]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Mixed formats in same body
+  // ---------------------------------------------------------------------------
+
+  it("handles mixed #N and URL formats in the same body", () => {
+    const body = [
+      "- [ ] #5",
+      "- [ ] https://github.com/acme/project/issues/42",
+      "- [ ] #99",
+    ].join("\n");
+    expect(parseSubIssues(body)).toEqual([5, 42, 99]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Non-issue task list items
+  // ---------------------------------------------------------------------------
+
+  it("ignores unchecked items that are not issue references", () => {
+    const body = [
+      "- [ ] Implement the parser",
+      "- [ ] #7",
+      "- [ ] Write tests",
+      "- [ ] https://github.com/org/repo/issues/8",
+    ].join("\n");
+    expect(parseSubIssues(body)).toEqual([7, 8]);
+  });
+
+  it("ignores items with text after the issue reference", () => {
+    const body = "- [ ] #7 some extra text";
+    expect(parseSubIssues(body)).toEqual([]);
+  });
+
+  it("ignores items with text before the issue reference", () => {
+    const body = "- [ ] see #7";
+    expect(parseSubIssues(body)).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Malformed URLs
+  // ---------------------------------------------------------------------------
+
+  it("ignores malformed GitHub URLs missing issue number", () => {
+    expect(
+      parseSubIssues("- [ ] https://github.com/owner/repo/issues/"),
+    ).toEqual([]);
+  });
+
+  it("ignores non-GitHub URLs", () => {
+    expect(
+      parseSubIssues("- [ ] https://gitlab.com/owner/repo/issues/5"),
+    ).toEqual([]);
+  });
+
+  it("ignores GitHub URLs with wrong path structure", () => {
+    expect(
+      parseSubIssues("- [ ] https://github.com/owner/repo/pull/5"),
+    ).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Preserves order
+  // ---------------------------------------------------------------------------
+
+  it("preserves the order of issues as they appear in the body", () => {
+    const body = ["- [ ] #30", "- [ ] #10", "- [ ] #20"].join("\n");
+    expect(parseSubIssues(body)).toEqual([30, 10, 20]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Realistic PRD body
+  // ---------------------------------------------------------------------------
+
+  it("handles a realistic PRD body with prose and task lists", () => {
+    const body = [
+      "# Feature: User Authentication",
+      "",
+      "## Overview",
+      "",
+      "Implement user authentication with JWT tokens.",
+      "",
+      "## Sub-issues",
+      "",
+      "- [x] #1",
+      "- [ ] #2",
+      "- [ ] https://github.com/acme/app/issues/3",
+      "- [x] https://github.com/acme/app/issues/4",
+      "- [ ] #5",
+      "",
+      "## Notes",
+      "",
+      "Remember to add rate limiting.",
+    ].join("\n");
+    expect(parseSubIssues(body)).toEqual([2, 3, 5]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------------------
+
+  it("handles trailing whitespace on lines", () => {
+    expect(parseSubIssues("- [ ] #42   ")).toEqual([42]);
+  });
+
+  it("handles Windows-style line endings", () => {
+    const body = "- [ ] #1\r\n- [ ] #2\r\n";
+    expect(parseSubIssues(body)).toEqual([1, 2]);
+  });
+
+  it("handles single item with no trailing newline", () => {
+    expect(parseSubIssues("- [ ] #7")).toEqual([7]);
+  });
+
+  it("ignores checkbox variants with uppercase X", () => {
+    expect(parseSubIssues("- [X] #13")).toEqual([]);
+  });
+});

--- a/src/prd-sub-issue-parser.ts
+++ b/src/prd-sub-issue-parser.ts
@@ -1,0 +1,56 @@
+/**
+ * PRD sub-issue parser: extracts issue numbers from unchecked task list
+ * items in a GitHub issue body string.
+ *
+ * Supported formats:
+ *   - `- [ ] #N`
+ *   - `- [ ] https://github.com/owner/repo/issues/N`
+ *
+ * Checked items (`- [x] #N`) are excluded.
+ *
+ * This module has NO I/O dependencies — all functions are pure.
+ */
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches an unchecked GitHub task list item that references an issue.
+ *
+ * Captures either:
+ *   Group 1: issue number from `#N` shorthand
+ *   Group 2: issue number from a full `https://github.com/.../issues/N` URL
+ *
+ * The regex requires `- [ ]` (unchecked checkbox) and will not match
+ * `- [x]` (checked checkbox).
+ */
+const UNCHECKED_ISSUE_RE =
+  /^- \[ \] (?:#(\d+)|https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+))\s*$/;
+
+/**
+ * Extract issue numbers from unchecked task list items in a GitHub issue
+ * body. Returns an array of issue numbers (as numbers), preserving the
+ * order they appear in the body.
+ *
+ * - Checked items (`- [x] ...`) are excluded.
+ * - Non-issue task items (e.g. `- [ ] some text`) are ignored.
+ * - Empty or undefined input returns an empty array.
+ */
+export function parseSubIssues(body: string | undefined | null): number[] {
+  if (!body) return [];
+
+  const issues: number[] = [];
+
+  for (const line of body.split("\n")) {
+    const match = UNCHECKED_ISSUE_RE.exec(line.trimEnd());
+    if (!match) continue;
+
+    const raw = match[1] ?? match[2];
+    if (!raw) continue;
+
+    issues.push(Number(raw));
+  }
+
+  return issues;
+}


### PR DESCRIPTION
Add a pure, I/O-free module that parses GitHub issue body strings to extract issue numbers from unchecked task list items. Supports both  shorthand and full GitHub issue URLs, excludes checked items, and handles edge cases like empty input, mixed formats, malformed URLs, and Windows line endings. This enables PRD discovery to determine which sub-issues still need work.

Closes #205

## Changes

### Features

- add pure sub-issue parser for extracting unchecked task list items


## Learnings

- Always check return values before using them.