### PR TITLE
fix: allow trailing description text in PRD sub-issue task list items

### DIFF
--- a/src/prd-sub-issue-parser.test.ts
+++ b/src/prd-sub-issue-parser.test.ts
@@ -91,9 +91,33 @@ describe("parseSubIssues", () => {
     expect(parseSubIssues(body)).toEqual([7, 8]);
   });
 
-  it("ignores items with text after the issue reference", () => {
+  it("extracts issue number even with trailing description text", () => {
     const body = "- [ ] #7 some extra text";
-    expect(parseSubIssues(body)).toEqual([]);
+    expect(parseSubIssues(body)).toEqual([7]);
+  });
+
+  it("extracts issue number with em-dash description", () => {
+    const body =
+      "- [ ] #219 — Extract `gatherPipelineState` from `printStatusOnce`";
+    expect(parseSubIssues(body)).toEqual([219]);
+  });
+
+  it("extracts issue numbers from real PRD with descriptions", () => {
+    const body = [
+      "## Slices",
+      "",
+      "- [ ] #219 — Extract `gatherPipelineState` from `printStatusOnce`",
+      "- [ ] #220 — Interactive menu shell with pipeline header and status action",
+      "- [ ] #221 — Interactive run next plan and pick from backlog",
+      "- [x] #222 — Interactive pick from GitHub with PRD tree display",
+      "- [ ] #223 — Interactive resume stalled, stop running, and reset plan",
+    ].join("\n");
+    expect(parseSubIssues(body)).toEqual([219, 220, 221, 223]);
+  });
+
+  it("extracts URL issue number with trailing description text", () => {
+    const body = "- [ ] https://github.com/owner/repo/issues/42 Fix login bug";
+    expect(parseSubIssues(body)).toEqual([42]);
   });
 
   it("ignores items with text before the issue reference", () => {
@@ -208,6 +232,10 @@ describe("hasCheckedSubIssues", () => {
 
   it("returns true when checked items with lowercase x exist", () => {
     expect(hasCheckedSubIssues("- [x] #10")).toBe(true);
+  });
+
+  it("returns true for checked items with trailing description text", () => {
+    expect(hasCheckedSubIssues("- [x] #10 — Implement auth")).toBe(true);
   });
 
   it("returns true when checked items with uppercase X exist", () => {

--- a/src/prd-sub-issue-parser.ts
+++ b/src/prd-sub-issue-parser.ts
@@ -23,17 +23,18 @@
  *   Group 2: issue number from a full `https://github.com/.../issues/N` URL
  *
  * The regex requires `- [ ]` (unchecked checkbox) and will not match
- * `- [x]` (checked checkbox).
+ * `- [x]` (checked checkbox). Trailing description text after the
+ * issue reference is allowed (e.g. `- [ ] #7 — Fix the bug`).
  */
 const UNCHECKED_ISSUE_RE =
-  /^- \[ \] (?:#(\d+)|https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+))\s*$/;
+  /^- \[ \] (?:#(\d+)|https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+))(?:\s.*)?$/;
 
 /**
  * Matches a checked (`[x]` or `[X]`) GitHub task list item that references
  * an issue.
  */
 const CHECKED_ISSUE_RE =
-  /^- \[[xX]\] (?:#(\d+)|https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+))\s*$/;
+  /^- \[[xX]\] (?:#(\d+)|https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+))(?:\s.*)?$/;
 
 /**
  * Extract issue numbers from unchecked task list items in a GitHub issue


### PR DESCRIPTION
## Summary

- PRD sub-issue parser rejected task list items with descriptive text after the issue reference (e.g. `- [ ] #219 — Extract gatherPipelineState`), causing `ralphai run <prd-number>` to silently fall back to treating the entire PRD body as the plan instead of processing sub-issues.
- Updated both `UNCHECKED_ISSUE_RE` and `CHECKED_ISSUE_RE` regexes to allow optional trailing text after the issue number or URL, separated by whitespace.
