### PR TITLE
fix: make hello-world plan explicitly use echo and forbid file creation

### DIFF
--- a/src/sample-plans/hello-world.md
+++ b/src/sample-plans/hello-world.md
@@ -4,10 +4,11 @@
 
 ## Acceptance Criteria
 
-- [ ] Running a single command prints `Hello world` to the console
+- [ ] Running `echo 'Hello world'` prints `Hello world` to the console
+- [ ] No files are created, modified, or committed
 
 ## Implementation Tasks
 
 ### Task 1: Print Hello world
 
-- Run a console command that prints `Hello world`
+- Run `echo 'Hello world'` in the terminal — do not create any files


### PR DESCRIPTION
## Summary

- Specifies `echo 'Hello world'` as the exact command so the coding agent doesn't improvise by creating script files
- Adds an explicit acceptance criterion that no files are created, modified, or committed