### PR TITLE
feat(prompt): instruct agent to complete only one task per iteration

### DIFF
--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -272,6 +272,15 @@ describe("assemblePrompt", () => {
     expect(prompt).toContain("2. Find the highest-priority incomplete task");
   });
 
+  it("instructs agent to complete only one task per iteration", () => {
+    const prompt = assemblePrompt(baseOptions());
+    expect(prompt).toContain("Complete ONLY the task identified in step 2");
+    expect(prompt).toContain("you will be re-invoked with updated progress");
+    expect(prompt).toContain(
+      "do not attempt to complete the entire plan in one pass",
+    );
+  });
+
   it("references 'all tasks complete' for tasks format", () => {
     const prompt = assemblePrompt(baseOptions({ planFormat: "tasks" }));
     expect(prompt).toContain("all tasks complete");

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -164,7 +164,7 @@ Ralphai extracts this block and appends it to the progress file automatically. D
    - Project documentation files that describe architecture, conventions, agent instructions, or reusable skills — update only if your changes affect them.
    Only update docs that are actually affected by your changes — do not rewrite docs unnecessarily.
 6. ${commitInstruction}
-Work on the next incomplete task. Complete it fully (including all its subtasks) before ending your response.
+Complete ONLY the task identified in step 2. Finish it fully (including all its subtasks), then end your response. Do not continue to the next task — you will be re-invoked with updated progress to continue. Ralphai manages the iteration loop, so do not attempt to complete the entire plan in one pass.
 If ${completionRef}, output <promise>COMPLETE</promise> — ${completeInstruction}
 When you output COMPLETE, also include a <pr-summary> block containing a 1-3 sentence plain-language description of what this PR accomplishes. Write it for a human reviewer — explain the purpose and impact, not a list of commits. Example:
 <pr-summary>


### PR DESCRIPTION
## Summary

- Updates the agent prompt to explicitly constrain each iteration to a single task (the one identified in step 2), and tells the agent it will be re-invoked with updated progress — preventing agents from attempting the entire plan in one pass and blowing their context window.
- Adds a test asserting the new single-task-per-iteration instruction is present in the assembled prompt.

## Context

The core purpose of ralphai's iteration loop is to keep LLMs from exhausting their context window. Previously, the prompt said "Work on the next incomplete task. Complete it fully before ending your response" — which didn't explicitly tell the agent to **stop** after one task or that ralphai would re-invoke it. The new wording makes this contract explicit:

> Complete ONLY the task identified in step 2. Finish it fully (including all its subtasks), then end your response. Do not continue to the next task — you will be re-invoked with updated progress to continue. Ralphai manages the iteration loop, so do not attempt to complete the entire plan in one pass.