### PR TITLE
fix: prevent PRD runner from re-pulling completed sub-issues

### DIFF
--- a/src/issues.test.ts
+++ b/src/issues.test.ts
@@ -9,6 +9,7 @@ import {
   slugify,
   peekGithubIssues,
   pullGithubIssues,
+  pullPrdSubIssue,
   PRD_LABEL,
   fetchPrdIssueByNumber,
   prdBranchName,
@@ -49,6 +50,7 @@ function defaultOptions(dir: string): PullIssueOptions {
     issueSource: "github",
     issueLabel: "ralphai",
     issueInProgressLabel: "ralphai:in-progress",
+    issueDoneLabel: "ralphai:done",
     issueRepo: "",
     issueCommentProgress: false,
   };
@@ -345,6 +347,32 @@ describe("fetchPrdIssueByNumber", () => {
           ctx.dir,
         ),
       ).toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pullPrdSubIssue — guard clause tests (no gh required)
+// ---------------------------------------------------------------------------
+
+describe("pullPrdSubIssue", () => {
+  const ctx = useTempDir();
+
+  it("returns early when issueSource is not github", () => {
+    const opts = { ...defaultOptions(ctx.dir), issueSource: "none" };
+    const result = pullPrdSubIssue(opts);
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("not 'github'");
+  });
+
+  it("returns early when gh is not available", () => {
+    initRepo(ctx.dir);
+    const ghAvailable = checkGhAvailable();
+    if (!ghAvailable) {
+      const opts = defaultOptions(ctx.dir);
+      const result = pullPrdSubIssue(opts);
+      expect(result.pulled).toBe(false);
+      expect(result.message).toContain("not available");
     }
   });
 });

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -26,6 +26,8 @@ export interface PullIssueOptions {
   issueLabel: string;
   /** Label applied when an issue is picked up (e.g. "ralphai:in-progress"). */
   issueInProgressLabel: string;
+  /** Label applied when an issue is completed (e.g. "ralphai:done"). */
+  issueDoneLabel: string;
   /** Explicit owner/repo (empty = auto-detect from git remote). */
   issueRepo: string;
   /** Whether to post a progress comment on the issue. */
@@ -479,6 +481,7 @@ export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
     issueSource,
     issueLabel,
     issueInProgressLabel,
+    issueDoneLabel,
     issueRepo,
     issueCommentProgress,
   } = options;
@@ -536,8 +539,31 @@ export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
     };
   }
 
-  // Pull the first unchecked sub-issue into the backlog
-  const subIssueNumber = subIssues[0]!;
+  // Find the first unchecked sub-issue that hasn't already been picked up
+  // or completed. Without this check, the runner's drain loop re-pulls
+  // completed sub-issues because the PRD body checkboxes are never updated.
+  const skipLabels = [issueInProgressLabel, issueDoneLabel];
+  let subIssueNumber: number | undefined;
+  for (const candidate of subIssues) {
+    const labelsRaw = execQuiet(
+      `gh issue view ${candidate} --repo "${repo}" --json labels --jq '[.labels[].name] | join(",")'`,
+      cwd,
+    );
+    const labels = labelsRaw ? labelsRaw.split(",") : [];
+    if (skipLabels.some((skip) => labels.includes(skip))) {
+      continue;
+    }
+    subIssueNumber = candidate;
+    break;
+  }
+
+  if (subIssueNumber === undefined) {
+    return {
+      pulled: false,
+      message: `PRD #${prd.number} — all unchecked sub-issues already in-progress or done`,
+    };
+  }
+
   console.log(
     `PRD #${prd.number} — pulling sub-issue #${subIssueNumber} into backlog`,
   );

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -3047,6 +3047,7 @@ async function runIssueTarget(
     issueSource: "github",
     issueLabel: worktreeConfig.issueLabel.value,
     issueInProgressLabel: worktreeConfig.issueInProgressLabel.value,
+    issueDoneLabel: worktreeConfig.issueDoneLabel.value,
     issueRepo: worktreeConfig.issueRepo.value || repo,
     issueCommentProgress: worktreeConfig.issueCommentProgress.value === "true",
     issueNumber,
@@ -3197,6 +3198,7 @@ async function runPrdIssueTarget(
       issueSource: "github",
       issueLabel: worktreeConfig.issueLabel.value,
       issueInProgressLabel: worktreeConfig.issueInProgressLabel.value,
+      issueDoneLabel: worktreeConfig.issueDoneLabel.value,
       issueRepo: worktreeConfig.issueRepo.value || repo,
       issueCommentProgress:
         worktreeConfig.issueCommentProgress.value === "true",
@@ -3224,12 +3226,18 @@ async function runPrdIssueTarget(
     const shouldResume = activeWorktree !== undefined || !isFirstSubIssue;
     const hasResumeFlag =
       runArgs.includes("--resume") || runArgs.includes("-r");
+    // --once ensures the runner exits after completing this single sub-issue,
+    // so the outer for-loop (not the runner's drain loop) controls sequencing.
+    // Without this, the runner re-fetches the PRD body, finds the same
+    // unchecked sub-issue, and re-pulls it.
+    const hasOnceFlag = runArgs.includes("--once");
     const worktreeRunOptions: RalphaiOptions = {
       ...options,
       subcommand: "run",
       runTarget: undefined,
       runArgs: [
         ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
+        ...(!hasOnceFlag ? ["--once"] : []),
         ...runArgs,
       ],
     };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -567,6 +567,7 @@ export async function runRunner(opts: RunnerOptions): Promise<void> {
           issueSource,
           issueLabel,
           issueInProgressLabel,
+          issueDoneLabel,
           issueRepo,
           issueCommentProgress,
         };


### PR DESCRIPTION
## Summary

- **Bug**: After completing a PRD sub-issue, the runner's drain loop re-fetched the PRD body, found the same sub-issue still unchecked (checkboxes are never updated), re-pulled it, re-labeled it `ralphai:in-progress`, and ran it again. This caused the "label doesn't change from in-progress" symptom and duplicate implementation attempts.
- **Fix A**: `runPrdIssueTarget()` now injects `--once` into runner args so the runner exits after each sub-issue, letting the outer for-loop control sequencing.
- **Fix B**: `pullPrdSubIssue()` now checks each candidate sub-issue's labels via `gh issue view` and skips any already labeled `ralphai:in-progress` or `ralphai:done` (defense-in-depth for the `--prd=N` managed worktree path).

