### PR TITLE
fix:  exits without pulling GitHub issues when backlog is empty

### DIFF
--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -64,9 +64,11 @@ import {
   fetchIssueTitleByNumber,
   prdBranchName,
   pullGithubIssueByNumber,
+  pullGithubIssues,
+  pullPrdSubIssue,
   slugify,
 } from "./issues.ts";
-import type { PrdIssue, PullIssueOptions } from "./issues.ts";
+import type { PrdIssue, PullIssueOptions, PullIssueResult } from "./issues.ts";
 import { discoverPrdTarget } from "./prd-discovery.ts";
 import type { PrdDiscoveryResult } from "./prd-discovery.ts";
 import { detectRunTarget, type RunTarget } from "./target-detection.ts";
@@ -1744,10 +1746,18 @@ export interface WorktreeEntry {
   bare: boolean;
 }
 
-interface SelectedWorktreePlan {
+export interface SelectedWorktreePlan {
   planFile: string;
   slug: string;
   source: "backlog" | "in-progress";
+}
+
+/** Options for attempting a GitHub issue pull when the local backlog is empty. */
+export interface GitHubFallbackOptions {
+  /** Configured issue source — pull is only attempted when this is "github". */
+  issueSource: string;
+  /** Function that attempts to pull a GitHub issue into the backlog. */
+  pullFn: () => import("./issues.ts").PullIssueResult;
 }
 
 // Receipt interface and functions (parseReceipt, checkReceiptSource) are
@@ -1793,10 +1803,11 @@ export function parseWorktreeList(output: string): WorktreeEntry[] {
   return entries;
 }
 
-function selectPlanForWorktree(
+export function selectPlanForWorktree(
   cwd: string,
   specificPlan?: string,
   activeWorktrees: WorktreeEntry[] = [],
+  githubOptions?: GitHubFallbackOptions,
 ): SelectedWorktreePlan | null {
   const { backlogDir, wipDir: inProgressDir } = getRepoPipelineDirs(cwd);
 
@@ -1890,6 +1901,22 @@ function selectPlanForWorktree(
     for (const planFile of attendedPlans) {
       console.error(`  ${planFile}`);
     }
+    return null;
+  }
+
+  // --- GitHub issue fallback: pull an issue if configured ---
+  if (githubOptions?.issueSource === "github") {
+    const result = githubOptions.pullFn();
+    if (result.pulled) {
+      // Re-check backlog after pulling
+      const newBacklogPlans = listPlanFiles(backlogDir, true);
+      if (newBacklogPlans.length > 0) {
+        const firstPlan = newBacklogPlans[0]!;
+        const slug = firstPlan.replace(/\.md$/, "");
+        return { planFile: firstPlan, slug, source: "backlog" };
+      }
+    }
+    console.error(`No plans in backlog and no GitHub issues available.`);
     return null;
   }
 
@@ -3477,8 +3504,14 @@ async function runRalphaiInManagedWorktree(
   const planFlag = runArgs.find((a) => a.startsWith("--plan="));
   const targetPlan = planFlag ? planFlag.slice("--plan=".length) : undefined;
 
-  // Resolve setupCommand from config/env/CLI (read-only, safe for dry-run)
+  // Resolve config from config/env/CLI (read-only, safe for dry-run)
   let setupCommand = "";
+  let resolvedIssueSource = "none";
+  let resolvedIssueLabel = "ralphai";
+  let resolvedIssueInProgressLabel = "ralphai:in-progress";
+  let resolvedIssueDoneLabel = "ralphai:done";
+  let resolvedIssueRepo = "";
+  let resolvedIssueCommentProgress = false;
   try {
     const cfgResult = resolveConfig({
       cwd,
@@ -3486,6 +3519,13 @@ async function runRalphaiInManagedWorktree(
       cliArgs: runArgs,
     });
     setupCommand = cfgResult.config.setupCommand.value;
+    resolvedIssueSource = cfgResult.config.issueSource.value;
+    resolvedIssueLabel = cfgResult.config.issueLabel.value;
+    resolvedIssueInProgressLabel = cfgResult.config.issueInProgressLabel.value;
+    resolvedIssueDoneLabel = cfgResult.config.issueDoneLabel.value;
+    resolvedIssueRepo = cfgResult.config.issueRepo.value;
+    resolvedIssueCommentProgress =
+      cfgResult.config.issueCommentProgress.value === "true";
   } catch {
     // Config resolution may fail if not yet initialised; setup will be skipped
   }
@@ -3728,7 +3768,39 @@ async function runRalphaiInManagedWorktree(
   }
 
   const activeWorktrees = listRalphaiWorktrees(cwd);
-  const plan = selectPlanForWorktree(cwd, targetPlan, activeWorktrees);
+
+  // Build GitHub fallback options so selectPlanForWorktree can pull an issue
+  // when the local backlog is empty and issueSource is "github".
+  const githubFallback: GitHubFallbackOptions | undefined =
+    resolvedIssueSource === "github"
+      ? {
+          issueSource: resolvedIssueSource,
+          pullFn: () => {
+            const { backlogDir } = getRepoPipelineDirs(cwd);
+            const pullOpts: PullIssueOptions = {
+              backlogDir,
+              cwd,
+              issueSource: resolvedIssueSource,
+              issueLabel: resolvedIssueLabel,
+              issueInProgressLabel: resolvedIssueInProgressLabel,
+              issueDoneLabel: resolvedIssueDoneLabel,
+              issueRepo: resolvedIssueRepo,
+              issueCommentProgress: resolvedIssueCommentProgress,
+            };
+            // Priority chain: try PRD sub-issues first, then regular issues
+            const prdResult = pullPrdSubIssue(pullOpts);
+            if (prdResult.pulled) return prdResult;
+            return pullGithubIssues(pullOpts);
+          },
+        }
+      : undefined;
+
+  const plan = selectPlanForWorktree(
+    cwd,
+    targetPlan,
+    activeWorktrees,
+    githubFallback,
+  );
   if (!plan) process.exit(1);
 
   const baseBranch = detectBaseBranch(cwd);

--- a/src/select-plan-github.test.ts
+++ b/src/select-plan-github.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for selectPlanForWorktree with GitHub issue pull fallback.
+ *
+ * Verifies that when the local backlog is empty and issueSource is "github",
+ * the plan selection attempts to pull a GitHub issue before giving up.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { execSync } from "child_process";
+import { useTempDir } from "./test-utils.ts";
+import { selectPlanForWorktree } from "./ralphai.ts";
+import type { PullIssueResult } from "./issues.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Initialize a git repo so getRepoPipelineDirs can detect the repo root. */
+function initRepo(dir: string): void {
+  execSync("git init -b main", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "init.txt"), "init\n");
+  execSync('git add -A && git commit -m "init"', {
+    cwd: dir,
+    stdio: "pipe",
+  });
+}
+
+/**
+ * Set up global pipeline directories for the test repo.
+ * Mirrors the pattern used in runner.test.ts.
+ */
+function setupPipeline(cwd: string): {
+  ralphaiHome: string;
+  backlogDir: string;
+  wipDir: string;
+} {
+  // Import getRepoPipelineDirs dynamically since we need to set RALPHAI_HOME first
+  const { getRepoPipelineDirs } = require("./global-state.ts");
+  const { mkdtempSync } = require("fs");
+  const { tmpdir } = require("os");
+
+  const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
+  process.env.RALPHAI_HOME = ralphaiHome;
+  const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
+  return { ralphaiHome, backlogDir: dirs.backlogDir, wipDir: dirs.wipDir };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: issueSource "github" pulls issue when backlog is empty
+// ---------------------------------------------------------------------------
+
+describe("selectPlanForWorktree — GitHub issue fallback", () => {
+  const ctx = useTempDir();
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.RALPHAI_HOME;
+    initRepo(ctx.dir);
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.RALPHAI_HOME;
+    else process.env.RALPHAI_HOME = savedHome;
+  });
+
+  test("calls pullFn when backlog is empty and issueSource is 'github'", () => {
+    const { backlogDir } = setupPipeline(ctx.dir);
+    let pullCalled = false;
+
+    // Provide a pullFn that simulates pulling a GitHub issue into the backlog
+    const pullFn = (): PullIssueResult => {
+      pullCalled = true;
+      // Write a plan file into the backlog to simulate a successful pull
+      writeFileSync(
+        join(backlogDir, "fix-some-bug.md"),
+        "---\nsource: github\nissue: 42\n---\n# Fix some bug\n",
+      );
+      return { pulled: true, message: "Pulled issue #42" };
+    };
+
+    const result = selectPlanForWorktree(ctx.dir, undefined, [], {
+      issueSource: "github",
+      pullFn,
+    });
+
+    expect(pullCalled).toBe(true);
+    expect(result).not.toBeNull();
+    expect(result!.slug).toBe("fix-some-bug");
+    expect(result!.source).toBe("backlog");
+  });
+
+  test("returns null with clear message when issueSource is 'github' but no issues available", () => {
+    setupPipeline(ctx.dir);
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+    try {
+      const pullFn = (): PullIssueResult => {
+        return { pulled: false, message: "No open issues found" };
+      };
+
+      const result = selectPlanForWorktree(ctx.dir, undefined, [], {
+        issueSource: "github",
+        pullFn,
+      });
+
+      expect(result).toBeNull();
+      const output = errors.join("\n");
+      expect(output).toContain("No plans in backlog");
+      expect(output).toContain("GitHub");
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("does not call pullFn when issueSource is 'none'", () => {
+    setupPipeline(ctx.dir);
+    let pullCalled = false;
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+    try {
+      const pullFn = (): PullIssueResult => {
+        pullCalled = true;
+        return { pulled: false, message: "should not be called" };
+      };
+
+      const result = selectPlanForWorktree(ctx.dir, undefined, [], {
+        issueSource: "none",
+        pullFn,
+      });
+
+      expect(result).toBeNull();
+      expect(pullCalled).toBe(false);
+      const output = errors.join("\n");
+      expect(output).toContain("No plans in backlog");
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("does not call pullFn when no github options provided (backward compat)", () => {
+    setupPipeline(ctx.dir);
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+    try {
+      // No githubOptions = default behavior (no pull attempt)
+      const result = selectPlanForWorktree(ctx.dir, undefined, []);
+
+      expect(result).toBeNull();
+      const output = errors.join("\n");
+      expect(output).toContain("No plans in backlog");
+      // Should NOT mention GitHub since no github options provided
+      expect(output).not.toContain("GitHub");
+    } finally {
+      console.error = origError;
+    }
+  });
+});


### PR DESCRIPTION
Fix  exiting with "No plans in backlog" when  is configured as "github" and there are labeled issues available on GitHub. The CLI layer now attempts to pull GitHub issues (PRD sub-issues first, then regular issues) before giving up on an empty backlog, matching the behavior already documented in the README and already implemented in the runner loop.

Closes #231

## Changes

### Bug Fixes

- pull GitHub issues before exiting when backlog is empty


## Learnings

- Always check return values before using them.