### PR TITLE
fix: pullGithubIssueByNumber applies standalone labels to sub-issues; reset can't clean up

### DIFF
--- a/src/issues.ts
+++ b/src/issues.ts
@@ -634,6 +634,10 @@ interface FetchAndWriteOptions {
   standaloneLabel: string;
   issueCommentProgress: boolean;
   issuePrdLabel?: string;
+  /** Optional subissue intake label (e.g. "ralphai-subissue"). */
+  subissueLabel?: string;
+  /** Optional subissue in-progress label (e.g. "ralphai-subissue:in-progress"). */
+  subissueInProgressLabel?: string;
 }
 
 /**
@@ -675,6 +679,15 @@ function fetchAndWriteIssuePlan(opts: FetchAndWriteOptions): PullIssueResult {
   // Discover parent PRD (non-fatal — plan is still usable without it)
   const prd = discoverParentPrd(repo, issueNumber, cwd, opts.issuePrdLabel);
 
+  // Select the correct label family: sub-issues (prd present and subissue
+  // labels provided) use subissue labels, standalone issues use standalone.
+  const isSubIssue =
+    prd !== undefined && opts.subissueLabel && opts.subissueInProgressLabel;
+  const effectiveIntakeLabel = isSubIssue ? opts.subissueLabel! : issueLabel;
+  const effectiveInProgressLabel = isSubIssue
+    ? opts.subissueInProgressLabel!
+    : issueInProgressLabel;
+
   // Query native GitHub blocking relationships via GraphQL (fail-open)
   const blockers = fetchBlockersViaGraphQL(repo, issueNumber, cwd);
 
@@ -699,8 +712,8 @@ function fetchAndWriteIssuePlan(opts: FetchAndWriteOptions): PullIssueResult {
   // Update issue labels: add in-progress, remove intake label
   transitionPull(
     { number: Number(issueNumber), repo },
-    issueLabel,
-    issueInProgressLabel,
+    effectiveIntakeLabel,
+    effectiveInProgressLabel,
     cwd,
   );
 
@@ -947,10 +960,13 @@ export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
     issueNumber: String(subIssueNumber),
     backlogDir,
     cwd,
-    standaloneInProgressLabel: issueInProgressLabel,
-    standaloneLabel: issueLabel,
+    standaloneInProgressLabel: options.standaloneInProgressLabel,
+    standaloneLabel: options.standaloneLabel,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,
+    subissueLabel: options.subissueLabel,
+    subissueInProgressLabel:
+      options.subissueInProgressLabel ?? subissueLabels?.inProgress,
   });
 }
 
@@ -1184,6 +1200,8 @@ export function pullGithubIssueByNumber(
     standaloneLabel: issueLabel,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,
+    subissueLabel: options.subissueLabel,
+    subissueInProgressLabel: options.subissueInProgressLabel,
   });
 }
 

--- a/src/label-lifecycle.ts
+++ b/src/label-lifecycle.ts
@@ -183,6 +183,11 @@ export function transitionStuck(
  *
  * Used by `ralphai reset` to return an issue to the pickup queue.
  * Removes both in-progress and stuck labels, adds the intake label.
+ *
+ * The optional `extraRemoveLabels` parameter allows callers to defensively
+ * remove labels from a second family (e.g. removing standalone state labels
+ * when resetting a sub-issue, in case the wrong family was applied).
+ * `gh issue edit --remove-label` is a no-op for labels that aren't present.
  */
 export function transitionReset(
   issue: IssueMeta,
@@ -191,15 +196,18 @@ export function transitionReset(
   stuckLabel: string,
   cwd: string,
   dryRun = false,
+  extraRemoveLabels: string[] = [],
 ): LabelTransitionResult {
   if (dryRun) {
     return dryRunSkip(`Issue #${issue.number}: reset to ${intakeLabel}`);
   }
-  const result = execQuiet(
+  let cmd =
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${intakeLabel}" --remove-label "${inProgressLabel}" --remove-label "${stuckLabel}"`,
-    cwd,
-  );
+    `--add-label "${intakeLabel}" --remove-label "${inProgressLabel}" --remove-label "${stuckLabel}"`;
+  for (const label of extraRemoveLabels) {
+    cmd += ` --remove-label "${label}"`;
+  }
+  const result = execQuiet(cmd, cwd);
   if (result === null) {
     return {
       ok: false,

--- a/src/pull-issue-by-number.test.ts
+++ b/src/pull-issue-by-number.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for pullGithubIssueByNumber() — the entry point used by
+ * `ralphai run <number>` for both standalone issues and PRD sub-issues.
+ *
+ * Uses mock.module to control `child_process.execSync` so we can verify
+ * that the correct label family (standalone vs subissue) is used for
+ * the transitionPull() call depending on whether the issue has a PRD parent.
+ */
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import type { PullIssueOptions } from "./issues.ts";
+
+// ---------------------------------------------------------------------------
+// Mock child_process.execSync
+// ---------------------------------------------------------------------------
+
+const realChildProcess = require("child_process");
+const realExecSync =
+  realChildProcess.execSync as typeof import("child_process").execSync;
+
+const mockExecSync = mock();
+
+mock.module("child_process", () => ({
+  ...realChildProcess,
+  execSync: (...args: Parameters<typeof realExecSync>) => {
+    const [cmd, options] = args;
+    if (typeof cmd === "string" && cmd.startsWith("gh ")) {
+      return mockExecSync(...args);
+    }
+    // Pass through non-gh commands
+    return realExecSync(cmd, options as Parameters<typeof realExecSync>[1]);
+  },
+}));
+
+// Import AFTER mocking so the module picks up the mock
+const { pullGithubIssueByNumber } = await import("./issues.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "ralphai-pull-by-number-"));
+}
+
+function defaultOptions(
+  dir: string,
+): PullIssueOptions & { issueNumber: number } {
+  return {
+    backlogDir: join(dir, ".ralphai", "pipeline", "backlog"),
+    cwd: dir,
+    issueSource: "github",
+    standaloneLabel: "ralphai-standalone",
+    standaloneInProgressLabel: "ralphai-standalone:in-progress",
+    standaloneDoneLabel: "ralphai-standalone:done",
+    standaloneStuckLabel: "ralphai-standalone:stuck",
+    subissueLabel: "ralphai-subissue",
+    subissueInProgressLabel: "ralphai-subissue:in-progress",
+    subissueDoneLabel: "ralphai-subissue:done",
+    subissueStuckLabel: "ralphai-subissue:stuck",
+    issueRepo: "owner/repo",
+    issueCommentProgress: false,
+    issueNumber: 201,
+  };
+}
+
+/**
+ * Build a command router that dispatches gh calls to handler functions.
+ * Unmatched commands throw.
+ */
+function mockGhCommands(
+  handlers: Record<string, (cmd: string) => string | Buffer>,
+): void {
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (cmd === "gh --version" || cmd === "gh auth status") {
+      return Buffer.from("ok");
+    }
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (cmd.includes(pattern)) {
+        return handler(cmd);
+      }
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+}
+
+/** Return the list of gh issue edit commands that were called. */
+function ghEditCalls(): string[] {
+  return mockExecSync.mock.calls
+    .filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" && call[0].includes("gh issue edit"),
+    )
+    .map((call: unknown[]) => call[0] as string);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockExecSync.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Cycle 1: Sub-issue (has PRD parent) should use subissue labels
+// ---------------------------------------------------------------------------
+
+describe("pullGithubIssueByNumber — sub-issue label selection", () => {
+  it("uses subissue labels when issue has a PRD parent", () => {
+    mockGhCommands({
+      // fetchAndWriteIssuePlan fetches title, body, url
+      'gh issue view 201 --repo "owner/repo" --json title --jq': () =>
+        "Sub task A",
+      'gh issue view 201 --repo "owner/repo" --json body --jq': () =>
+        "Sub task body",
+      'gh issue view 201 --repo "owner/repo" --json url --jq': () =>
+        "https://github.com/owner/repo/issues/201",
+      // Parent PRD discovery — issue has a parent with PRD label
+      "gh api repos/owner/repo/issues/201/parent": () =>
+        JSON.stringify({
+          number: 100,
+          labels: [{ name: "ralphai-prd" }],
+        }),
+      // GraphQL blockers
+      "gh api graphql": () =>
+        JSON.stringify({
+          data: {
+            repository: { issue: { blockedBy: { nodes: [] } } },
+          },
+        }),
+      // Label swap
+      "gh issue edit": () => "",
+    });
+
+    const dir = makeTempDir();
+    const result = pullGithubIssueByNumber(defaultOptions(dir));
+    expect(result.pulled).toBe(true);
+
+    // Verify the transitionPull call used subissue labels, NOT standalone
+    const editCalls = ghEditCalls();
+    expect(editCalls.length).toBe(1);
+    const cmd = editCalls[0]!;
+
+    // Should use subissue labels
+    expect(cmd).toContain('--add-label "ralphai-subissue:in-progress"');
+    expect(cmd).toContain('--remove-label "ralphai-subissue"');
+
+    // Should NOT contain standalone labels in the edit call
+    expect(cmd).not.toContain("ralphai-standalone:in-progress");
+    expect(cmd).not.toContain('--remove-label "ralphai-standalone"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cycle 2: Standalone issue (no PRD parent) should use standalone labels
+// ---------------------------------------------------------------------------
+
+describe("pullGithubIssueByNumber — standalone label selection", () => {
+  it("uses standalone labels when issue has no PRD parent", () => {
+    mockGhCommands({
+      'gh issue view 42 --repo "owner/repo" --json title --jq': () =>
+        "Standalone bug",
+      'gh issue view 42 --repo "owner/repo" --json body --jq': () => "Bug body",
+      'gh issue view 42 --repo "owner/repo" --json url --jq': () =>
+        "https://github.com/owner/repo/issues/42",
+      // No parent (API call fails/404)
+      "gh api repos/owner/repo/issues/42/parent": () => {
+        throw new Error("not found");
+      },
+      // GraphQL blockers
+      "gh api graphql": () =>
+        JSON.stringify({
+          data: {
+            repository: { issue: { blockedBy: { nodes: [] } } },
+          },
+        }),
+      // Label swap
+      "gh issue edit": () => "",
+    });
+
+    const dir = makeTempDir();
+    const opts = { ...defaultOptions(dir), issueNumber: 42 };
+    const result = pullGithubIssueByNumber(opts);
+    expect(result.pulled).toBe(true);
+
+    // Verify standalone labels were used
+    const editCalls = ghEditCalls();
+    expect(editCalls.length).toBe(1);
+    const cmd = editCalls[0]!;
+
+    expect(cmd).toContain('--add-label "ralphai-standalone:in-progress"');
+    expect(cmd).toContain('--remove-label "ralphai-standalone"');
+
+    // Should NOT contain subissue labels
+    expect(cmd).not.toContain("ralphai-subissue");
+  });
+});

--- a/src/pull-prd-sub-issue.test.ts
+++ b/src/pull-prd-sub-issue.test.ts
@@ -853,3 +853,68 @@ describe("pullPrdSubIssue — PRD in-progress label on parent", () => {
     expect(prdEditCall).toContain("--add-label");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression guard: drain path uses subissue labels for transitionPull
+// ---------------------------------------------------------------------------
+
+describe("pullPrdSubIssue — subissue label family in transitionPull", () => {
+  it("calls transitionPull with subissue labels (not standalone) for sub-issues", () => {
+    const prdIssues = [{ number: 100, title: "Feature PRD" }];
+    const subIssues = [{ number: 201, title: "Sub A", state: "open" }];
+
+    const editCalls: string[] = [];
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === "gh --version" || cmd === "gh auth status") {
+        return "ok";
+      }
+      if (typeof cmd === "string" && cmd.includes("gh issue edit")) {
+        editCalls.push(cmd);
+        return "";
+      }
+      if (cmd.includes("gh issue list")) return JSON.stringify(prdIssues);
+      if (cmd.includes("gh api repos/owner/repo/issues/100/sub_issues"))
+        return JSON.stringify(subIssues);
+      if (cmd.includes("gh issue view 201") && cmd.includes("--json labels"))
+        return "";
+      if (cmd.includes("gh issue view 201") && cmd.includes("--json title"))
+        return "Sub A";
+      if (cmd.includes("gh issue view 201") && cmd.includes("--json body"))
+        return "Sub A body";
+      if (cmd.includes("gh issue view 201") && cmd.includes("--json url"))
+        return "https://github.com/owner/repo/issues/201";
+      if (cmd.includes("gh api repos/owner/repo/issues/201/parent"))
+        return JSON.stringify({
+          number: 100,
+          labels: [{ name: "ralphai-prd" }],
+        });
+      if (cmd.includes("gh api graphql"))
+        return JSON.stringify({
+          data: { repository: { issue: { blockedBy: { nodes: [] } } } },
+        });
+      throw new Error(`Unexpected command: ${cmd}`);
+    });
+
+    const dir = makeTempDir();
+    const result = pullPrdSubIssue(defaultOptions(dir));
+    expect(result.pulled).toBe(true);
+
+    // Find the edit call for sub-issue #201 (not the PRD parent #100)
+    const subIssueEditCall = editCalls.find((c) =>
+      c.includes("gh issue edit 201"),
+    );
+    expect(subIssueEditCall).toBeDefined();
+
+    // Verify subissue labels were used
+    expect(subIssueEditCall).toContain(
+      '--add-label "ralphai-subissue:in-progress"',
+    );
+    expect(subIssueEditCall).toContain('--remove-label "ralphai-subissue"');
+
+    // Should NOT contain standalone labels in the sub-issue transition
+    expect(subIssueEditCall).not.toContain("ralphai-standalone:in-progress");
+    expect(subIssueEditCall).not.toContain(
+      '--remove-label "ralphai-standalone"',
+    );
+  });
+});

--- a/src/reset-labels.test.ts
+++ b/src/reset-labels.test.ts
@@ -291,11 +291,14 @@ describe("restoreIssueLabels — sub-issue label selection", () => {
     expect(ghEditCalls.length).toBe(1);
     const cmd = ghEditCalls[0]![0] as string;
     expect(cmd).toContain("gh issue edit 201");
+    // Primary: subissue intake label is restored
     expect(cmd).toContain('--add-label "ralphai-subissue"');
+    // Removes subissue state labels
     expect(cmd).toContain('--remove-label "ralphai-subissue:in-progress"');
     expect(cmd).toContain('--remove-label "ralphai-subissue:stuck"');
-    // Should NOT contain standalone labels
-    expect(cmd).not.toContain("ralphai-standalone");
+    // Defensive: also removes standalone state labels (cross-family cleanup)
+    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
+    expect(cmd).toContain('--remove-label "ralphai-standalone:stuck"');
   });
 
   it("uses standalone labels when plan has no prd frontmatter even with subissue labels provided", () => {
@@ -332,7 +335,8 @@ describe("restoreIssueLabels — sub-issue label selection", () => {
     expect(cmd).toContain('--add-label "ralphai-standalone"');
     expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
     expect(cmd).toContain('--remove-label "ralphai-standalone:stuck"');
-    // Should NOT contain subissue labels
+    // Standalone issues don't need cross-family cleanup (subissue labels
+    // would never be erroneously applied to a standalone issue)
     expect(cmd).not.toContain("ralphai-subissue");
   });
 
@@ -366,5 +370,55 @@ describe("restoreIssueLabels — sub-issue label selection", () => {
     // Falls back to standalone since subissue labels not provided
     expect(cmd).toContain('--add-label "ralphai-standalone"');
     expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-family reset cleanup
+// ---------------------------------------------------------------------------
+
+describe("restoreIssueLabels — cross-family label cleanup", () => {
+  it("removes labels from both families for sub-issues, cleaning up erroneously-applied standalone labels", () => {
+    mockGhAvailable();
+
+    // This simulates the bug scenario: a sub-issue that had
+    // ralphai-standalone:in-progress erroneously applied instead
+    // of ralphai-subissue:in-progress. Reset should remove both.
+    const planPath = writePlanFile(
+      ctx.dir,
+      "gh-201-cross-family",
+      githubSubIssuePlanContent(201, 100),
+    );
+
+    const result = restoreIssueLabels({
+      planPath,
+      standaloneLabel: "ralphai-standalone",
+      standaloneInProgressLabel: "ralphai-standalone:in-progress",
+      standaloneStuckLabel: "ralphai-standalone:stuck",
+      subissueLabel: "ralphai-subissue",
+      subissueInProgressLabel: "ralphai-subissue:in-progress",
+      subissueStuckLabel: "ralphai-subissue:stuck",
+      issueRepo: "owner/repo",
+      cwd: ctx.dir,
+    });
+
+    expect(result.restored).toBe(true);
+
+    const ghEditCalls = mockExecSync.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" && call[0].includes("gh issue edit"),
+    );
+    expect(ghEditCalls.length).toBe(1);
+    const cmd = ghEditCalls[0]![0] as string;
+
+    // Primary family: subissue intake restored, subissue state labels removed
+    expect(cmd).toContain('--add-label "ralphai-subissue"');
+    expect(cmd).toContain('--remove-label "ralphai-subissue:in-progress"');
+    expect(cmd).toContain('--remove-label "ralphai-subissue:stuck"');
+
+    // Defensive cleanup: standalone state labels also removed
+    // (these may have been erroneously applied by the old bug)
+    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
+    expect(cmd).toContain('--remove-label "ralphai-standalone:stuck"');
   });
 });

--- a/src/reset-labels.ts
+++ b/src/reset-labels.ts
@@ -136,13 +136,26 @@ export function restoreIssueLabels(
     };
   }
 
-  // Reverse the label transition: remove in-progress and stuck, add intake
+  // Reverse the label transition: remove in-progress and stuck, add intake.
+  // For sub-issues, also defensively remove standalone state labels in case
+  // the wrong family was applied (the pullGithubIssueByNumber bug).
+  // gh issue edit --remove-label is a no-op for labels that aren't present.
+  const extraRemoveLabels: string[] = [];
+  if (isSubIssue && options.subissueLabel) {
+    // We're resetting a sub-issue with subissue labels — also remove
+    // any standalone state labels that may have been erroneously applied.
+    extraRemoveLabels.push(options.standaloneInProgressLabel);
+    extraRemoveLabels.push(options.standaloneStuckLabel);
+  }
+
   const transitionResult = transitionReset(
     { number: fm.issue, repo },
     issueLabel,
     issueInProgressLabel,
     issueStuckLabel,
     cwd,
+    false,
+    extraRemoveLabels,
   );
 
   return {


### PR DESCRIPTION
Fix pullGithubIssueByNumber to apply the correct subissue label family (ralphai-subissue:in-progress) instead of standalone labels when processing sub-issues with a PRD parent, and make ralphai reset defensively clean up labels from both families to recover from the erroneous state.

Closes #302

## Changes

### Bug Fixes

- pullGithubIssueByNumber applies correct subissue labels for sub-issues


## Learnings

- <entry>status: none</entry>