### PR TITLE
refactor: remove label prompts from init wizard

### DIFF
--- a/src/init-labels.test.ts
+++ b/src/init-labels.test.ts
@@ -181,8 +181,14 @@ describe("init label creation", () => {
   // Source-level: success message lists all labels dynamically
   // ---------------------------------------------------------------------------
 
-  it("success message is built from labelDefs", () => {
-    expect(ralphaiSrc).toContain("const allLabels = labelDefs(initLabelNames)");
+  it("success message shows per-family label summary", () => {
+    expect(ralphaiSrc).toContain("Created 12 labels across 3 families:");
+    expect(ralphaiSrc).toContain("Intake label for standalone issues");
+    expect(ralphaiSrc).toContain("Intake label for PRD sub-issues");
+    expect(ralphaiSrc).toContain("Intake label for PRD parent issues");
+    expect(ralphaiSrc).toContain(
+      "Each has :in-progress, :done, and :stuck variants",
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -224,14 +230,10 @@ describe("init label creation", () => {
   // Source-level: init config uses 3 base label keys
   // ---------------------------------------------------------------------------
 
-  it("scaffold config includes standaloneLabel, subissueLabel, and prdLabel", () => {
-    expect(ralphaiSrc).toContain(
-      "answers.standaloneLabel ?? DEFAULTS.standaloneLabel",
-    );
-    expect(ralphaiSrc).toContain(
-      "answers.subissueLabel ?? DEFAULTS.subissueLabel",
-    );
-    expect(ralphaiSrc).toContain("answers.prdLabel ?? DEFAULTS.prdLabel");
+  it("scaffold config uses DEFAULTS directly for label values", () => {
+    expect(ralphaiSrc).toContain("standaloneLabel: DEFAULTS.standaloneLabel");
+    expect(ralphaiSrc).toContain("subissueLabel: DEFAULTS.subissueLabel");
+    expect(ralphaiSrc).toContain("prdLabel: DEFAULTS.prdLabel");
   });
 
   // ---------------------------------------------------------------------------

--- a/src/init-wizard.test.ts
+++ b/src/init-wizard.test.ts
@@ -14,77 +14,44 @@ describe("init wizard", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Label prompts in wizard when GitHub Issues enabled
+  // Labels are NOT prompted — they are created automatically with defaults
   // ---------------------------------------------------------------------------
 
-  it("prompts for all three base label names when issues are enabled", () => {
-    expect(ralphaiSrc).toContain(
+  it("does not prompt for label names", () => {
+    expect(ralphaiSrc).not.toContain(
       'message: "Standalone issue label (base name):"',
     );
-    expect(ralphaiSrc).toContain('message: "Sub-issue label (base name):"');
-    expect(ralphaiSrc).toContain('message: "PRD label (base name):"');
+    expect(ralphaiSrc).not.toContain('message: "Sub-issue label (base name):"');
+    expect(ralphaiSrc).not.toContain('message: "PRD label (base name):"');
   });
 
-  it("label prompts use DEFAULTS as initialValue", () => {
-    expect(ralphaiSrc).toContain("initialValue: DEFAULTS.standaloneLabel");
-    expect(ralphaiSrc).toContain("initialValue: DEFAULTS.subissueLabel");
-    expect(ralphaiSrc).toContain("initialValue: DEFAULTS.prdLabel");
-  });
-
-  it("label prompts are inside the enableIssues block", () => {
-    // Extract the section from "if (enableIssues)" to the AGENTS.md step
-    const issueBlock = ralphaiSrc.slice(
-      ralphaiSrc.indexOf("if (enableIssues)"),
-      ralphaiSrc.indexOf("// 7. Update AGENTS.md"),
-    );
-    expect(issueBlock).toContain(
-      'message: "Standalone issue label (base name):"',
-    );
-    expect(issueBlock).toContain('message: "PRD label (base name):"');
-  });
-
-  it("wizard returns label fields in the answers object", () => {
-    // The return statement should include all three base label fields
-    expect(ralphaiSrc).toContain("standaloneLabel,");
-    expect(ralphaiSrc).toContain("subissueLabel,");
-    expect(ralphaiSrc).toContain("prdLabel,");
-  });
-
-  // ---------------------------------------------------------------------------
-  // WizardAnswers type includes label fields
-  // ---------------------------------------------------------------------------
-
-  it("WizardAnswers type includes label fields", () => {
+  it("WizardAnswers type does not include label fields", () => {
     const parseOptsSrc = readFileSync(
       join(__dirname, "parse-options.ts"),
       "utf-8",
     );
-    expect(parseOptsSrc).toContain("standaloneLabel?:");
-    expect(parseOptsSrc).toContain("subissueLabel?:");
-    expect(parseOptsSrc).toContain("prdLabel?:");
+    expect(parseOptsSrc).not.toContain("standaloneLabel?:");
+    expect(parseOptsSrc).not.toContain("subissueLabel?:");
+    expect(parseOptsSrc).not.toContain("prdLabel?:");
   });
 
   // ---------------------------------------------------------------------------
-  // scaffold uses answers' label values with fallback to DEFAULTS
+  // scaffold uses DEFAULTS directly for label values
   // ---------------------------------------------------------------------------
 
-  it("scaffold uses answers label values with DEFAULTS fallback", () => {
-    expect(ralphaiSrc).toContain(
-      "answers.standaloneLabel ?? DEFAULTS.standaloneLabel",
-    );
-    expect(ralphaiSrc).toContain(
-      "answers.subissueLabel ?? DEFAULTS.subissueLabel",
-    );
-    expect(ralphaiSrc).toContain("answers.prdLabel ?? DEFAULTS.prdLabel");
+  it("scaffold uses DEFAULTS directly for label values", () => {
+    expect(ralphaiSrc).toContain("standaloneLabel: DEFAULTS.standaloneLabel");
+    expect(ralphaiSrc).toContain("subissueLabel: DEFAULTS.subissueLabel");
+    expect(ralphaiSrc).toContain("prdLabel: DEFAULTS.prdLabel");
   });
 
   // ---------------------------------------------------------------------------
-  // Post-init text references configured label, not hardcoded DEFAULTS
+  // Post-init text references configured label
   // ---------------------------------------------------------------------------
 
-  it("post-init GitHub hint uses answers label value", () => {
+  it("post-init GitHub hint uses configObj label value", () => {
     expect(ralphaiSrc).toContain(
-      'answers.standaloneLabel ?? DEFAULTS.standaloneLabel}" and Ralphai will pick it up automatically',
+      'configObj.standaloneLabel}" and Ralphai will pick it up automatically',
     );
   });
 });

--- a/src/parse-options.ts
+++ b/src/parse-options.ts
@@ -57,9 +57,6 @@ export interface WizardAnswers {
   feedbackCommands: string;
   autoCommit?: boolean;
   issueSource: "none" | "github";
-  standaloneLabel?: string;
-  subissueLabel?: string;
-  prdLabel?: string;
   updateAgentsMd?: boolean;
   createSamplePlan?: boolean;
   workspaces?: Record<string, { feedbackCommands: string[] }>;

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -259,51 +259,6 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
   }
 
   const enableIssues = disableIssues;
-  let standaloneLabel: string | undefined;
-  let subissueLabel: string | undefined;
-  let prdLabel: string | undefined;
-
-  if (enableIssues) {
-    // Label configuration prompts
-    const standaloneLabelAnswer = await clack.text({
-      message: "Standalone issue label (base name):",
-      initialValue: DEFAULTS.standaloneLabel,
-      validate: (value) => {
-        if (!value.trim()) return "Label cannot be empty";
-      },
-    });
-    if (clack.isCancel(standaloneLabelAnswer)) {
-      clack.cancel("Setup cancelled.");
-      return null;
-    }
-    standaloneLabel = standaloneLabelAnswer;
-
-    const subissueLabelAnswer = await clack.text({
-      message: "Sub-issue label (base name):",
-      initialValue: DEFAULTS.subissueLabel,
-      validate: (value) => {
-        if (!value.trim()) return "Label cannot be empty";
-      },
-    });
-    if (clack.isCancel(subissueLabelAnswer)) {
-      clack.cancel("Setup cancelled.");
-      return null;
-    }
-    subissueLabel = subissueLabelAnswer;
-
-    const prdLabelAnswer = await clack.text({
-      message: "PRD label (base name):",
-      initialValue: DEFAULTS.prdLabel,
-      validate: (value) => {
-        if (!value.trim()) return "Label cannot be empty";
-      },
-    });
-    if (clack.isCancel(prdLabelAnswer)) {
-      clack.cancel("Setup cancelled.");
-      return null;
-    }
-    prdLabel = prdLabelAnswer;
-  }
 
   // 7. Update AGENTS.md
   const agentsMdPath = join(cwd, "AGENTS.md");
@@ -347,9 +302,6 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
     feedbackCommands: feedbackCommands || "",
     autoCommit,
     issueSource: enableIssues ? "github" : "none",
-    standaloneLabel,
-    subissueLabel,
-    prdLabel,
     updateAgentsMd,
     createSamplePlan,
   };
@@ -551,9 +503,9 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
     autoCommit: answers.autoCommit ?? false,
     iterationTimeout: 0,
     issueSource: answers.issueSource ?? "none",
-    standaloneLabel: answers.standaloneLabel ?? DEFAULTS.standaloneLabel,
-    subissueLabel: answers.subissueLabel ?? DEFAULTS.subissueLabel,
-    prdLabel: answers.prdLabel ?? DEFAULTS.prdLabel,
+    standaloneLabel: DEFAULTS.standaloneLabel,
+    subissueLabel: DEFAULTS.subissueLabel,
+    prdLabel: DEFAULTS.prdLabel,
     issueRepo: "",
     issueCommentProgress: true,
   };
@@ -617,11 +569,20 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
   );
   if (labelResult) {
     if (labelResult.success) {
-      const allLabels = labelDefs(initLabelNames).map((l) => `"${l.name}"`);
-      const labelList =
-        allLabels.slice(0, -1).join(", ") + ", and " + allLabels.at(-1);
       console.log(
-        `  GitHub labels              ${DIM}Created ${labelList} labels${RESET}`,
+        `  GitHub labels              ${DIM}Created 12 labels across 3 families:${RESET}`,
+      );
+      console.log(
+        `    ${TEXT}${configObj.standaloneLabel}${RESET}       ${DIM}Intake label for standalone issues${RESET}`,
+      );
+      console.log(
+        `    ${TEXT}${configObj.subissueLabel}${RESET}         ${DIM}Intake label for PRD sub-issues${RESET}`,
+      );
+      console.log(
+        `    ${TEXT}${configObj.prdLabel}${RESET}              ${DIM}Intake label for PRD parent issues${RESET}`,
+      );
+      console.log(
+        `                             ${DIM}Each has :in-progress, :done, and :stuck variants${RESET}`,
       );
     } else {
       console.log();
@@ -660,7 +621,7 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
   if (answers.issueSource === "github") {
     console.log();
     console.log(
-      `${DIM}Label a GitHub issue with "${answers.standaloneLabel ?? DEFAULTS.standaloneLabel}" and Ralphai will pick it up automatically.${RESET}`,
+      `${DIM}Label a GitHub issue with "${configObj.standaloneLabel}" and Ralphai will pick it up automatically.${RESET}`,
     );
   }
   console.log();


### PR DESCRIPTION
## Summary

- **Remove label prompts from `ralphai init`** -- the 3 `clack.text` prompts for standalone, sub-issue, and PRD base label names added unnecessary friction. Almost no one will customize them during init.
- **Auto-create labels with defaults and report what was created** -- the post-init output now shows a per-family breakdown with brief descriptions instead of a dense comma-separated list of all 12 label names.
- **Remove `standaloneLabel`, `subissueLabel`, `prdLabel` from `WizardAnswers`** -- scaffold uses `DEFAULTS` directly. Labels remain configurable post-init via `config.json` or env vars.

## Changes

| File | What changed |
|------|-------------|
| `src/ralphai.ts` | Removed 3 label prompts from `runWizard()`, scaffold uses `DEFAULTS` directly, improved success output |
| `src/parse-options.ts` | Removed 3 optional label fields from `WizardAnswers` |
| `src/init-wizard.test.ts` | Replaced prompt-exists assertions with no-prompt assertions |
| `src/init-labels.test.ts` | Updated scaffold and success-message assertions |

## Post-init output (labels section)

```
  GitHub labels              Created 12 labels across 3 families:
    ralphai-standalone       Intake label for standalone issues
    ralphai-subissue         Intake label for PRD sub-issues
    ralphai-prd              Intake label for PRD parent issues
                             Each has :in-progress, :done, and :stuck variants
```