### PR TITLE
feat: make GitHub integration the default in init command

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -85,6 +85,8 @@ The dashboard auto-refreshes every 3 seconds. In non-TTY environments, `ralphai`
 
 In monorepo projects, `init` detects workspace packages from `pnpm-workspace.yaml`, `package.json` `workspaces`, or `.sln` files for .NET projects. In mixed repos, workspaces from all ecosystems are merged. Both modes display workspace info without adding config, and feedback commands are auto-filtered by scope at runtime.
 
+GitHub Issues integration is enabled by default during `init` (both interactive and `--yes`). To use a different issue tracker, decline the prompt in interactive mode or set `issueSource` to `"none"` in `config.json` after init.
+
 ## Run
 
 `ralphai run [<issue-number>]` is the only execution entrypoint. It always works through a managed git worktree.
@@ -356,21 +358,21 @@ Settings resolve in this order: **CLI flags > env vars > `config.json` > default
 
 ### Config Keys
 
-| Key                    | Default              | Env Var                           | Description                                              |
-| ---------------------- | -------------------- | --------------------------------- | -------------------------------------------------------- |
-| `agentCommand`         | _(none)_             | `RALPHAI_AGENT_COMMAND`           | CLI command to invoke the coding agent                   |
-| `feedbackCommands`     | _(auto-detected)_    | `RALPHAI_FEEDBACK_COMMANDS`       | Comma-separated build/test/lint commands                 |
-| `baseBranch`           | `"main"`             | `RALPHAI_BASE_BRANCH`             | Base branch for worktree creation                        |
-| `autoCommit`           | `false`              | `RALPHAI_AUTO_COMMIT`             | Enable auto-commit recovery snapshots                    |
-| `maxStuck`             | `3`                  | `RALPHAI_MAX_STUCK`               | Consecutive no-commit iterations before abort            |
-| `iterationTimeout`     | `0`                  | `RALPHAI_ITERATION_TIMEOUT`       | Per-agent-invocation timeout in seconds (0 = no timeout) |
-| `issueSource`          | `"none"`             | `RALPHAI_ISSUE_SOURCE`            | Issue source (`"github"` or `"none"`)                    |
-| `issueLabel`           | `"ralphai"`          | `RALPHAI_ISSUE_LABEL`             | GitHub label for intake issues                           |
-| `issueInProgressLabel` | `"ralphai-progress"` | `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | GitHub label applied when a plan is in progress          |
-| `issueDoneLabel`       | `"ralphai-done"`     | `RALPHAI_ISSUE_DONE_LABEL`        | GitHub label applied when a plan is completed            |
-| `issuePrdLabel`        | `"ralphai-prd"`      | `RALPHAI_ISSUE_PRD_LABEL`         | GitHub label identifying PRD issues                      |
-| `issueRepo`            | _(auto-detected)_    | `RALPHAI_ISSUE_REPO`              | GitHub `owner/repo` for issue queries                    |
-| `issueCommentProgress` | `false`              | `RALPHAI_ISSUE_COMMENT_PROGRESS`  | Post progress comments on GitHub issues                  |
+| Key                    | Default              | Env Var                           | Description                                                          |
+| ---------------------- | -------------------- | --------------------------------- | -------------------------------------------------------------------- |
+| `agentCommand`         | _(none)_             | `RALPHAI_AGENT_COMMAND`           | CLI command to invoke the coding agent                               |
+| `feedbackCommands`     | _(auto-detected)_    | `RALPHAI_FEEDBACK_COMMANDS`       | Comma-separated build/test/lint commands                             |
+| `baseBranch`           | `"main"`             | `RALPHAI_BASE_BRANCH`             | Base branch for worktree creation                                    |
+| `autoCommit`           | `false`              | `RALPHAI_AUTO_COMMIT`             | Enable auto-commit recovery snapshots                                |
+| `maxStuck`             | `3`                  | `RALPHAI_MAX_STUCK`               | Consecutive no-commit iterations before abort                        |
+| `iterationTimeout`     | `0`                  | `RALPHAI_ITERATION_TIMEOUT`       | Per-agent-invocation timeout in seconds (0 = no timeout)             |
+| `issueSource`          | `"none"`             | `RALPHAI_ISSUE_SOURCE`            | Issue source (`"github"` or `"none"`); `init` defaults to `"github"` |
+| `issueLabel`           | `"ralphai"`          | `RALPHAI_ISSUE_LABEL`             | GitHub label for intake issues                                       |
+| `issueInProgressLabel` | `"ralphai-progress"` | `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | GitHub label applied when a plan is in progress                      |
+| `issueDoneLabel`       | `"ralphai-done"`     | `RALPHAI_ISSUE_DONE_LABEL`        | GitHub label applied when a plan is completed                        |
+| `issuePrdLabel`        | `"ralphai-prd"`      | `RALPHAI_ISSUE_PRD_LABEL`         | GitHub label identifying PRD issues                                  |
+| `issueRepo`            | _(auto-detected)_    | `RALPHAI_ISSUE_REPO`              | GitHub `owner/repo` for issue queries                                |
+| `issueCommentProgress` | `false`              | `RALPHAI_ISSUE_COMMENT_PROGRESS`  | Post progress comments on GitHub issues                              |
 
 ### Workspaces
 

