### PR TITLE
docs: document PRD workflow across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This shows a pipeline summary header and an interactive menu. From here you can 
 
 ### 3. Run headlessly
 
-Ralphai always creates or reuses a managed worktree on **`ralphai/<plan-slug>`**, so there is no need to create a feature branch yourself.
+Ralphai always creates or reuses a managed worktree on **`ralphai/<plan-slug>`** (or **`feat/<prd-slug>`** for PRD runs), so there is no need to create a feature branch yourself.
 
 ```bash
 ralphai run
@@ -82,6 +82,7 @@ Each run creates or reuses an isolated worktree, works on a `ralphai/<plan-slug>
 
 ```bash
 ralphai run              # drain the backlog: one branch/PR per plan
+ralphai run 42           # run GitHub issue #42 (PRD or standalone)
 ralphai run --once       # process a single plan then exit
 ralphai run --resume     # auto-commit dirty state and continue
 ralphai run --dry-run    # preview without changing anything
@@ -126,11 +127,26 @@ ralphai clean --worktrees # clean only orphaned worktrees
 
 Ralphai extracts learnings from the agent's output during each run and surfaces them in the **Learnings** section of the draft PR. Review them when reviewing the PR and promote useful lessons to `AGENTS.md` or skill docs. [More on learnings ->](docs/how-ralphai-works.md#learnings-system)
 
-## GitHub Issues Integration
+## GitHub Issues & PRDs
 
-Ralphai can pull plans from GitHub issues when the backlog is empty. Label issues with `ralphai` (configurable), and Ralphai converts them into plan files, runs them, and comments progress back on the issue.
+For multi-step features, **PRDs (Product Requirements Documents)** are the recommended way to work. Create a GitHub issue, label it `ralphai-prd`, and add sub-issues for each piece of work. Then point Ralphai at it:
 
-Requires the `gh` CLI. Configure via `issueSource`, `issueLabel`, and related keys in `config.json`. See the [CLI Reference](docs/cli-reference.md#issue-tracking) for all options.
+```bash
+ralphai run 42           # run PRD #42: all sub-issues on one branch
+```
+
+Ralphai processes sub-issues sequentially on a single `feat/<prd-slug>` branch, skips any that get stuck, and opens one aggregate draft PR when done. Sub-issues support dependencies via GitHub's native blocking relationships.
+
+For **standalone issues** — one-off bugs, small tasks — label them with `ralphai` (configurable) and either target them directly or let the drain loop pick them up:
+
+```bash
+ralphai run 57           # run standalone issue #57
+ralphai run              # auto-pulls from GitHub when the backlog is empty
+```
+
+Each standalone issue gets its own branch and PR, the same as a local plan file.
+
+Both workflows require the `gh` CLI and `issueSource: "github"` in config. See the [CLI Reference](docs/cli-reference.md#issue-tracking) for all options.
 
 ## Multi-Repo Management
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,7 +87,9 @@ In monorepo projects, `init` detects workspace packages from `pnpm-workspace.yam
 
 ## Run
 
-`ralphai run` is the only execution entrypoint. It always works through a managed git worktree.
+`ralphai run [<issue-number>]` is the only execution entrypoint. It always works through a managed git worktree.
+
+Pass a GitHub issue number to target a specific issue or PRD directly. Without an argument, Ralphai picks from the local backlog (or pulls from GitHub when the backlog is empty).
 
 Use it for headless execution, automation, or when you want to kick off work directly from the terminal without opening the dashboard.
 
