### PR TITLE
fix: clean up zombie repo entries with no config.json and empty pipelines

### DIFF
--- a/src/global-state.ts
+++ b/src/global-state.ts
@@ -284,9 +284,12 @@ export function resolveRepoByNameOrPath(
 /**
  * Remove stale repo entries from global state.
  *
- * A repo is considered stale when its stored `repoPath` points to a directory
- * that no longer exists **and** its pipeline is completely empty (no backlog,
- * in-progress, or completed plans). Returns the IDs of removed entries.
+ * A repo is considered stale when its pipeline is completely empty (no backlog,
+ * in-progress, or completed plans) **and** either:
+ * - its stored `repoPath` points to a directory that no longer exists, or
+ * - it has no `config.json` at all (e.g. orphaned skeleton from a test leak).
+ *
+ * Returns the IDs of removed entries.
  */
 export function removeStaleRepos(
   env?: Record<string, string | undefined>,
@@ -296,12 +299,13 @@ export function removeStaleRepos(
   const removed: string[] = [];
 
   for (const repo of repos) {
-    const isStale =
-      repo.repoPath !== null &&
-      !repo.pathExists &&
+    const emptyPipeline =
       repo.backlogCount === 0 &&
       repo.inProgressCount === 0 &&
       repo.completedCount === 0;
+
+    const isStale =
+      emptyPipeline && (repo.repoPath === null || !repo.pathExists);
 
     if (isStale) {
       const stateDir = join(reposDir, repo.id);

--- a/src/repos.test.ts
+++ b/src/repos.test.ts
@@ -110,14 +110,39 @@ describe("removeStaleRepos", () => {
     expect(existsSync(staleDir)).toBe(false);
   });
 
-  it("preserves entries with no repoPath", () => {
+  it("removes entries with no repoPath and empty pipeline", () => {
     const home = join(ctx.dir, ".ralphai-home");
     const dir = join(home, "repos", "_path-no-repopath");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "config.json"), JSON.stringify({}));
 
     const removed = removeStaleRepos(env());
-    expect(removed).not.toContain("_path-no-repopath");
+    expect(removed).toContain("_path-no-repopath");
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("removes entries with no config.json and empty pipeline", () => {
+    const home = join(ctx.dir, ".ralphai-home");
+    const dir = join(home, "repos", "_path-no-config");
+    const pipelineDir = join(dir, "pipeline");
+    mkdirSync(join(pipelineDir, "backlog"), { recursive: true });
+    mkdirSync(join(pipelineDir, "in-progress"), { recursive: true });
+    mkdirSync(join(pipelineDir, "out"), { recursive: true });
+
+    const removed = removeStaleRepos(env());
+    expect(removed).toContain("_path-no-config");
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("preserves entries with no config.json but non-empty pipeline", () => {
+    const home = join(ctx.dir, ".ralphai-home");
+    const dir = join(home, "repos", "_path-no-config-has-plans");
+    const backlogDir = join(dir, "pipeline", "backlog");
+    mkdirSync(backlogDir, { recursive: true });
+    writeFileSync(join(backlogDir, "task.md"), "# Task\n");
+
+    const removed = removeStaleRepos(env());
+    expect(removed).not.toContain("_path-no-config-has-plans");
     expect(existsSync(dir)).toBe(true);
   });
 

--- a/src/runner-drain.test.ts
+++ b/src/runner-drain.test.ts
@@ -54,7 +54,7 @@ function createManagedWorktree(mainDir: string, slug: string): string {
 function setupGlobalPipeline(cwd: string) {
   const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
   process.env.RALPHAI_HOME = ralphaiHome;
-  const dirs = getRepoPipelineDirs(cwd);
+  const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
   return { ralphaiHome, ...dirs };
 }
 

--- a/src/runner-learnings.test.ts
+++ b/src/runner-learnings.test.ts
@@ -57,7 +57,7 @@ function setupGlobalPipeline(cwd: string): {
 } {
   const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
   process.env.RALPHAI_HOME = ralphaiHome;
-  const dirs = getRepoPipelineDirs(cwd);
+  const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
   return { ralphaiHome, ...dirs };
 }
 

--- a/src/runner-resume.test.ts
+++ b/src/runner-resume.test.ts
@@ -43,7 +43,7 @@ function setupGlobalPipeline(cwd: string): {
 } {
   const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
   process.env.RALPHAI_HOME = ralphaiHome;
-  return getRepoPipelineDirs(cwd);
+  return getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
 }
 
 function makeResolvedConfig(

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -214,7 +214,7 @@ function setupGlobalPipeline(cwd: string): {
 } {
   const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
   process.env.RALPHAI_HOME = ralphaiHome;
-  const dirs = getRepoPipelineDirs(cwd);
+  const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
   return { ralphaiHome, ...dirs };
 }
 


### PR DESCRIPTION
## Summary

- **Fix `removeStaleRepos()`** to treat repos with no `config.json` (or no `repoPath` field) as stale when their pipeline is empty. Previously `repoPath !== null` was required, so orphaned skeleton directories accumulated forever.
- **Harden test isolation** in 4 runner test files by passing explicit `{ RALPHAI_HOME }` env to `getRepoPipelineDirs()` instead of relying solely on `process.env` mutation.
- **Add tests** for the new cleanup behavior: no-config empty repos are removed, no-config repos with plans are preserved.

## Root cause

`getRepoPipelineDirs()` creates `~/.ralphai/repos/<id>/pipeline/{backlog,in-progress,out}` as a side effect. When called against a directory with no git remote, the repo ID falls back to `_path-<sha256>`. If no `config.json` is ever written (e.g. test leak or interrupted init), the `removeStaleRepos()` guard `repoPath !== null` prevents cleanup — the directory has no `repoPath` at all, so it's never considered stale.