--- a/src/init-labels.test.ts
+++ b/src/init-labels.test.ts
@@ -139,13 +139,12 @@ describe("init label creation", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // init --yes (issueSource=none) does not show label info
+  // init --yes (issueSource=github) shows label info
   // ---------------------------------------------------------------------------
 
-  it("init --yes with default issueSource=none does not mention labels", () => {
+  it("init --yes with default issueSource=github mentions GitHub issue labeling", () => {
     const result = runCli(["init", "--yes"], ctx.dir, testEnv());
     const output = stripLogo(result.stdout || result.stderr);
-    expect(output).not.toContain("GitHub labels");
-    expect(output).not.toContain("ralphai-prd label");
+    expect(output).toContain("Label a GitHub issue");
   });
 });

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -97,7 +97,7 @@ describe("init command", () => {
     expect(parsed.iterationTimeout).toBe(0);
 
     // Issue tracking defaults
-    expect(parsed.issueSource).toBe("none");
+    expect(parsed.issueSource).toBe("github");
     expect(parsed.issueLabel).toBe("ralphai");
     expect(parsed.issueInProgressLabel).toBe("ralphai:in-progress");
     expect(parsed.issueDoneLabel).toBe("ralphai:done");

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -227,29 +227,31 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
 
   let autoCommit = false;
 
-  // 6. GitHub Issues integration
-  const enableIssues = await clack.confirm({
+  // 6. GitHub Issues integration (enabled by default)
+  clack.note(
+    "When Ralphai's backlog is empty, it will automatically pull the oldest\n" +
+      `open issue labeled "${DEFAULTS.issueLabel}" and convert it to a plan.\n` +
+      "Disable this if you use a different issue tracker.",
+    "GitHub Issues",
+  );
+
+  const disableIssues = await clack.confirm({
     message: "Enable GitHub Issues integration?",
-    initialValue: false,
+    initialValue: true,
   });
 
-  if (clack.isCancel(enableIssues)) {
+  if (clack.isCancel(disableIssues)) {
     clack.cancel("Setup cancelled.");
     return null;
   }
 
+  const enableIssues = disableIssues;
   let issueLabel: string | undefined;
   let issueInProgressLabel: string | undefined;
   let issueDoneLabel: string | undefined;
   let issuePrdLabel: string | undefined;
 
   if (enableIssues) {
-    clack.note(
-      "When Ralphai's backlog is empty, it will automatically pull the oldest\n" +
-        `open issue labeled "${DEFAULTS.issueLabel}" and convert it to a plan.`,
-      "GitHub Issues",
-    );
-
     // Label configuration prompts
     const labelAnswer = await clack.text({
       message: "Issue intake label:",
@@ -1266,7 +1268,7 @@ async function runRalphaiInit(
       baseBranch: detectBaseBranch(cwd),
       feedbackCommands: detectedFeedbackStr,
       autoCommit: false,
-      issueSource: "none",
+      issueSource: "github",
       updateAgentsMd: !agentsMdHasSection,
       createSamplePlan: true,
     };
@@ -1285,6 +1287,9 @@ async function runRalphaiInit(
     console.log(`  ${DIM}Setup:${RESET}     ${TEXT}${setupDisplay}${RESET}`);
     console.log(
       `  ${DIM}Project:${RESET}   ${TEXT}${detectedProject?.label ?? "(none)"}${RESET}`,
+    );
+    console.log(
+      `  ${DIM}Issues:${RESET}    ${TEXT}GitHub Issues (enabled)${RESET}`,
     );
 
     // Workspace detection for --yes mode

--- a/src/status-doctor.test.ts
+++ b/src/status-doctor.test.ts
@@ -21,27 +21,26 @@ describe("GitHub Issues integration", () => {
     return getConfigFilePath(ctx.dir, testEnv());
   }
 
-  it("init --yes defaults issueSource to none in config", () => {
+  it("init --yes defaults issueSource to github in config", () => {
     runCli(["init", "--yes"], ctx.dir, testEnv());
 
     const parsed = JSON.parse(readFileSync(configPath(), "utf-8"));
-    expect(parsed.issueSource).toBe("none");
+    expect(parsed.issueSource).toBe("github");
   });
 
-  it("init --yes includes issueSource as none in JSON config", () => {
+  it("init --yes includes issueSource as github in JSON config", () => {
     runCli(["init", "--yes"], ctx.dir, testEnv());
 
     const parsed = JSON.parse(readFileSync(configPath(), "utf-8"));
-    // issueSource should be "none" by default (all 17 keys are explicit)
-    expect(parsed.issueSource).toBe("none");
+    // issueSource should be "github" by default (all 17 keys are explicit)
+    expect(parsed.issueSource).toBe("github");
   });
 
-  it("init --yes output does not contain GitHub label info", () => {
+  it("init --yes output contains GitHub label info", () => {
     const result = runCli(["init", "--yes"], ctx.dir, testEnv());
     const output = stripLogo(result.stdout || result.stderr);
 
-    expect(output).not.toContain("GitHub labels");
-    expect(output).not.toContain("Label a GitHub issue");
+    expect(output).toContain("Label a GitHub issue");
   });
 });
 


### PR DESCRIPTION
## Summary

- GitHub Issues integration is now **enabled by default** in both interactive and `--yes` init modes (previously opt-in with `initialValue: false`)
- Interactive wizard shows the GitHub Issues explanation note upfront and defaults the confirm prompt to Yes, so users can opt out if they use a different issue tracker
- `init --yes` now writes `issueSource: "github"` (was `"none"`), creates GitHub labels, and shows the "Label a GitHub issue" hint in output
- Updated CLI reference docs to document the new default behavior

The runtime config `DEFAULTS.issueSource` remains `"none"` so existing users without explicit config are unaffected — only newly initialized repos get the new default.