@@ -100,6 +102,8 @@ What it does:
 5. Opens or updates a draft PR when `gh` is available
 
 ```
+<issue-number>                    Target a GitHub issue or PRD by number
+--prd=<number>                    Explicitly target a PRD issue (alternative to positional arg)
 --dry-run, -n                     Preview what would happen without changing anything
 --resume, -r                      Auto-commit dirty state and continue
 --allow-dirty                     Skip the clean working tree check
@@ -128,6 +132,29 @@ By default, `ralphai run` drains the backlog — processing plans sequentially, 
 ### Issue Tracking
 
 Issue tracking is configured via `config.json` or environment variables (see [Configuration](#configuration)). Set `issueSource` to `"github"` to enable pulling plans from GitHub issues when the backlog is empty.
+
+#### PRDs (Product Requirements Documents)
+
+For multi-step features, create a GitHub issue labeled `ralphai-prd` with sub-issues. The label is hardcoded and not configurable.
+
+```bash
+ralphai run 42           # auto-detects PRD label, processes sub-issues sequentially
+ralphai run --prd=42     # explicitly target a PRD (errors if label is missing)
+```
+
+PRD behavior:
+
+- All sub-issues run on a single `feat/<prd-slug>` branch in one worktree
+- Sub-issues are processed in GitHub API order; dependencies via blocking relationships are respected
+- Per-sub-issue PRs are suppressed; one aggregate draft PR is opened at the end
+- Stuck sub-issues are skipped and listed in the PR body; the PRD continues to the next
+- The aggregate PR title uses `feat: <PRD title>` and includes completed/stuck checklists
+
+The `ralphai run <number>` form auto-detects whether the issue is a PRD or standalone. If it has the `ralphai-prd` label and open sub-issues, it runs in PRD mode. Otherwise it runs as a standalone issue.
+
+#### Standalone Issues
+
+Label issues with the configured intake label (`ralphai` by default). Each gets its own `ralphai/<slug>` branch and draft PR, the same as a local plan file.
 
 ## Clean
 

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -114,6 +114,39 @@ By default, `ralphai run` drains the backlog — processing plans sequentially u
 
 Use `--once` to process a single work unit and exit instead of draining.
 
+## PRD Execution Model
+
+PRDs (Product Requirements Documents) are the recommended way to drive multi-step features. A PRD is a GitHub issue labeled `ralphai-prd` with sub-issues representing each piece of work.
+
+```bash
+ralphai run 42           # target PRD #42
+```
+
+### How it differs from standalone plans
+
+| Aspect         | Standalone plan / issue          | PRD                                         |
+| -------------- | -------------------------------- | ------------------------------------------- |
+| Branch         | `ralphai/<slug>` per plan        | `feat/<prd-slug>` for the whole PRD         |
+| PR             | One draft PR per plan            | One aggregate draft PR for all sub-issues   |
+| Stuck handling | Plan is skipped, drain continues | Sub-issue is skipped, PRD continues to next |
+
+### Sequencing
+
+Ralphai fetches sub-issues from the GitHub API and processes them in order. Sub-issues can declare dependencies on each other via GitHub's native blocking relationships — Ralphai writes these as `depends-on` frontmatter and respects them during plan selection.
+
+### Aggregate PR
+
+Per-sub-issue PRs are suppressed. When all sub-issues complete (or are skipped), Ralphai opens a single draft PR with:
+
+- A `Closes #N` block for the PRD and each completed sub-issue
+- A checklist of completed sub-issues
+- A checklist of stuck sub-issues (if any)
+- A categorized commit log covering all changes on the branch
+
+### Stuck sub-issues
+
+When a sub-issue hits the stuck threshold (default 3 consecutive no-commit iterations), Ralphai skips it and moves to the next sub-issue. The stuck sub-issue is listed in the aggregate PR body so you can address it manually.
+
 ## Iteration Timeout
 
 Use `--iteration-timeout=<seconds>` or `iterationTimeout` in `config.json` to set a per-invocation timeout. If the agent exceeds the limit, Ralphai kills it and the iteration counts toward the stuck budget. The default is `0`, which means no timeout.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -110,3 +110,24 @@ ERROR: <command> must be run inside a git repository.
 - `cd` into your repo first, then run the command
 - Use `ralphai repos` to see all known repos and their paths
 - Use `--repo=<name-or-path>` with read-only commands (`status`, `doctor`, `backlog-dir`, etc.) to inspect a repo from anywhere
+
+## "Sub-issue stuck during PRD run"
+
+When a sub-issue hits the stuck threshold during a PRD run, Ralphai skips it and moves to the next sub-issue. The PRD continues — it does not abort.
+
+**Steps:**
+
+1. Check the aggregate draft PR body for the stuck sub-issue checklist.
+2. Inspect `progress.md` in `in-progress/<slug>/` for the stuck sub-issue to see what the agent attempted.
+3. Edit the sub-issue's plan file or add hints, then re-run the PRD: `ralphai run <prd-number>`. Already-completed sub-issues are skipped on re-run.
+
+## "PRD not detected from GitHub issue"
+
+When `ralphai run <number>` treats your PRD as a standalone issue, the issue is missing the required label or has no sub-issues.
+
+**Check:**
+
+1. The issue must have the exact label `ralphai-prd`. This label is hardcoded and not configurable (unlike the intake label `ralphai`).
+2. The issue must have at least one **open** sub-issue. If all sub-issues are closed, Ralphai reports "all sub-issues are already completed."
+3. Run `gh issue view <number> --json labels` to verify the label is present.
+4. If the label doesn't exist in your repo yet, `ralphai run --prd=<number>` auto-creates it. The positional `ralphai run <number>` form does not.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -22,6 +22,34 @@ ralphai run
 
 Processes all dependency-ready plans sequentially, one branch and PR per plan. When the backlog is empty, Ralphai checks for PRD sub-issues, then regular GitHub issues. Use `--once` to process a single plan and exit.
 
+## Work from a PRD (recommended for features)
+
+For multi-step features, create a PRD (Product Requirements Document) on GitHub:
+
+1. Create a GitHub issue for the feature. Label it `ralphai-prd`.
+2. Add sub-issues for each piece of work. Use GitHub's native blocking relationships for ordering.
+3. Point Ralphai at the PRD:
+
+```bash
+ralphai run 42           # PRD #42: all sub-issues sequentially on one branch
+```
+
+Ralphai creates a single worktree on a `feat/<prd-slug>` branch and processes sub-issues one at a time. Stuck sub-issues are skipped — the PRD continues to the next. When all sub-issues are done (or skipped), Ralphai opens one aggregate draft PR listing completed and stuck items.
+
+The TUI also supports PRDs: select "Pick from GitHub" and PRD issues appear with their sub-issue tree.
+
+## Run a single GitHub issue
+
+For one-off bugs or small tasks, label a GitHub issue with `ralphai` (configurable via `issueLabel`) and target it directly:
+
+```bash
+ralphai run 57           # run standalone issue #57: one branch, one PR
+```
+
+Or let the drain loop auto-pull when the local backlog is empty — Ralphai checks for PRD sub-issues first, then standalone issues. Each standalone issue gets its own `ralphai/<slug>` branch and draft PR, the same as a local plan file.
+
+Requires `issueSource: "github"` in config and the `gh` CLI. See the [CLI Reference](cli-reference.md#issue-tracking) for all options.
+
 ## Parallel runs
 
 ```bash


### PR DESCRIPTION
## Summary

- Expands the README "GitHub Issues" section into "GitHub Issues & PRDs", positioning PRDs as the recommended workflow for multi-step features
- Adds `ralphai run 42` example to the README command block and notes the `feat/<prd-slug>` branch convention
- Adds "Work from a PRD" and "Run a single GitHub issue" recipe sections to `docs/workflows.md`
- Documents the positional `<issue-number>` argument, `--prd=<number>` flag, and PRD/standalone issue subsections in `docs/cli-reference.md`
- Adds a "PRD Execution Model" section to `docs/how-ralphai-works.md` with comparison table, sequencing, aggregate PR, and stuck handling details
- Adds troubleshooting entries for stuck PRD sub-issues and PRD detection failures in `docs/troubleshooting.md`
- `docs/worktrees.md` already had adequate PRD coverage (line 29) — no changes needed