### PR TITLE
refactor: replace 12 per-family suffixed labels with 6 shared state labels

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ Worktree logic is split into focused sub-modules, re-exported through a barrel (
 | `src/show-config.ts`       | `--show-config` output formatting.                                        |
 | `src/issues.ts`            | GitHub issue pulling, slug generation, label fetching, parent discovery.  |
 | `src/issue-dispatch.ts`    | Label-driven dispatch classification and validation for issue targets.    |
-| `src/labels.ts`            | Label derivation from base label names (`deriveLabels()`).                |
+| `src/labels.ts`            | Shared state label constants (`in-progress`, `done`, `stuck`).            |
 | `src/label-lifecycle.ts`   | Centralized label transitions (pull, done, stuck, reset, PRD).            |
 | `src/prd-discovery.ts`     | PRD issue discovery and sub-issue routing.                                |
 | `src/pr-lifecycle.ts`      | PR creation after plan completion.                                        |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ ralphai run              # auto-pulls from GitHub when the backlog is empty
 
 Each standalone issue gets its own branch and PR, the same as a local plan file.
 
-Both workflows require the `gh` CLI and `issueSource: "github"` in config. Ralphai creates 12 GitHub labels (3 families — `standaloneLabel`, `subissueLabel`, `prdLabel` — × 4 states each), all configurable via `config.json` or environment variables. See the [CLI Reference](docs/cli-reference.md#config-keys) for all options.
+Both workflows require the `gh` CLI and `issueSource: "github"` in config. Ralphai creates 6 GitHub labels — 3 family labels (`standaloneLabel`, `subissueLabel`, `prdLabel`) plus 3 shared state labels (`in-progress`, `done`, `stuck`). Family labels are configurable via `config.json` or environment variables. See the [CLI Reference](docs/cli-reference.md#config-keys) for all options.
 
 ## Multi-Repo Management
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -374,9 +374,9 @@ Settings resolve in this order: **CLI flags > env vars > `config.json` > default
 | `maxStuck`             | `3`                    | `RALPHAI_MAX_STUCK`              | Consecutive no-commit iterations before abort                        |
 | `iterationTimeout`     | `0`                    | `RALPHAI_ITERATION_TIMEOUT`      | Per-agent-invocation timeout in seconds (0 = no timeout)             |
 | `issueSource`          | `"none"`               | `RALPHAI_ISSUE_SOURCE`           | Issue source (`"github"` or `"none"`); `init` defaults to `"github"` |
-| `standaloneLabel`      | `"ralphai-standalone"` | `RALPHAI_STANDALONE_LABEL`       | Base name for standalone issue labels (4 states derived)             |
-| `subissueLabel`        | `"ralphai-subissue"`   | `RALPHAI_SUBISSUE_LABEL`         | Base name for PRD sub-issue labels (4 states derived)                |
-| `prdLabel`             | `"ralphai-prd"`        | `RALPHAI_PRD_LABEL`              | Base name for PRD parent labels (4 states derived)                   |
+| `standaloneLabel`      | `"ralphai-standalone"` | `RALPHAI_STANDALONE_LABEL`       | Family label for standalone issues                                   |
+| `subissueLabel`        | `"ralphai-subissue"`   | `RALPHAI_SUBISSUE_LABEL`         | Family label for PRD sub-issues                                      |
+| `prdLabel`             | `"ralphai-prd"`        | `RALPHAI_PRD_LABEL`              | Family label for PRD parent issues                                   |
 | `issueRepo`            | _(auto-detected)_      | `RALPHAI_ISSUE_REPO`             | GitHub `owner/repo` for issue queries                                |
 | `issueCommentProgress` | `false`                | `RALPHAI_ISSUE_COMMENT_PROGRESS` | Post progress comments on GitHub issues                              |
 

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -126,7 +126,7 @@ When you run `ralphai run <number>`, Ralphai fetches the issue's labels from Git
 
 If no recognized label is found, Ralphai exits with an error and guidance to add the appropriate label. The old unified `ralphai` label is not recognized (hard cutover).
 
-Both the intake label (e.g. `ralphai-standalone`) and the in-progress label (e.g. `ralphai-standalone:in-progress`) are recognized for dispatch, so re-running an issue that's already in progress works correctly.
+Both the family label (e.g. `ralphai-standalone`) and the shared `in-progress` label can be present simultaneously — classification only checks for the family label, so re-running an issue that's already in progress works correctly.
 
 ### Validation rules
 
@@ -157,11 +157,11 @@ When `ralphai run` (auto-detect, no target) encounters a plan with `prd: N` fron
 
 ### PRD In-Progress Label
 
-When Ralphai begins processing a PRD's sub-issues — either via an explicit `ralphai run 42` or via auto-drain — it applies the configured PRD in-progress label (`ralphai-prd:in-progress`, derived from `prdLabel`) to the parent PRD issue. This is best-effort: if the label application fails, processing continues normally.
+When Ralphai begins processing a PRD's sub-issues — either via an explicit `ralphai run 42` or via auto-drain — it adds the shared `in-progress` label to the parent PRD issue. This is best-effort: if the label application fails, processing continues normally.
 
 ### PRD Done Label
 
-When all of a PRD's sub-issues have completed successfully (all have the done label, none have stuck or in-progress labels), Ralphai swaps the PRD in-progress label for the PRD done label (`ralphai-prd:done`, derived from `prdLabel`). This transition happens in three code paths: the explicit PRD runner after its sub-issue loop, the auto-drain path when no more eligible sub-issues remain, and the early exit path when all sub-issues are already complete on entry.
+When all of a PRD's sub-issues have completed successfully (all have the `done` label, none have `stuck` or `in-progress` labels), Ralphai swaps the `in-progress` label for the `done` label on the PRD parent. This transition happens in three code paths: the explicit PRD runner after its sub-issue loop, the auto-drain path when no more eligible sub-issues remain, and the early exit path when all sub-issues are already complete on entry.
 
 ### Sequencing
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -173,7 +173,7 @@ ralphai run -w --plan=dark-mode  # wizard + specific plan
 
 ## Customize GitHub labels
 
-By default, Ralphai creates 12 GitHub labels from 3 base names — `ralphai-standalone`, `ralphai-subissue`, and `ralphai-prd` — each with 4 state suffixes (intake, `:in-progress`, `:done`, `:stuck`). Override the base names in `config.json`:
+By default, Ralphai creates 6 GitHub labels: 3 family labels (`ralphai-standalone`, `ralphai-subissue`, `ralphai-prd`) plus 3 shared state labels (`in-progress`, `done`, `stuck`). Override the family label names in `config.json`:
 
 ```json
 {

--- a/src/init-labels.test.ts
+++ b/src/init-labels.test.ts
@@ -16,113 +16,66 @@ describe("init label creation", () => {
   }
 
   // ---------------------------------------------------------------------------
-  // Source-level: labelDefs produces 12 labels (3 families × 4 states)
+  // Source-level: labelDefs produces 6 labels (3 family + 3 shared state)
   // ---------------------------------------------------------------------------
 
-  it("labelDefs includes standalone intake label with color 7057ff", () => {
+  it("labelDefs includes standalone family label with color 7057ff", () => {
     expect(ralphaiSrc).toContain(
       'description: "Ralphai picks up this standalone issue"',
     );
     expect(ralphaiSrc).toContain('const STANDALONE_INTAKE_COLOR = "7057ff"');
   });
 
-  it("labelDefs includes standalone in-progress label with shared yellow color", () => {
-    expect(ralphaiSrc).toContain(
-      'description: "Ralphai is working on this standalone issue"',
-    );
-  });
-
-  it("labelDefs includes standalone done label with shared green color", () => {
-    expect(ralphaiSrc).toContain(
-      'description: "Ralphai finished this standalone issue"',
-    );
-  });
-
-  it("labelDefs includes standalone stuck label with shared red color", () => {
-    expect(ralphaiSrc).toContain(
-      'description: "Ralphai is stuck on this standalone issue"',
-    );
-  });
-
-  it("labelDefs includes subissue intake label with color c5def5", () => {
+  it("labelDefs includes subissue family label with color c5def5", () => {
     expect(ralphaiSrc).toContain(
       'description: "Ralphai picks up this PRD sub-issue"',
     );
     expect(ralphaiSrc).toContain('const SUBISSUE_INTAKE_COLOR = "c5def5"');
   });
 
-  it("labelDefs includes subissue in-progress label", () => {
-    expect(ralphaiSrc).toContain(
-      'description: "Ralphai is working on this PRD sub-issue"',
-    );
-  });
-
-  it("labelDefs includes subissue done label", () => {
-    expect(ralphaiSrc).toContain(
-      'description: "Ralphai finished this PRD sub-issue"',
-    );
-  });
-
-  it("labelDefs includes subissue stuck label", () => {
-    expect(ralphaiSrc).toContain(
-      'description: "Ralphai is stuck on this PRD sub-issue"',
-    );
-  });
-
-  it("labelDefs includes PRD intake label with color 1d76db", () => {
+  it("labelDefs includes PRD family label with color 1d76db", () => {
     expect(ralphaiSrc).toContain(
       'description: "Ralphai PRD — groups sub-issues for drain runs"',
     );
     expect(ralphaiSrc).toContain('const PRD_INTAKE_COLOR = "1d76db"');
   });
 
-  it("labelDefs includes PRD in-progress label", () => {
+  it("labelDefs includes shared in-progress state label", () => {
     expect(ralphaiSrc).toContain(
-      'description: "Ralphai is processing this PRD\'s sub-issues"',
+      'description: "Ralphai is working on this issue"',
     );
   });
 
-  it("labelDefs includes PRD done label", () => {
+  it("labelDefs includes shared done state label", () => {
+    expect(ralphaiSrc).toContain('description: "Ralphai finished this issue"');
+  });
+
+  it("labelDefs includes shared stuck state label", () => {
     expect(ralphaiSrc).toContain(
-      'description: "Ralphai finished all sub-issues for this PRD"',
+      'description: "Ralphai is stuck on this issue"',
     );
   });
 
-  it("labelDefs includes PRD stuck label", () => {
-    expect(ralphaiSrc).toContain(
-      'description: "Ralphai is stuck processing this PRD"',
-    );
-  });
-
-  it("labelDefs uses shared state colors across families", () => {
+  it("labelDefs uses shared state colors", () => {
     expect(ralphaiSrc).toContain('const IN_PROGRESS_COLOR = "fbca04"');
     expect(ralphaiSrc).toContain('const DONE_COLOR = "0e8a16"');
     expect(ralphaiSrc).toContain('const STUCK_COLOR = "d93f0b"');
   });
 
   // ---------------------------------------------------------------------------
-  // Source-level: LabelNames uses 3 families with DerivedLabels
+  // Source-level: LabelNames uses 3 plain string families
   // ---------------------------------------------------------------------------
 
-  it("LabelNames interface has standalone, subissue, and prd families", () => {
-    expect(ralphaiSrc).toContain("standalone: DerivedLabels");
-    expect(ralphaiSrc).toContain("subissue: DerivedLabels");
-    expect(ralphaiSrc).toContain("prd: DerivedLabels");
+  it("LabelNames interface has standalone, subissue, and prd as strings", () => {
+    expect(ralphaiSrc).toContain("standalone: string");
+    expect(ralphaiSrc).toContain("subissue: string");
+    expect(ralphaiSrc).toContain("prd: string");
   });
 
   it("labelDefs references names.standalone, names.subissue, and names.prd", () => {
-    expect(ralphaiSrc).toContain("names.standalone.intake");
-    expect(ralphaiSrc).toContain("names.standalone.inProgress");
-    expect(ralphaiSrc).toContain("names.standalone.done");
-    expect(ralphaiSrc).toContain("names.standalone.stuck");
-    expect(ralphaiSrc).toContain("names.subissue.intake");
-    expect(ralphaiSrc).toContain("names.subissue.inProgress");
-    expect(ralphaiSrc).toContain("names.subissue.done");
-    expect(ralphaiSrc).toContain("names.subissue.stuck");
-    expect(ralphaiSrc).toContain("names.prd.intake");
-    expect(ralphaiSrc).toContain("names.prd.inProgress");
-    expect(ralphaiSrc).toContain("names.prd.done");
-    expect(ralphaiSrc).toContain("names.prd.stuck");
+    expect(ralphaiSrc).toContain("names.standalone");
+    expect(ralphaiSrc).toContain("names.subissue");
+    expect(ralphaiSrc).toContain("names.prd");
   });
 
   // ---------------------------------------------------------------------------
@@ -152,17 +105,15 @@ describe("init label creation", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Source-level: scaffold builds LabelNames from deriveLabels for all 3 families
+  // Source-level: scaffold builds LabelNames from plain config values
   // ---------------------------------------------------------------------------
 
-  it("scaffold builds initLabelNames using deriveLabels for all 3 base config values", () => {
+  it("scaffold builds initLabelNames using config values directly", () => {
     expect(ralphaiSrc).toContain(
-      "deriveLabels(configObj.standaloneLabel as string)",
+      "standalone: configObj.standaloneLabel as string",
     );
-    expect(ralphaiSrc).toContain(
-      "deriveLabels(configObj.subissueLabel as string)",
-    );
-    expect(ralphaiSrc).toContain("deriveLabels(configObj.prdLabel as string)");
+    expect(ralphaiSrc).toContain("subissue: configObj.subissueLabel as string");
+    expect(ralphaiSrc).toContain("prd: configObj.prdLabel as string");
   });
 
   // ---------------------------------------------------------------------------
@@ -178,17 +129,17 @@ describe("init label creation", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Source-level: success message lists all labels dynamically
+  // Source-level: success message lists 6 labels
   // ---------------------------------------------------------------------------
 
-  it("success message shows per-family label summary", () => {
-    expect(ralphaiSrc).toContain("Created 12 labels across 3 families:");
-    expect(ralphaiSrc).toContain("Intake label for standalone issues");
-    expect(ralphaiSrc).toContain("Intake label for PRD sub-issues");
-    expect(ralphaiSrc).toContain("Intake label for PRD parent issues");
+  it("success message shows family and shared state label summary", () => {
     expect(ralphaiSrc).toContain(
-      "Each has :in-progress, :done, and :stuck variants",
+      "Created 6 labels (3 family + 3 shared state):",
     );
+    expect(ralphaiSrc).toContain("Family label for standalone issues");
+    expect(ralphaiSrc).toContain("Family label for PRD sub-issues");
+    expect(ralphaiSrc).toContain("Family label for PRD parent issues");
+    expect(ralphaiSrc).toContain("Shared state: in-progress, done, stuck");
   });
 
   // ---------------------------------------------------------------------------
@@ -197,27 +148,22 @@ describe("init label creation", () => {
 
   it("runRalphaiRunner ensures labels when issueSource is github", () => {
     expect(ralphaiSrc).toContain('config.issueSource.value === "github"');
-    // Verify the ensure call derives labels from 3 base config keys
-    expect(ralphaiSrc).toContain("deriveLabels(config.standaloneLabel.value)");
-    expect(ralphaiSrc).toContain("deriveLabels(config.subissueLabel.value)");
-    expect(ralphaiSrc).toContain("deriveLabels(config.prdLabel.value)");
+    // Verify the ensure call uses plain config values for 3 families
+    expect(ralphaiSrc).toContain("standalone: config.standaloneLabel.value");
+    expect(ralphaiSrc).toContain("subissue: config.subissueLabel.value");
+    expect(ralphaiSrc).toContain("prd: config.prdLabel.value");
   });
 
-  it("runRalphaiRunner creates all 12 labels in a single ensureGitHubLabels call", () => {
-    // After the refactor, run should call ensureGitHubLabels once (not twice)
-    // with all 3 families in one LabelNames object
+  it("runRalphaiRunner creates all 6 labels in a single ensureGitHubLabels call", () => {
+    // run should call ensureGitHubLabels once with all 3 families
     const runBlock = ralphaiSrc.slice(
       ralphaiSrc.indexOf("// Best-effort: ensure all issue-tracking labels"),
       ralphaiSrc.indexOf("// --- Pre-flight: interactive dirty-state check"),
     );
     // Should have standalone, subissue, and prd in the same call
-    expect(runBlock).toContain(
-      "standalone: deriveLabels(config.standaloneLabel.value)",
-    );
-    expect(runBlock).toContain(
-      "subissue: deriveLabels(config.subissueLabel.value)",
-    );
-    expect(runBlock).toContain("prd: deriveLabels(config.prdLabel.value)");
+    expect(runBlock).toContain("standalone: config.standaloneLabel.value");
+    expect(runBlock).toContain("subissue: config.subissueLabel.value");
+    expect(runBlock).toContain("prd: config.prdLabel.value");
   });
 
   it("run-start label ensure is skipped in dry-run mode", () => {

--- a/src/issue-dispatch.test.ts
+++ b/src/issue-dispatch.test.ts
@@ -38,9 +38,9 @@ describe("classifyIssue", () => {
     }
   });
 
-  it("classifies ralphai-standalone:in-progress as standalone", () => {
+  it("classifies issue with ralphai-standalone and in-progress as standalone", () => {
     const result = classifyIssue(
-      ["ralphai-standalone:in-progress"],
+      ["ralphai-standalone", "in-progress"],
       defaultConfig,
     );
     expect(result.ok).toBe(true);
@@ -58,9 +58,9 @@ describe("classifyIssue", () => {
     }
   });
 
-  it("classifies ralphai-subissue:in-progress as subissue", () => {
+  it("classifies issue with ralphai-subissue and in-progress as subissue", () => {
     const result = classifyIssue(
-      ["ralphai-subissue:in-progress"],
+      ["ralphai-subissue", "in-progress"],
       defaultConfig,
     );
     expect(result.ok).toBe(true);
@@ -78,8 +78,8 @@ describe("classifyIssue", () => {
     }
   });
 
-  it("classifies ralphai-prd:in-progress as prd", () => {
-    const result = classifyIssue(["ralphai-prd:in-progress"], defaultConfig);
+  it("classifies issue with ralphai-prd and in-progress as prd", () => {
+    const result = classifyIssue(["ralphai-prd", "in-progress"], defaultConfig);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.family).toBe("prd");
@@ -104,34 +104,6 @@ describe("classifyIssue", () => {
     if (!result.ok) {
       expect(result.reason).toBe("no-label");
     }
-  });
-
-  // Scenario 34: Old ralphai label is not recognized (hard cutover)
-  it("does NOT recognize the old 'ralphai' label", () => {
-    const result = classifyIssue(["ralphai"], defaultConfig);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toBe("no-label");
-    }
-  });
-
-  it("does NOT recognize old 'ralphai:in-progress' label", () => {
-    const result = classifyIssue(["ralphai:in-progress"], defaultConfig);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toBe("no-label");
-    }
-  });
-
-  // Done and stuck labels should NOT be classified (only intake and in-progress)
-  it("does NOT classify ralphai-standalone:done as dispatchable", () => {
-    const result = classifyIssue(["ralphai-standalone:done"], defaultConfig);
-    expect(result.ok).toBe(false);
-  });
-
-  it("does NOT classify ralphai-standalone:stuck as dispatchable", () => {
-    const result = classifyIssue(["ralphai-standalone:stuck"], defaultConfig);
-    expect(result.ok).toBe(false);
   });
 
   // Priority: standalone checked first
@@ -172,13 +144,13 @@ describe("classifyIssue", () => {
     }
   });
 
-  it("custom config in-progress labels work", () => {
+  it("custom config with in-progress shared label works", () => {
     const custom: LabelConfig = {
       standaloneLabel: "my-bot",
       subissueLabel: "my-bot-sub",
       prdLabel: "my-bot-prd",
     };
-    const result = classifyIssue(["my-bot-sub:in-progress"], custom);
+    const result = classifyIssue(["my-bot-sub", "in-progress"], custom);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.family).toBe("subissue");

--- a/src/issue-dispatch.ts
+++ b/src/issue-dispatch.ts
@@ -8,13 +8,15 @@
  * - `prd`        — discover sub-issues, process sequentially on shared branch
  * - `none`       — no recognized label, error with guidance
  *
+ * With shared state labels, classification only needs to check for family
+ * labels (which persist through all states). The `in-progress` label is
+ * shared and doesn't affect family classification.
+ *
  * Validation catches misconfigurations early with skip-with-warning:
  * - standalone + has parent PRD → skip
  * - subissue + no parent PRD → skip
  * - subissue + parent lacks ralphai-prd label → skip
  */
-
-import { deriveLabels } from "./labels.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,38 +67,28 @@ export interface LabelConfig {
 /**
  * Classify an issue into a dispatch family based on its labels.
  *
- * Matches against the intake and in-progress state for each family.
+ * Checks for family labels only — since family labels persist through
+ * all states, an issue with `ralphai-standalone` (with or without
+ * `in-progress`, `done`, etc.) is classified as standalone.
+ *
  * The old unified `ralphai` label is NOT recognized (hard cutover).
  */
 export function classifyIssue(
   issueLabels: string[],
   config: LabelConfig,
 ): DispatchResult {
-  const standaloneLabels = deriveLabels(config.standaloneLabel);
-  const subissueLabels = deriveLabels(config.subissueLabel);
-  const prdLabels = deriveLabels(config.prdLabel);
-
-  // Check standalone family (intake or in-progress)
-  if (
-    issueLabels.includes(standaloneLabels.intake) ||
-    issueLabels.includes(standaloneLabels.inProgress)
-  ) {
+  // Check standalone family
+  if (issueLabels.includes(config.standaloneLabel)) {
     return { ok: true, family: "standalone" };
   }
 
-  // Check subissue family (intake or in-progress)
-  if (
-    issueLabels.includes(subissueLabels.intake) ||
-    issueLabels.includes(subissueLabels.inProgress)
-  ) {
+  // Check subissue family
+  if (issueLabels.includes(config.subissueLabel)) {
     return { ok: true, family: "subissue" };
   }
 
-  // Check PRD family (intake or in-progress)
-  if (
-    issueLabels.includes(prdLabels.intake) ||
-    issueLabels.includes(prdLabels.inProgress)
-  ) {
+  // Check PRD family
+  if (issueLabels.includes(config.prdLabel)) {
     return { ok: true, family: "prd" };
   }
 

--- a/src/issues.test.ts
+++ b/src/issues.test.ts
@@ -49,8 +49,6 @@ function defaultOptions(dir: string): PullIssueOptions {
     cwd: dir,
     issueSource: "github",
     standaloneLabel: "ralphai-standalone",
-    standaloneInProgressLabel: "ralphai-standalone:in-progress",
-    standaloneDoneLabel: "ralphai-standalone:done",
     issueRepo: "",
     issueCommentProgress: false,
   };

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -9,7 +9,7 @@ import { execSync } from "child_process";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { DEFAULTS } from "./config.ts";
-import { deriveLabels } from "./labels.ts";
+import { IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL } from "./labels.ts";
 import { transitionPull, prdTransitionInProgress } from "./label-lifecycle.ts";
 // ---------------------------------------------------------------------------
 // Types
@@ -23,30 +23,16 @@ export interface PullIssueOptions {
   cwd: string;
   /** Configured issue source — must be "github" to proceed. */
   issueSource: string;
-  /** Label to filter open issues by (e.g. "ralphai-standalone"). */
+  /** Family label to filter open standalone issues by (e.g. "ralphai-standalone"). */
   standaloneLabel: string;
-  /** Label applied when an issue is picked up (e.g. "ralphai-standalone:in-progress"). */
-  standaloneInProgressLabel: string;
-  /** Label applied when an issue is completed (e.g. "ralphai-standalone:done"). */
-  standaloneDoneLabel: string;
-  /** Label applied when an issue is stuck (e.g. "ralphai-standalone:stuck"). */
-  standaloneStuckLabel?: string;
-  /** Sub-issue intake label (e.g. "ralphai-subissue"). Used by pullPrdSubIssue(). */
+  /** Sub-issue family label (e.g. "ralphai-subissue"). Used by pullPrdSubIssue(). */
   subissueLabel?: string;
-  /** Sub-issue in-progress label (e.g. "ralphai-subissue:in-progress"). */
-  subissueInProgressLabel?: string;
-  /** Sub-issue done label (e.g. "ralphai-subissue:done"). */
-  subissueDoneLabel?: string;
-  /** Sub-issue stuck label (e.g. "ralphai-subissue:stuck"). */
-  subissueStuckLabel?: string;
   /** Explicit owner/repo (empty = auto-detect from git remote). */
   issueRepo: string;
   /** Whether to post a progress comment on the issue. */
   issueCommentProgress: boolean;
-  /** Label that marks an issue as a PRD (e.g. "ralphai-prd"). */
+  /** Family label that marks an issue as a PRD (e.g. "ralphai-prd"). */
   issuePrdLabel?: string;
-  /** Label applied to PRD parent when drain processing starts (e.g. "ralphai-prd:in-progress"). */
-  issuePrdInProgressLabel?: string;
 }
 
 /** Result of a pullGithubIssues() call. */
@@ -659,14 +645,10 @@ interface FetchAndWriteOptions {
   issueNumber: string;
   backlogDir: string;
   cwd: string;
-  standaloneInProgressLabel: string;
-  standaloneLabel: string;
   issueCommentProgress: boolean;
   issuePrdLabel?: string;
-  /** Optional subissue intake label (e.g. "ralphai-subissue"). */
+  /** Optional subissue family label (e.g. "ralphai-subissue"). */
   subissueLabel?: string;
-  /** Optional subissue in-progress label (e.g. "ralphai-subissue:in-progress"). */
-  subissueInProgressLabel?: string;
 }
 
 /**
@@ -675,15 +657,7 @@ interface FetchAndWriteOptions {
  * and pullGithubIssueByNumber().
  */
 function fetchAndWriteIssuePlan(opts: FetchAndWriteOptions): PullIssueResult {
-  const {
-    repo,
-    issueNumber,
-    backlogDir,
-    cwd,
-    standaloneInProgressLabel: issueInProgressLabel,
-    standaloneLabel: issueLabel,
-    issueCommentProgress,
-  } = opts;
+  const { repo, issueNumber, backlogDir, cwd, issueCommentProgress } = opts;
 
   const title = execQuiet(
     `gh issue view ${issueNumber} --repo "${repo}" --json title --jq '.title'`,
@@ -708,15 +682,6 @@ function fetchAndWriteIssuePlan(opts: FetchAndWriteOptions): PullIssueResult {
   // Discover parent PRD (non-fatal — plan is still usable without it)
   const prd = discoverParentPrd(repo, issueNumber, cwd, opts.issuePrdLabel);
 
-  // Select the correct label family: sub-issues (prd present and subissue
-  // labels provided) use subissue labels, standalone issues use standalone.
-  const isSubIssue =
-    prd !== undefined && opts.subissueLabel && opts.subissueInProgressLabel;
-  const effectiveIntakeLabel = isSubIssue ? opts.subissueLabel! : issueLabel;
-  const effectiveInProgressLabel = isSubIssue
-    ? opts.subissueInProgressLabel!
-    : issueInProgressLabel;
-
   // Query native GitHub blocking relationships via GraphQL (fail-open)
   const blockers = fetchBlockersViaGraphQL(repo, issueNumber, cwd);
 
@@ -738,13 +703,8 @@ function fetchAndWriteIssuePlan(opts: FetchAndWriteOptions): PullIssueResult {
   });
   writeFileSync(planPath, planContent, "utf-8");
 
-  // Update issue labels: add in-progress, remove intake label
-  transitionPull(
-    { number: Number(issueNumber), repo },
-    effectiveIntakeLabel,
-    effectiveInProgressLabel,
-    cwd,
-  );
+  // Update issue labels: add in-progress (family label stays)
+  transitionPull({ number: Number(issueNumber), repo }, cwd);
 
   if (issueCommentProgress) {
     execQuiet(
@@ -777,7 +737,6 @@ export function pullGithubIssues(options: PullIssueOptions): PullIssueResult {
     cwd,
     issueSource,
     standaloneLabel: issueLabel,
-    standaloneInProgressLabel: issueInProgressLabel,
     issueRepo,
     issueCommentProgress,
   } = options;
@@ -822,8 +781,6 @@ export function pullGithubIssues(options: PullIssueOptions): PullIssueResult {
     issueNumber: number,
     backlogDir,
     cwd,
-    standaloneInProgressLabel: issueInProgressLabel,
-    standaloneLabel: issueLabel,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,
   });
@@ -845,17 +802,6 @@ export function pullGithubIssues(options: PullIssueOptions): PullIssueResult {
 export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
   const { backlogDir, cwd, issueSource, issueRepo, issueCommentProgress } =
     options;
-
-  // Sub-issues use the subissue label family when provided, falling back
-  // to the standalone labels for backward compatibility.
-  const subissueLabels = options.subissueLabel
-    ? deriveLabels(options.subissueLabel)
-    : null;
-  const issueLabel = subissueLabels?.intake ?? options.standaloneLabel;
-  const issueInProgressLabel =
-    subissueLabels?.inProgress ?? options.standaloneInProgressLabel;
-  const issueDoneLabel = subissueLabels?.done ?? options.standaloneDoneLabel;
-  const issueStuckLabel = subissueLabels?.stuck ?? options.standaloneStuckLabel;
 
   const prdLabel = options.issuePrdLabel ?? DEFAULTS.prdLabel;
 
@@ -947,8 +893,7 @@ export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
   // Find the first open sub-issue that hasn't already been picked up
   // or completed (label check prevents re-pulling issues that were
   // already processed by a prior drain iteration).
-  const skipLabels = [issueInProgressLabel, issueDoneLabel];
-  if (issueStuckLabel) skipLabels.push(issueStuckLabel);
+  const skipLabels = [IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL];
   let subIssueNumber: number | undefined;
   for (const candidate of openSubIssues) {
     const labelsRaw = execQuiet(
@@ -975,27 +920,16 @@ export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
   );
 
   // Best-effort: mark the PRD parent as in-progress when we first pull a sub-issue.
-  const prdInProgressLabel =
-    options.issuePrdInProgressLabel ??
-    deriveLabels(DEFAULTS.prdLabel).inProgress;
-  prdTransitionInProgress(
-    { number: prd.number, repo },
-    prdInProgressLabel,
-    cwd,
-  );
+  prdTransitionInProgress({ number: prd.number, repo }, cwd);
 
   return fetchAndWriteIssuePlan({
     repo,
     issueNumber: String(subIssueNumber),
     backlogDir,
     cwd,
-    standaloneInProgressLabel: options.standaloneInProgressLabel,
-    standaloneLabel: options.standaloneLabel,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,
     subissueLabel: options.subissueLabel,
-    subissueInProgressLabel:
-      options.subissueInProgressLabel ?? subissueLabels?.inProgress,
   });
 }
 
@@ -1201,8 +1135,6 @@ export function pullGithubIssueByNumber(
     backlogDir,
     cwd,
     issueSource,
-    standaloneLabel: issueLabel,
-    standaloneInProgressLabel: issueInProgressLabel,
     issueRepo,
     issueCommentProgress,
     issueNumber,
@@ -1233,12 +1165,9 @@ export function pullGithubIssueByNumber(
     issueNumber: String(issueNumber),
     backlogDir,
     cwd,
-    standaloneInProgressLabel: issueInProgressLabel,
-    standaloneLabel: issueLabel,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,
     subissueLabel: options.subissueLabel,
-    subissueInProgressLabel: options.subissueInProgressLabel,
   });
 }
 
@@ -1259,7 +1188,6 @@ export function pullGithubIssueByNumber(
 export function checkAllPrdSubIssuesDone(
   repo: string,
   prdNumber: number,
-  subissueDoneLabel: string,
   cwd: string,
 ): boolean {
   // Fetch all sub-issues via the native REST API
@@ -1289,7 +1217,7 @@ export function checkAllPrdSubIssuesDone(
       cwd,
     );
     const labels = labelsRaw ? labelsRaw.split(",") : [];
-    if (!labels.includes(subissueDoneLabel)) {
+    if (!labels.includes(DONE_LABEL)) {
       return false;
     }
   }

--- a/src/label-lifecycle.test.ts
+++ b/src/label-lifecycle.test.ts
@@ -7,6 +7,10 @@
  * Tests verify correct `--add-label`/`--remove-label` arguments for each
  * transition (pull, done, stuck, reset) and for PRD parent propagation
  * (in-progress, done, stuck).
+ *
+ * All transition functions use shared state labels (in-progress, done,
+ * stuck) — family labels are managed separately and never passed to
+ * transition functions.
  */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -79,19 +83,14 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// transitionPull: intake → in-progress
+// transitionPull: add in-progress (family label stays)
 // ---------------------------------------------------------------------------
 
 describe("transitionPull", () => {
-  it("calls gh issue edit with correct add/remove labels", () => {
+  it("calls gh issue edit to add in-progress label", () => {
     mockGhSuccess();
 
-    const result = transitionPull(
-      ISSUE,
-      "ralphai-standalone",
-      "ralphai-standalone:in-progress",
-      "/tmp",
-    );
+    const result = transitionPull(ISSUE, "/tmp");
 
     expect(result.ok).toBe(true);
 
@@ -99,19 +98,15 @@ describe("transitionPull", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 42");
     expect(calls[0]).toContain('--repo "acme/widgets"');
-    expect(calls[0]).toContain('--add-label "ralphai-standalone:in-progress"');
-    expect(calls[0]).toContain('--remove-label "ralphai-standalone"');
+    expect(calls[0]).toContain('--add-label "in-progress"');
+    // Family label is not touched — no --remove-label
+    expect(calls[0]).not.toContain("--remove-label");
   });
 
   it("returns ok: false on gh failure", () => {
     mockGhFailure();
 
-    const result = transitionPull(
-      ISSUE,
-      "ralphai-standalone",
-      "ralphai-standalone:in-progress",
-      "/tmp",
-    );
+    const result = transitionPull(ISSUE, "/tmp");
 
     expect(result.ok).toBe(false);
     expect(result.message).toContain("failed");
@@ -123,15 +118,10 @@ describe("transitionPull", () => {
 // ---------------------------------------------------------------------------
 
 describe("transitionDone", () => {
-  it("calls gh issue edit with correct add/remove labels", () => {
+  it("calls gh issue edit to add done and remove in-progress", () => {
     mockGhSuccess();
 
-    const result = transitionDone(
-      ISSUE,
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:done",
-      "/tmp",
-    );
+    const result = transitionDone(ISSUE, "/tmp");
 
     expect(result.ok).toBe(true);
 
@@ -139,21 +129,14 @@ describe("transitionDone", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 42");
     expect(calls[0]).toContain('--repo "acme/widgets"');
-    expect(calls[0]).toContain('--add-label "ralphai-standalone:done"');
-    expect(calls[0]).toContain(
-      '--remove-label "ralphai-standalone:in-progress"',
-    );
+    expect(calls[0]).toContain('--add-label "done"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
   });
 
   it("returns ok: false on gh failure", () => {
     mockGhFailure();
 
-    const result = transitionDone(
-      ISSUE,
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:done",
-      "/tmp",
-    );
+    const result = transitionDone(ISSUE, "/tmp");
 
     expect(result.ok).toBe(false);
     expect(result.message).toContain("failed");
@@ -165,15 +148,10 @@ describe("transitionDone", () => {
 // ---------------------------------------------------------------------------
 
 describe("transitionStuck", () => {
-  it("calls gh issue edit with correct add/remove labels", () => {
+  it("calls gh issue edit to add stuck and remove in-progress", () => {
     mockGhSuccess();
 
-    const result = transitionStuck(
-      ISSUE,
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:stuck",
-      "/tmp",
-    );
+    const result = transitionStuck(ISSUE, "/tmp");
 
     expect(result.ok).toBe(true);
 
@@ -181,21 +159,14 @@ describe("transitionStuck", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 42");
     expect(calls[0]).toContain('--repo "acme/widgets"');
-    expect(calls[0]).toContain('--add-label "ralphai-standalone:stuck"');
-    expect(calls[0]).toContain(
-      '--remove-label "ralphai-standalone:in-progress"',
-    );
+    expect(calls[0]).toContain('--add-label "stuck"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
   });
 
   it("returns ok: false on gh failure", () => {
     mockGhFailure();
 
-    const result = transitionStuck(
-      ISSUE,
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:stuck",
-      "/tmp",
-    );
+    const result = transitionStuck(ISSUE, "/tmp");
 
     expect(result.ok).toBe(false);
     expect(result.message).toContain("failed");
@@ -203,20 +174,14 @@ describe("transitionStuck", () => {
 });
 
 // ---------------------------------------------------------------------------
-// transitionReset: in-progress/stuck → intake
+// transitionReset: remove in-progress + stuck
 // ---------------------------------------------------------------------------
 
 describe("transitionReset", () => {
-  it("calls gh issue edit to add intake and remove in-progress + stuck", () => {
+  it("calls gh issue edit to remove in-progress and stuck labels", () => {
     mockGhSuccess();
 
-    const result = transitionReset(
-      ISSUE,
-      "ralphai-standalone",
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:stuck",
-      "/tmp",
-    );
+    const result = transitionReset(ISSUE, "/tmp");
 
     expect(result.ok).toBe(true);
 
@@ -224,23 +189,16 @@ describe("transitionReset", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 42");
     expect(calls[0]).toContain('--repo "acme/widgets"');
-    expect(calls[0]).toContain('--add-label "ralphai-standalone"');
-    expect(calls[0]).toContain(
-      '--remove-label "ralphai-standalone:in-progress"',
-    );
-    expect(calls[0]).toContain('--remove-label "ralphai-standalone:stuck"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
+    expect(calls[0]).toContain('--remove-label "stuck"');
+    // No --add-label — family label stays untouched
+    expect(calls[0]).not.toContain("--add-label");
   });
 
   it("returns ok: false on gh failure", () => {
     mockGhFailure();
 
-    const result = transitionReset(
-      ISSUE,
-      "ralphai-standalone",
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:stuck",
-      "/tmp",
-    );
+    const result = transitionReset(ISSUE, "/tmp");
 
     expect(result.ok).toBe(false);
     expect(result.message).toContain("failed");
@@ -252,15 +210,11 @@ describe("transitionReset", () => {
 // ---------------------------------------------------------------------------
 
 describe("prdTransitionInProgress", () => {
-  it("calls gh issue edit to add prd in-progress label", () => {
+  it("calls gh issue edit to add in-progress label", () => {
     mockGhSuccess();
 
     const prdIssue = { number: 100, repo: "acme/widgets" };
-    const result = prdTransitionInProgress(
-      prdIssue,
-      "ralphai-prd:in-progress",
-      "/tmp",
-    );
+    const result = prdTransitionInProgress(prdIssue, "/tmp");
 
     expect(result.ok).toBe(true);
 
@@ -268,7 +222,7 @@ describe("prdTransitionInProgress", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 100");
     expect(calls[0]).toContain('--repo "acme/widgets"');
-    expect(calls[0]).toContain('--add-label "ralphai-prd:in-progress"');
+    expect(calls[0]).toContain('--add-label "in-progress"');
     // Should NOT have --remove-label (additive only)
     expect(calls[0]).not.toContain("--remove-label");
   });
@@ -278,7 +232,6 @@ describe("prdTransitionInProgress", () => {
 
     const result = prdTransitionInProgress(
       { number: 100, repo: "acme/widgets" },
-      "ralphai-prd:in-progress",
       "/tmp",
     );
 
@@ -296,12 +249,7 @@ describe("prdTransitionDone", () => {
     mockGhSuccess();
 
     const prdIssue = { number: 100, repo: "acme/widgets" };
-    const result = prdTransitionDone(
-      prdIssue,
-      "ralphai-prd:in-progress",
-      "ralphai-prd:done",
-      "/tmp",
-    );
+    const result = prdTransitionDone(prdIssue, "/tmp");
 
     expect(result.ok).toBe(true);
 
@@ -309,8 +257,8 @@ describe("prdTransitionDone", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 100");
     expect(calls[0]).toContain('--repo "acme/widgets"');
-    expect(calls[0]).toContain('--add-label "ralphai-prd:done"');
-    expect(calls[0]).toContain('--remove-label "ralphai-prd:in-progress"');
+    expect(calls[0]).toContain('--add-label "done"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
   });
 
   it("returns ok: false on gh failure", () => {
@@ -318,8 +266,6 @@ describe("prdTransitionDone", () => {
 
     const result = prdTransitionDone(
       { number: 100, repo: "acme/widgets" },
-      "ralphai-prd:in-progress",
-      "ralphai-prd:done",
       "/tmp",
     );
 
@@ -333,11 +279,11 @@ describe("prdTransitionDone", () => {
 // ---------------------------------------------------------------------------
 
 describe("prdTransitionStuck", () => {
-  it("calls gh issue edit to add prd stuck label", () => {
+  it("calls gh issue edit to add stuck label", () => {
     mockGhSuccess();
 
     const prdIssue = { number: 100, repo: "acme/widgets" };
-    const result = prdTransitionStuck(prdIssue, "ralphai-prd:stuck", "/tmp");
+    const result = prdTransitionStuck(prdIssue, "/tmp");
 
     expect(result.ok).toBe(true);
 
@@ -345,7 +291,7 @@ describe("prdTransitionStuck", () => {
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 100");
     expect(calls[0]).toContain('--repo "acme/widgets"');
-    expect(calls[0]).toContain('--add-label "ralphai-prd:stuck"');
+    expect(calls[0]).toContain('--add-label "stuck"');
     // Should NOT have --remove-label (additive only)
     expect(calls[0]).not.toContain("--remove-label");
   });
@@ -355,7 +301,6 @@ describe("prdTransitionStuck", () => {
 
     const result = prdTransitionStuck(
       { number: 100, repo: "acme/widgets" },
-      "ralphai-prd:stuck",
       "/tmp",
     );
 
@@ -365,84 +310,61 @@ describe("prdTransitionStuck", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Cross-family: works with subissue labels too
+// Shared state labels work the same regardless of issue family
 // ---------------------------------------------------------------------------
 
-describe("cross-family labels", () => {
-  it("transitionPull works with subissue labels", () => {
+describe("shared state labels across families", () => {
+  it("transitionPull uses the same in-progress label for any issue", () => {
     mockGhSuccess();
 
-    const result = transitionPull(
-      { number: 7, repo: "org/repo" },
-      "ralphai-subissue",
-      "ralphai-subissue:in-progress",
-      "/tmp",
-    );
+    const result = transitionPull({ number: 7, repo: "org/repo" }, "/tmp");
 
     expect(result.ok).toBe(true);
 
     const calls = ghEditCalls();
     expect(calls.length).toBe(1);
-    expect(calls[0]).toContain('--add-label "ralphai-subissue:in-progress"');
-    expect(calls[0]).toContain('--remove-label "ralphai-subissue"');
+    expect(calls[0]).toContain('--add-label "in-progress"');
   });
 
-  it("transitionDone works with custom label base names", () => {
+  it("transitionDone uses the same done/in-progress labels for any issue", () => {
     mockGhSuccess();
 
-    const result = transitionDone(
-      { number: 7, repo: "org/repo" },
-      "my-custom:in-progress",
-      "my-custom:done",
-      "/tmp",
-    );
+    const result = transitionDone({ number: 7, repo: "org/repo" }, "/tmp");
 
     expect(result.ok).toBe(true);
 
     const calls = ghEditCalls();
     expect(calls.length).toBe(1);
-    expect(calls[0]).toContain('--add-label "my-custom:done"');
-    expect(calls[0]).toContain('--remove-label "my-custom:in-progress"');
+    expect(calls[0]).toContain('--add-label "done"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
   });
 
-  it("transitionStuck works with subissue labels", () => {
+  it("transitionStuck uses the same stuck/in-progress labels for any issue", () => {
     mockGhSuccess();
 
-    const result = transitionStuck(
-      { number: 201, repo: "org/repo" },
-      "ralphai-subissue:in-progress",
-      "ralphai-subissue:stuck",
-      "/tmp",
-    );
+    const result = transitionStuck({ number: 201, repo: "org/repo" }, "/tmp");
 
     expect(result.ok).toBe(true);
 
     const calls = ghEditCalls();
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 201");
-    expect(calls[0]).toContain('--add-label "ralphai-subissue:stuck"');
-    expect(calls[0]).toContain('--remove-label "ralphai-subissue:in-progress"');
+    expect(calls[0]).toContain('--add-label "stuck"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
   });
 
-  it("transitionReset works with subissue labels", () => {
+  it("transitionReset removes the same state labels for any issue", () => {
     mockGhSuccess();
 
-    const result = transitionReset(
-      { number: 201, repo: "org/repo" },
-      "ralphai-subissue",
-      "ralphai-subissue:in-progress",
-      "ralphai-subissue:stuck",
-      "/tmp",
-    );
+    const result = transitionReset({ number: 201, repo: "org/repo" }, "/tmp");
 
     expect(result.ok).toBe(true);
 
     const calls = ghEditCalls();
     expect(calls.length).toBe(1);
     expect(calls[0]).toContain("gh issue edit 201");
-    expect(calls[0]).toContain('--add-label "ralphai-subissue"');
-    expect(calls[0]).toContain('--remove-label "ralphai-subissue:in-progress"');
-    expect(calls[0]).toContain('--remove-label "ralphai-subissue:stuck"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
+    expect(calls[0]).toContain('--remove-label "stuck"');
   });
 });
 
@@ -451,37 +373,32 @@ describe("cross-family labels", () => {
 // ---------------------------------------------------------------------------
 
 describe("sub-issue stuck with PRD parent propagation", () => {
-  it("sub-issue stuck uses subissue labels and PRD parent gets prd:stuck", () => {
+  it("sub-issue gets stuck label, PRD parent also gets stuck label", () => {
     mockGhSuccess();
 
     const subIssue = { number: 201, repo: "org/repo" };
     const prdIssue = { number: 100, repo: "org/repo" };
 
-    // 1. Sub-issue transitions to stuck with subissue label family
-    const stuckResult = transitionStuck(
-      subIssue,
-      "ralphai-subissue:in-progress",
-      "ralphai-subissue:stuck",
-      "/tmp",
-    );
+    // 1. Sub-issue transitions to stuck
+    const stuckResult = transitionStuck(subIssue, "/tmp");
     expect(stuckResult.ok).toBe(true);
 
     // 2. PRD parent gets stuck label propagated
-    const prdResult = prdTransitionStuck(prdIssue, "ralphai-prd:stuck", "/tmp");
+    const prdResult = prdTransitionStuck(prdIssue, "/tmp");
     expect(prdResult.ok).toBe(true);
 
     // Verify both calls happened
     const calls = ghEditCalls();
     expect(calls.length).toBe(2);
 
-    // First call: sub-issue stuck with subissue labels
+    // First call: sub-issue stuck
     expect(calls[0]).toContain("gh issue edit 201");
-    expect(calls[0]).toContain('--add-label "ralphai-subissue:stuck"');
-    expect(calls[0]).toContain('--remove-label "ralphai-subissue:in-progress"');
+    expect(calls[0]).toContain('--add-label "stuck"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
 
-    // Second call: PRD parent gets ralphai-prd:stuck (additive only)
+    // Second call: PRD parent gets stuck (additive only)
     expect(calls[1]).toContain("gh issue edit 100");
-    expect(calls[1]).toContain('--add-label "ralphai-prd:stuck"');
+    expect(calls[1]).toContain('--add-label "stuck"');
     expect(calls[1]).not.toContain("--remove-label");
   });
 });
@@ -492,77 +409,49 @@ describe("sub-issue stuck with PRD parent propagation", () => {
 
 describe("dry-run safety — label lifecycle", () => {
   it("transitionPull skips gh call and returns skipped result", () => {
-    const result = transitionPull(
-      ISSUE,
-      "ralphai-standalone",
-      "ralphai-standalone:in-progress",
-      "/tmp",
-      true,
-    );
+    const result = transitionPull(ISSUE, "/tmp", true);
 
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.message).toContain("[dry-run]");
-    expect(result.message).toContain("ralphai-standalone");
-    expect(result.message).toContain("ralphai-standalone:in-progress");
+    expect(result.message).toContain("in-progress");
     expect(ghEditCalls()).toHaveLength(0);
   });
 
   it("transitionDone skips gh call and returns skipped result", () => {
-    const result = transitionDone(
-      ISSUE,
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:done",
-      "/tmp",
-      true,
-    );
+    const result = transitionDone(ISSUE, "/tmp", true);
 
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.message).toContain("[dry-run]");
-    expect(result.message).toContain("ralphai-standalone:in-progress");
-    expect(result.message).toContain("ralphai-standalone:done");
+    expect(result.message).toContain("in-progress");
+    expect(result.message).toContain("done");
     expect(ghEditCalls()).toHaveLength(0);
   });
 
   it("transitionStuck skips gh call and returns skipped result", () => {
-    const result = transitionStuck(
-      ISSUE,
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:stuck",
-      "/tmp",
-      true,
-    );
+    const result = transitionStuck(ISSUE, "/tmp", true);
 
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.message).toContain("[dry-run]");
-    expect(result.message).toContain("ralphai-standalone:in-progress");
-    expect(result.message).toContain("ralphai-standalone:stuck");
+    expect(result.message).toContain("in-progress");
+    expect(result.message).toContain("stuck");
     expect(ghEditCalls()).toHaveLength(0);
   });
 
   it("transitionReset skips gh call and returns skipped result", () => {
-    const result = transitionReset(
-      ISSUE,
-      "ralphai-standalone",
-      "ralphai-standalone:in-progress",
-      "ralphai-standalone:stuck",
-      "/tmp",
-      true,
-    );
+    const result = transitionReset(ISSUE, "/tmp", true);
 
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.message).toContain("[dry-run]");
-    expect(result.message).toContain("reset to ralphai-standalone");
     expect(ghEditCalls()).toHaveLength(0);
   });
 
   it("prdTransitionInProgress skips gh call and returns skipped result", () => {
     const result = prdTransitionInProgress(
       { number: 100, repo: "acme/widgets" },
-      "ralphai-prd:in-progress",
       "/tmp",
       true,
     );
@@ -570,15 +459,13 @@ describe("dry-run safety — label lifecycle", () => {
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.message).toContain("[dry-run]");
-    expect(result.message).toContain("ralphai-prd:in-progress");
+    expect(result.message).toContain("in-progress");
     expect(ghEditCalls()).toHaveLength(0);
   });
 
   it("prdTransitionDone skips gh call and returns skipped result", () => {
     const result = prdTransitionDone(
       { number: 100, repo: "acme/widgets" },
-      "ralphai-prd:in-progress",
-      "ralphai-prd:done",
       "/tmp",
       true,
     );
@@ -586,15 +473,14 @@ describe("dry-run safety — label lifecycle", () => {
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.message).toContain("[dry-run]");
-    expect(result.message).toContain("ralphai-prd:in-progress");
-    expect(result.message).toContain("ralphai-prd:done");
+    expect(result.message).toContain("in-progress");
+    expect(result.message).toContain("done");
     expect(ghEditCalls()).toHaveLength(0);
   });
 
   it("prdTransitionStuck skips gh call and returns skipped result", () => {
     const result = prdTransitionStuck(
       { number: 100, repo: "acme/widgets" },
-      "ralphai-prd:stuck",
       "/tmp",
       true,
     );
@@ -602,19 +488,14 @@ describe("dry-run safety — label lifecycle", () => {
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.message).toContain("[dry-run]");
-    expect(result.message).toContain("ralphai-prd:stuck");
+    expect(result.message).toContain("stuck");
     expect(ghEditCalls()).toHaveLength(0);
   });
 
   it("dryRun=false (default) still executes gh calls", () => {
     mockGhSuccess();
 
-    const result = transitionPull(
-      ISSUE,
-      "ralphai-standalone",
-      "ralphai-standalone:in-progress",
-      "/tmp",
-    );
+    const result = transitionPull(ISSUE, "/tmp");
 
     expect(result.ok).toBe(true);
     expect(result.skipped).toBeUndefined();
@@ -627,13 +508,7 @@ describe("dry-run safety — label lifecycle", () => {
     console.log = (...args: unknown[]) => logs.push(args.join(" "));
 
     try {
-      transitionStuck(
-        ISSUE,
-        "ralphai-standalone:in-progress",
-        "ralphai-standalone:stuck",
-        "/tmp",
-        true,
-      );
+      transitionStuck(ISSUE, "/tmp", true);
     } finally {
       console.log = origLog;
     }
@@ -641,7 +516,7 @@ describe("dry-run safety — label lifecycle", () => {
     expect(logs.length).toBe(1);
     expect(logs[0]).toContain("[dry-run] Would execute label operation");
     expect(logs[0]).toContain("Issue #42");
-    expect(logs[0]).toContain("ralphai-standalone:in-progress");
-    expect(logs[0]).toContain("ralphai-standalone:stuck");
+    expect(logs[0]).toContain("in-progress");
+    expect(logs[0]).toContain("stuck");
   });
 });

--- a/src/label-lifecycle.ts
+++ b/src/label-lifecycle.ts
@@ -2,11 +2,15 @@
  * Label lifecycle module — centralises all `gh issue edit` label
  * transitions for GitHub issues tracked by Ralphai.
  *
+ * Labels use a two-label scheme: a family label (e.g. `ralphai-standalone`)
+ * persists through all states, while a shared state label (`in-progress`,
+ * `done`, `stuck`) is added/removed as the issue progresses.
+ *
  * Every label transition in the system flows through this module:
- *   pull:  intake → in-progress
- *   done:  in-progress → done
- *   stuck: in-progress → stuck
- *   reset: in-progress/stuck → intake
+ *   pull:  add in-progress  (family label stays)
+ *   done:  remove in-progress, add done
+ *   stuck: remove in-progress, add stuck
+ *   reset: remove in-progress + stuck  (family label stays)
  *
  * PRD parent propagation helpers:
  *   prdInProgress: add in-progress label to PRD parent
@@ -20,6 +24,7 @@
  * returns a successful result without executing any `gh issue edit` calls.
  */
 import { execSync } from "child_process";
+import { IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL } from "./labels.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -77,36 +82,33 @@ function dryRunSkip(description: string): LabelTransitionResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Pull transition: intake → in-progress.
+ * Pull transition: add in-progress.
  *
- * Used when an issue is picked up from the backlog.
+ * Used when an issue is picked up from the backlog. The family label
+ * stays; only the shared `in-progress` label is added.
  */
 export function transitionPull(
   issue: IssueMeta,
-  intakeLabel: string,
-  inProgressLabel: string,
   cwd: string,
   dryRun = false,
 ): LabelTransitionResult {
   if (dryRun) {
-    return dryRunSkip(
-      `Issue #${issue.number}: ${intakeLabel} → ${inProgressLabel}`,
-    );
+    return dryRunSkip(`Issue #${issue.number}: add ${IN_PROGRESS_LABEL}`);
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${inProgressLabel}" --remove-label "${intakeLabel}"`,
+      `--add-label "${IN_PROGRESS_LABEL}"`,
     cwd,
   );
   if (result === null) {
     return {
       ok: false,
-      message: `Label swap failed for issue #${issue.number} (pull: ${intakeLabel} → ${inProgressLabel})`,
+      message: `Label add failed for issue #${issue.number} (pull: add ${IN_PROGRESS_LABEL})`,
     };
   }
   return {
     ok: true,
-    message: `Issue #${issue.number}: ${intakeLabel} → ${inProgressLabel}`,
+    message: `Issue #${issue.number}: added ${IN_PROGRESS_LABEL}`,
   };
 }
 
@@ -117,30 +119,28 @@ export function transitionPull(
  */
 export function transitionDone(
   issue: IssueMeta,
-  inProgressLabel: string,
-  doneLabel: string,
   cwd: string,
   dryRun = false,
 ): LabelTransitionResult {
   if (dryRun) {
     return dryRunSkip(
-      `Issue #${issue.number}: ${inProgressLabel} → ${doneLabel}`,
+      `Issue #${issue.number}: ${IN_PROGRESS_LABEL} → ${DONE_LABEL}`,
     );
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${doneLabel}" --remove-label "${inProgressLabel}"`,
+      `--add-label "${DONE_LABEL}" --remove-label "${IN_PROGRESS_LABEL}"`,
     cwd,
   );
   if (result === null) {
     return {
       ok: false,
-      message: `Label swap failed for issue #${issue.number} (done: ${inProgressLabel} → ${doneLabel})`,
+      message: `Label swap failed for issue #${issue.number} (done: ${IN_PROGRESS_LABEL} → ${DONE_LABEL})`,
     };
   }
   return {
     ok: true,
-    message: `Issue #${issue.number}: ${inProgressLabel} → ${doneLabel}`,
+    message: `Issue #${issue.number}: ${IN_PROGRESS_LABEL} → ${DONE_LABEL}`,
   };
 }
 
@@ -151,62 +151,49 @@ export function transitionDone(
  */
 export function transitionStuck(
   issue: IssueMeta,
-  inProgressLabel: string,
-  stuckLabel: string,
   cwd: string,
   dryRun = false,
 ): LabelTransitionResult {
   if (dryRun) {
     return dryRunSkip(
-      `Issue #${issue.number}: ${inProgressLabel} → ${stuckLabel}`,
+      `Issue #${issue.number}: ${IN_PROGRESS_LABEL} → ${STUCK_LABEL}`,
     );
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${stuckLabel}" --remove-label "${inProgressLabel}"`,
+      `--add-label "${STUCK_LABEL}" --remove-label "${IN_PROGRESS_LABEL}"`,
     cwd,
   );
   if (result === null) {
     return {
       ok: false,
-      message: `Label swap failed for issue #${issue.number} (stuck: ${inProgressLabel} → ${stuckLabel})`,
+      message: `Label swap failed for issue #${issue.number} (stuck: ${IN_PROGRESS_LABEL} → ${STUCK_LABEL})`,
     };
   }
   return {
     ok: true,
-    message: `Issue #${issue.number}: ${inProgressLabel} → ${stuckLabel}`,
+    message: `Issue #${issue.number}: ${IN_PROGRESS_LABEL} → ${STUCK_LABEL}`,
   };
 }
 
 /**
- * Reset transition: in-progress/stuck → intake.
+ * Reset transition: remove in-progress + stuck.
  *
  * Used by `ralphai reset` to return an issue to the pickup queue.
- * Removes both in-progress and stuck labels, adds the intake label.
- *
- * The optional `extraRemoveLabels` parameter allows callers to defensively
- * remove labels from a second family (e.g. removing standalone state labels
- * when resetting a sub-issue, in case the wrong family was applied).
- * `gh issue edit --remove-label` is a no-op for labels that aren't present.
+ * Removes both in-progress and stuck labels. The family label stays
+ * (it was never removed during pull).
  */
 export function transitionReset(
   issue: IssueMeta,
-  intakeLabel: string,
-  inProgressLabel: string,
-  stuckLabel: string,
   cwd: string,
   dryRun = false,
-  extraRemoveLabels: string[] = [],
 ): LabelTransitionResult {
   if (dryRun) {
-    return dryRunSkip(`Issue #${issue.number}: reset to ${intakeLabel}`);
+    return dryRunSkip(`Issue #${issue.number}: remove state labels`);
   }
-  let cmd =
+  const cmd =
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-    `--add-label "${intakeLabel}" --remove-label "${inProgressLabel}" --remove-label "${stuckLabel}"`;
-  for (const label of extraRemoveLabels) {
-    cmd += ` --remove-label "${label}"`;
-  }
+    `--remove-label "${IN_PROGRESS_LABEL}" --remove-label "${STUCK_LABEL}"`;
   const result = execQuiet(cmd, cwd);
   if (result === null) {
     return {
@@ -233,27 +220,26 @@ export function transitionReset(
  */
 export function prdTransitionInProgress(
   issue: IssueMeta,
-  prdInProgressLabel: string,
   cwd: string,
   dryRun = false,
 ): LabelTransitionResult {
   if (dryRun) {
-    return dryRunSkip(`PRD #${issue.number}: add ${prdInProgressLabel}`);
+    return dryRunSkip(`PRD #${issue.number}: add ${IN_PROGRESS_LABEL}`);
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${prdInProgressLabel}"`,
+      `--add-label "${IN_PROGRESS_LABEL}"`,
     cwd,
   );
   if (result === null) {
     return {
       ok: false,
-      message: `Failed to add ${prdInProgressLabel} to PRD #${issue.number}`,
+      message: `Failed to add ${IN_PROGRESS_LABEL} to PRD #${issue.number}`,
     };
   }
   return {
     ok: true,
-    message: `PRD #${issue.number}: added ${prdInProgressLabel}`,
+    message: `PRD #${issue.number}: added ${IN_PROGRESS_LABEL}`,
   };
 }
 
@@ -265,19 +251,17 @@ export function prdTransitionInProgress(
  */
 export function prdTransitionDone(
   issue: IssueMeta,
-  prdInProgressLabel: string,
-  prdDoneLabel: string,
   cwd: string,
   dryRun = false,
 ): LabelTransitionResult {
   if (dryRun) {
     return dryRunSkip(
-      `PRD #${issue.number}: ${prdInProgressLabel} → ${prdDoneLabel}`,
+      `PRD #${issue.number}: ${IN_PROGRESS_LABEL} → ${DONE_LABEL}`,
     );
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${prdDoneLabel}" --remove-label "${prdInProgressLabel}"`,
+      `--add-label "${DONE_LABEL}" --remove-label "${IN_PROGRESS_LABEL}"`,
     cwd,
   );
   if (result === null) {
@@ -288,7 +272,7 @@ export function prdTransitionDone(
   }
   return {
     ok: true,
-    message: `PRD #${issue.number}: ${prdInProgressLabel} → ${prdDoneLabel}`,
+    message: `PRD #${issue.number}: ${IN_PROGRESS_LABEL} → ${DONE_LABEL}`,
   };
 }
 
@@ -301,26 +285,25 @@ export function prdTransitionDone(
  */
 export function prdTransitionStuck(
   issue: IssueMeta,
-  prdStuckLabel: string,
   cwd: string,
   dryRun = false,
 ): LabelTransitionResult {
   if (dryRun) {
-    return dryRunSkip(`PRD #${issue.number}: add ${prdStuckLabel}`);
+    return dryRunSkip(`PRD #${issue.number}: add ${STUCK_LABEL}`);
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${prdStuckLabel}"`,
+      `--add-label "${STUCK_LABEL}"`,
     cwd,
   );
   if (result === null) {
     return {
       ok: false,
-      message: `Failed to add ${prdStuckLabel} to PRD #${issue.number}`,
+      message: `Failed to add ${STUCK_LABEL} to PRD #${issue.number}`,
     };
   }
   return {
     ok: true,
-    message: `PRD #${issue.number}: added ${prdStuckLabel}`,
+    message: `PRD #${issue.number}: added ${STUCK_LABEL}`,
   };
 }

--- a/src/labels.test.ts
+++ b/src/labels.test.ts
@@ -1,104 +1,36 @@
 import { describe, it, expect } from "bun:test";
-import { deriveLabels } from "./labels.ts";
+import {
+  IN_PROGRESS_LABEL,
+  DONE_LABEL,
+  STUCK_LABEL,
+  STATE_LABELS,
+} from "./labels.ts";
 
 // ---------------------------------------------------------------------------
-// deriveLabels — default names
+// Shared state label constants
 // ---------------------------------------------------------------------------
 
-describe("deriveLabels — default standalone name", () => {
-  it("derives four labels from ralphai-standalone", () => {
-    const labels = deriveLabels("ralphai-standalone");
-    expect(labels).toEqual({
-      intake: "ralphai-standalone",
-      inProgress: "ralphai-standalone:in-progress",
-      done: "ralphai-standalone:done",
-      stuck: "ralphai-standalone:stuck",
-    });
-  });
-});
-
-describe("deriveLabels — default subissue name", () => {
-  it("derives four labels from ralphai-subissue", () => {
-    const labels = deriveLabels("ralphai-subissue");
-    expect(labels).toEqual({
-      intake: "ralphai-subissue",
-      inProgress: "ralphai-subissue:in-progress",
-      done: "ralphai-subissue:done",
-      stuck: "ralphai-subissue:stuck",
-    });
-  });
-});
-
-describe("deriveLabels — default prd name", () => {
-  it("derives four labels from ralphai-prd including :stuck", () => {
-    const labels = deriveLabels("ralphai-prd");
-    expect(labels).toEqual({
-      intake: "ralphai-prd",
-      inProgress: "ralphai-prd:in-progress",
-      done: "ralphai-prd:done",
-      stuck: "ralphai-prd:stuck",
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// deriveLabels — custom names
-// ---------------------------------------------------------------------------
-
-describe("deriveLabels — custom base name", () => {
-  it("works with arbitrary base names", () => {
-    const labels = deriveLabels("my-team-label");
-    expect(labels).toEqual({
-      intake: "my-team-label",
-      inProgress: "my-team-label:in-progress",
-      done: "my-team-label:done",
-      stuck: "my-team-label:stuck",
-    });
+describe("shared state label constants", () => {
+  it("IN_PROGRESS_LABEL is 'in-progress'", () => {
+    expect(IN_PROGRESS_LABEL).toBe("in-progress");
   });
 
-  it("handles base names with colons", () => {
-    const labels = deriveLabels("org:task");
-    expect(labels).toEqual({
-      intake: "org:task",
-      inProgress: "org:task:in-progress",
-      done: "org:task:done",
-      stuck: "org:task:stuck",
-    });
+  it("DONE_LABEL is 'done'", () => {
+    expect(DONE_LABEL).toBe("done");
   });
 
-  it("handles single-word base name", () => {
-    const labels = deriveLabels("review");
-    expect(labels.intake).toBe("review");
-    expect(labels.inProgress).toBe("review:in-progress");
-    expect(labels.done).toBe("review:done");
-    expect(labels.stuck).toBe("review:stuck");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// deriveLabels — edge cases
-// ---------------------------------------------------------------------------
-
-describe("deriveLabels — edge cases", () => {
-  it("handles empty base name", () => {
-    const labels = deriveLabels("");
-    expect(labels).toEqual({
-      intake: "",
-      inProgress: ":in-progress",
-      done: ":done",
-      stuck: ":stuck",
-    });
+  it("STUCK_LABEL is 'stuck'", () => {
+    expect(STUCK_LABEL).toBe("stuck");
   });
 
-  it("handles base name with spaces", () => {
-    const labels = deriveLabels("my label");
-    expect(labels.intake).toBe("my label");
-    expect(labels.inProgress).toBe("my label:in-progress");
+  it("STATE_LABELS contains all three state labels", () => {
+    expect(STATE_LABELS).toEqual(["in-progress", "done", "stuck"]);
   });
 
-  it("handles base name with unicode", () => {
-    const labels = deriveLabels("ralphai-\u2713");
-    expect(labels.intake).toBe("ralphai-\u2713");
-    expect(labels.done).toBe("ralphai-\u2713:done");
+  it("state labels are plain strings without family prefixes", () => {
+    for (const label of STATE_LABELS) {
+      expect(label).not.toContain(":");
+      expect(label).not.toContain("ralphai");
+    }
   });
 });

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,45 +1,36 @@
 /**
- * Label derivation module — pure functions for deriving state-suffixed
- * GitHub labels from a base label name.
+ * Shared state label constants for GitHub issue tracking.
  *
- * Given a base name like "ralphai-standalone", deriveLabels returns:
- *   { intake: "ralphai-standalone",
- *     inProgress: "ralphai-standalone:in-progress",
- *     done: "ralphai-standalone:done",
- *     stuck: "ralphai-standalone:stuck" }
+ * Ralphai uses two kinds of labels on GitHub issues:
+ *
+ * 1. **Family labels** (configurable per repo):
+ *    - `ralphai-standalone`  — standalone issues
+ *    - `ralphai-subissue`    — PRD sub-issues
+ *    - `ralphai-prd`         — PRD parent issues
+ *
+ * 2. **State labels** (fixed, shared across all families):
+ *    - `in-progress`  — issue is being worked on
+ *    - `done`         — issue completed successfully
+ *    - `stuck`        — agent is stuck on this issue
+ *
+ * An issue carries its family label through all states. When a state
+ * transition occurs, only the state label changes — the family label
+ * stays. For example, a standalone issue that gets picked up will have
+ * both `ralphai-standalone` and `in-progress` labels.
  */
 
 // ---------------------------------------------------------------------------
-// Types
+// Shared state labels
 // ---------------------------------------------------------------------------
 
-/** The four state labels derived from a single base name. */
-export interface DerivedLabels {
-  /** The intake/triage label (the base name itself). */
-  intake: string;
-  /** The in-progress state label. */
-  inProgress: string;
-  /** The done state label. */
-  done: string;
-  /** The stuck state label. */
-  stuck: string;
-}
+/** Label added when an issue is picked up and work begins. */
+export const IN_PROGRESS_LABEL = "in-progress";
 
-// ---------------------------------------------------------------------------
-// Derivation
-// ---------------------------------------------------------------------------
+/** Label added when work completes successfully. */
+export const DONE_LABEL = "done";
 
-/**
- * Derive the four state labels from a base label name.
- *
- * The intake label is the base name itself. State suffixes are appended
- * with a colon separator: `:in-progress`, `:done`, `:stuck`.
- */
-export function deriveLabels(baseName: string): DerivedLabels {
-  return {
-    intake: baseName,
-    inProgress: `${baseName}:in-progress`,
-    done: `${baseName}:done`,
-    stuck: `${baseName}:stuck`,
-  };
-}
+/** Label added when the agent gets stuck on an issue. */
+export const STUCK_LABEL = "stuck";
+
+/** All state labels that can be removed during a reset. */
+export const STATE_LABELS = [IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL];

--- a/src/pr-lifecycle-subissue.test.ts
+++ b/src/pr-lifecycle-subissue.test.ts
@@ -1,9 +1,10 @@
 /**
- * Unit tests for archiveRun() sub-issue label behaviour.
+ * Unit tests for archiveRun() label behaviour with sub-issues.
  *
- * When a plan has `prd: <number>` in its frontmatter, archiveRun() should
- * use the subissue label family (ralphai-subissue:*) for the done transition
- * instead of the standalone labels.
+ * With shared state labels, archiveRun() uses the same `done` and
+ * `in-progress` labels regardless of whether the plan is a standalone
+ * issue or a sub-issue. This file verifies that the done transition
+ * works correctly for both plan types.
  *
  * Uses mock.module to control `child_process.execSync` so we can verify
  * the label arguments passed to `gh issue edit`.
@@ -64,8 +65,8 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("archiveRun — sub-issue label selection", () => {
-  it("uses subissue labels for done transition when plan has prd frontmatter", () => {
+describe("archiveRun — shared state labels for sub-issues", () => {
+  it("uses shared done label for sub-issue plans (prd frontmatter)", () => {
     mockGhAvailable();
 
     const wipDir = join(ctx.dir, "in-progress", "gh-201-sub-task");
@@ -79,16 +80,12 @@ describe("archiveRun — sub-issue label selection", () => {
     const result = archiveRun({
       wipFiles: [join(wipDir, "gh-201-sub-task.md")],
       archiveDir,
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneDoneLabel: "ralphai-standalone:done",
-      subissueInProgressLabel: "ralphai-subissue:in-progress",
-      subissueDoneLabel: "ralphai-subissue:done",
       cwd: ctx.dir,
     });
 
     expect(result.archived).toBe(true);
 
-    // Verify gh issue edit was called with subissue labels, not standalone
+    // Verify gh issue edit was called with shared state labels
     const ghEditCalls = mockExecSync.mock.calls.filter(
       (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("gh issue edit"),
@@ -96,13 +93,11 @@ describe("archiveRun — sub-issue label selection", () => {
     expect(ghEditCalls.length).toBe(1);
     const cmd = ghEditCalls[0]![0] as string;
     expect(cmd).toContain("gh issue edit 201");
-    expect(cmd).toContain('--add-label "ralphai-subissue:done"');
-    expect(cmd).toContain('--remove-label "ralphai-subissue:in-progress"');
-    // Should NOT contain standalone labels
-    expect(cmd).not.toContain("ralphai-standalone");
+    expect(cmd).toContain('--add-label "done"');
+    expect(cmd).toContain('--remove-label "in-progress"');
   });
 
-  it("uses standalone labels for done transition when plan has no prd frontmatter", () => {
+  it("uses the same shared labels for standalone issues (no prd frontmatter)", () => {
     mockGhAvailable();
 
     const wipDir = join(ctx.dir, "in-progress", "gh-42-fix-bug");
@@ -116,16 +111,12 @@ describe("archiveRun — sub-issue label selection", () => {
     const result = archiveRun({
       wipFiles: [join(wipDir, "gh-42-fix-bug.md")],
       archiveDir,
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneDoneLabel: "ralphai-standalone:done",
-      subissueInProgressLabel: "ralphai-subissue:in-progress",
-      subissueDoneLabel: "ralphai-subissue:done",
       cwd: ctx.dir,
     });
 
     expect(result.archived).toBe(true);
 
-    // Verify gh issue edit was called with standalone labels
+    // Verify gh issue edit was called with the same shared state labels
     const ghEditCalls = mockExecSync.mock.calls.filter(
       (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("gh issue edit"),
@@ -133,42 +124,59 @@ describe("archiveRun — sub-issue label selection", () => {
     expect(ghEditCalls.length).toBe(1);
     const cmd = ghEditCalls[0]![0] as string;
     expect(cmd).toContain("gh issue edit 42");
-    expect(cmd).toContain('--add-label "ralphai-standalone:done"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
-    // Should NOT contain subissue labels
-    expect(cmd).not.toContain("ralphai-subissue");
+    expect(cmd).toContain('--add-label "done"');
+    expect(cmd).toContain('--remove-label "in-progress"');
   });
 
-  it("falls back to standalone labels when subissue labels are not provided for a sub-issue", () => {
+  it("both standalone and sub-issue use identical label transitions", () => {
     mockGhAvailable();
 
-    const wipDir = join(ctx.dir, "in-progress", "gh-201-sub-task");
-    const archiveDir = join(ctx.dir, "out");
-    mkdirSync(wipDir, { recursive: true });
+    // Sub-issue plan
+    const wipDir1 = join(ctx.dir, "in-progress", "gh-201-sub-task");
+    mkdirSync(wipDir1, { recursive: true });
     writeFileSync(
-      join(wipDir, "gh-201-sub-task.md"),
+      join(wipDir1, "gh-201-sub-task.md"),
       "---\nsource: github\nissue: 201\nprd: 100\nissue-url: https://github.com/owner/repo/issues/201\n---\n\n# Sub task\n",
     );
 
-    // Do NOT pass subissue label options — should fall back to standalone
-    const result = archiveRun({
-      wipFiles: [join(wipDir, "gh-201-sub-task.md")],
-      archiveDir,
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneDoneLabel: "ralphai-standalone:done",
+    archiveRun({
+      wipFiles: [join(wipDir1, "gh-201-sub-task.md")],
+      archiveDir: join(ctx.dir, "out1"),
       cwd: ctx.dir,
     });
 
-    expect(result.archived).toBe(true);
+    // Standalone plan
+    const wipDir2 = join(ctx.dir, "in-progress", "gh-42-fix-bug");
+    mkdirSync(wipDir2, { recursive: true });
+    writeFileSync(
+      join(wipDir2, "gh-42-fix-bug.md"),
+      "---\nsource: github\nissue: 42\nissue-url: https://github.com/owner/repo/issues/42\n---\n\n# Fix bug\n",
+    );
 
+    archiveRun({
+      wipFiles: [join(wipDir2, "gh-42-fix-bug.md")],
+      archiveDir: join(ctx.dir, "out2"),
+      cwd: ctx.dir,
+    });
+
+    // Both calls should use the same shared state labels
     const ghEditCalls = mockExecSync.mock.calls.filter(
       (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("gh issue edit"),
     );
-    expect(ghEditCalls.length).toBe(1);
-    const cmd = ghEditCalls[0]![0] as string;
-    // Falls back to standalone since subissue labels not provided
-    expect(cmd).toContain('--add-label "ralphai-standalone:done"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
+    expect(ghEditCalls.length).toBe(2);
+
+    const cmd1 = ghEditCalls[0]![0] as string;
+    const cmd2 = ghEditCalls[1]![0] as string;
+
+    // Extract just the label parts (everything after the issue number)
+    const labelPart1 = cmd1.replace(/gh issue edit \d+/, "");
+    const labelPart2 = cmd2.replace(/gh issue edit \d+/, "");
+
+    // Same label operations for both families
+    expect(labelPart1).toContain('--add-label "done"');
+    expect(labelPart2).toContain('--add-label "done"');
+    expect(labelPart1).toContain('--remove-label "in-progress"');
+    expect(labelPart2).toContain('--remove-label "in-progress"');
   });
 });

--- a/src/pr-lifecycle.test.ts
+++ b/src/pr-lifecycle.test.ts
@@ -108,8 +108,6 @@ describe("archiveRun", () => {
     const result = archiveRun({
       wipFiles: [],
       archiveDir: join(ctx.dir, "out"),
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneDoneLabel: "ralphai-standalone:done",
       cwd: ctx.dir,
     });
     expect(result.archived).toBe(false);
@@ -128,8 +126,6 @@ describe("archiveRun", () => {
     const result = archiveRun({
       wipFiles: [join(wipDir, "plan.md"), join(wipDir, "progress.md")],
       archiveDir,
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneDoneLabel: "ralphai-standalone:done",
       cwd: ctx.dir,
     });
 
@@ -151,8 +147,6 @@ describe("archiveRun", () => {
     archiveRun({
       wipFiles: [join(wipDir, "plan.md")],
       archiveDir,
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneDoneLabel: "ralphai-standalone:done",
       cwd: ctx.dir,
     });
 
@@ -174,8 +168,6 @@ describe("archiveRun", () => {
     const result = archiveRun({
       wipFiles: [join(wipDir, "plan.md")],
       archiveDir,
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneDoneLabel: "ralphai-standalone:done",
       cwd: ctx.dir,
     });
 

--- a/src/pr-lifecycle.ts
+++ b/src/pr-lifecycle.ts
@@ -89,12 +89,6 @@ export interface ContinuousPrOptions {
 export interface ArchiveRunOptions {
   wipFiles: string[];
   archiveDir: string;
-  standaloneInProgressLabel: string;
-  standaloneDoneLabel: string;
-  /** Sub-issue in-progress label (e.g. "ralphai-subissue:in-progress"). */
-  subissueInProgressLabel?: string;
-  /** Sub-issue done label (e.g. "ralphai-subissue:done"). */
-  subissueDoneLabel?: string;
   cwd: string;
 }
 
@@ -166,15 +160,7 @@ export function archiveRun(options: ArchiveRunOptions): {
   archived: boolean;
   message: string;
 } {
-  const {
-    wipFiles,
-    archiveDir,
-    standaloneInProgressLabel,
-    standaloneDoneLabel,
-    subissueInProgressLabel,
-    subissueDoneLabel,
-    cwd,
-  } = options;
+  const { wipFiles, archiveDir, cwd } = options;
   if (wipFiles.length === 0) {
     return { archived: false, message: "No WIP files to archive" };
   }
@@ -188,25 +174,14 @@ export function archiveRun(options: ArchiveRunOptions): {
   let issueSource = "";
   let issueNumber: number | undefined;
   let issueUrl = "";
-  let isSubIssue = false;
   for (const f of wipFiles) {
     if (!existsSync(f)) continue;
     const fm = extractIssueFrontmatter(f);
     issueSource = fm.source;
     issueNumber = fm.issue;
     issueUrl = fm.issueUrl;
-    if (fm.prd !== undefined) isSubIssue = true;
     if (issueSource === "github") break;
   }
-
-  // Choose the correct label family: sub-issues use subissue labels when
-  // available, standalone issues use standalone labels.
-  const issueInProgressLabel =
-    isSubIssue && subissueInProgressLabel
-      ? subissueInProgressLabel
-      : standaloneInProgressLabel;
-  const issueDoneLabel =
-    isSubIssue && subissueDoneLabel ? subissueDoneLabel : standaloneDoneLabel;
 
   const dest = join(archiveDir, planSlug);
   renameSync(planDir, dest);
@@ -227,12 +202,7 @@ export function archiveRun(options: ArchiveRunOptions): {
           `--body "Ralphai completed this task and is preparing to merge."`,
         cwd,
       );
-      transitionDone(
-        { number: issueNumber, repo },
-        issueInProgressLabel,
-        issueDoneLabel,
-        cwd,
-      );
+      transitionDone({ number: issueNumber, repo }, cwd);
     }
   }
 

--- a/src/prd-done-detection.test.ts
+++ b/src/prd-done-detection.test.ts
@@ -4,6 +4,9 @@
  *
  * Uses mock.module to control `child_process.execSync` so we can test
  * the full flow without requiring a real GitHub repo or gh CLI.
+ *
+ * The shared "done" label is used for all issue families (standalone,
+ * subissue, PRD). checkAllPrdSubIssuesDone checks for this fixed label.
  */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -37,7 +40,6 @@ const { checkAllPrdSubIssuesDone } = await import("./issues.ts");
 
 const REPO = "acme/widgets";
 const PRD_NUMBER = 100;
-const DONE_LABEL = "ralphai-subissue:done";
 
 /**
  * Build a command router that dispatches gh calls to handler functions.
@@ -77,12 +79,7 @@ describe("checkAllPrdSubIssuesDone", () => {
         ]),
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(true);
   });
 
@@ -93,16 +90,11 @@ describe("checkAllPrdSubIssuesDone", () => {
           { number: 201, state: "open" },
           { number: 202, state: "open" },
         ]),
-      "gh issue view 201": () => "ralphai-subissue:done",
-      "gh issue view 202": () => "ralphai-subissue:done",
+      "gh issue view 201": () => "done",
+      "gh issue view 202": () => "done",
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(true);
   });
 
@@ -113,15 +105,10 @@ describe("checkAllPrdSubIssuesDone", () => {
           { number: 201, state: "closed" },
           { number: 202, state: "open" },
         ]),
-      "gh issue view 202": () => "ralphai-subissue:done",
+      "gh issue view 202": () => "done",
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(true);
   });
 
@@ -132,16 +119,11 @@ describe("checkAllPrdSubIssuesDone", () => {
           { number: 201, state: "open" },
           { number: 202, state: "open" },
         ]),
-      "gh issue view 201": () => "ralphai-subissue:done",
-      "gh issue view 202": () => "ralphai-subissue:in-progress",
+      "gh issue view 201": () => "done",
+      "gh issue view 202": () => "in-progress",
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
   });
 
@@ -152,12 +134,7 @@ describe("checkAllPrdSubIssuesDone", () => {
       "gh issue view 201": () => "",
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
   });
 
@@ -168,12 +145,7 @@ describe("checkAllPrdSubIssuesDone", () => {
       },
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
   });
 
@@ -182,12 +154,7 @@ describe("checkAllPrdSubIssuesDone", () => {
       "gh api repos/acme/widgets/issues/100/sub_issues": () => "not json",
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
   });
 
@@ -197,12 +164,7 @@ describe("checkAllPrdSubIssuesDone", () => {
         JSON.stringify([]),
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
   });
 
@@ -212,12 +174,7 @@ describe("checkAllPrdSubIssuesDone", () => {
         JSON.stringify({ error: "not found" }),
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
   });
 
@@ -230,30 +187,8 @@ describe("checkAllPrdSubIssuesDone", () => {
       },
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
-  });
-
-  it("works with custom done labels", () => {
-    const customDoneLabel = "my-custom:done";
-    mockGhCommands({
-      "gh api repos/acme/widgets/issues/100/sub_issues": () =>
-        JSON.stringify([{ number: 201, state: "open" }]),
-      "gh issue view 201": () => "my-custom:done",
-    });
-
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      customDoneLabel,
-      "/tmp",
-    );
-    expect(result).toBe(true);
   });
 
   it("short-circuits on first non-done open sub-issue", () => {
@@ -266,21 +201,16 @@ describe("checkAllPrdSubIssuesDone", () => {
           { number: 202, state: "open" },
         ]),
       "gh issue view": (cmd: string) => {
-        if (cmd.includes("201")) return "ralphai-subissue:in-progress";
+        if (cmd.includes("201")) return "in-progress";
         if (cmd.includes("202")) {
           issue202Checked = true;
-          return "ralphai-subissue:done";
+          return "done";
         }
         throw new Error(`Unexpected: ${cmd}`);
       },
     });
 
-    const result = checkAllPrdSubIssuesDone(
-      REPO,
-      PRD_NUMBER,
-      DONE_LABEL,
-      "/tmp",
-    );
+    const result = checkAllPrdSubIssuesDone(REPO, PRD_NUMBER, "/tmp");
     expect(result).toBe(false);
     expect(issue202Checked).toBe(false);
   });
@@ -300,14 +230,8 @@ describe("stuck stickiness — design verification", () => {
 
     const subIssue = { number: 201, repo: "org/repo" };
 
-    // Reset the sub-issue: subissue labels are restored
-    const result = transitionReset(
-      subIssue,
-      "ralphai-subissue",
-      "ralphai-subissue:in-progress",
-      "ralphai-subissue:stuck",
-      "/tmp",
-    );
+    // Reset the sub-issue: removes shared state labels
+    const result = transitionReset(subIssue, "/tmp");
     expect(result.ok).toBe(true);
 
     // Verify only ONE gh issue edit call was made — for the sub-issue
@@ -321,13 +245,10 @@ describe("stuck stickiness — design verification", () => {
     expect(ghCalls).toHaveLength(1);
     // The call targets the sub-issue (#201), NOT the PRD parent
     expect(ghCalls[0]).toContain("gh issue edit 201");
-    // It restores subissue labels — no PRD labels involved
-    expect(ghCalls[0]).toContain('--add-label "ralphai-subissue"');
-    expect(ghCalls[0]).toContain(
-      '--remove-label "ralphai-subissue:in-progress"',
-    );
-    expect(ghCalls[0]).toContain('--remove-label "ralphai-subissue:stuck"');
-    // PRD stuck label is NOT touched
+    // It removes shared state labels
+    expect(ghCalls[0]).toContain('--remove-label "in-progress"');
+    expect(ghCalls[0]).toContain('--remove-label "stuck"');
+    // PRD labels are NOT touched
     expect(ghCalls[0]).not.toContain("ralphai-prd");
   });
 });

--- a/src/pull-issue-by-number.test.ts
+++ b/src/pull-issue-by-number.test.ts
@@ -54,13 +54,7 @@ function defaultOptions(
     cwd: dir,
     issueSource: "github",
     standaloneLabel: "ralphai-standalone",
-    standaloneInProgressLabel: "ralphai-standalone:in-progress",
-    standaloneDoneLabel: "ralphai-standalone:done",
-    standaloneStuckLabel: "ralphai-standalone:stuck",
     subissueLabel: "ralphai-subissue",
-    subissueInProgressLabel: "ralphai-subissue:in-progress",
-    subissueDoneLabel: "ralphai-subissue:done",
-    subissueStuckLabel: "ralphai-subissue:stuck",
     issueRepo: "owner/repo",
     issueCommentProgress: false,
     issueNumber: 201,
@@ -140,27 +134,24 @@ describe("pullGithubIssueByNumber — sub-issue label selection", () => {
     const result = pullGithubIssueByNumber(defaultOptions(dir));
     expect(result.pulled).toBe(true);
 
-    // Verify the transitionPull call used subissue labels, NOT standalone
+    // Verify the transitionPull call used shared state labels
     const editCalls = ghEditCalls();
     expect(editCalls.length).toBe(1);
     const cmd = editCalls[0]!;
 
-    // Should use subissue labels
-    expect(cmd).toContain('--add-label "ralphai-subissue:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-subissue"');
-
-    // Should NOT contain standalone labels in the edit call
-    expect(cmd).not.toContain("ralphai-standalone:in-progress");
-    expect(cmd).not.toContain('--remove-label "ralphai-standalone"');
+    // Should use shared in-progress label (same for all families)
+    expect(cmd).toContain('--add-label "in-progress"');
+    // Family label is not touched during pull
+    expect(cmd).not.toContain("--remove-label");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Cycle 2: Standalone issue (no PRD parent) should use standalone labels
+// Cycle 2: Standalone issue (no PRD parent) uses same shared labels
 // ---------------------------------------------------------------------------
 
 describe("pullGithubIssueByNumber — standalone label selection", () => {
-  it("uses standalone labels when issue has no PRD parent", () => {
+  it("uses the same shared labels when issue has no PRD parent", () => {
     mockGhCommands({
       'gh issue view 42 --repo "owner/repo" --json title --jq': () =>
         "Standalone bug",
@@ -187,15 +178,13 @@ describe("pullGithubIssueByNumber — standalone label selection", () => {
     const result = pullGithubIssueByNumber(opts);
     expect(result.pulled).toBe(true);
 
-    // Verify standalone labels were used
+    // Verify shared state labels were used
     const editCalls = ghEditCalls();
     expect(editCalls.length).toBe(1);
     const cmd = editCalls[0]!;
 
-    expect(cmd).toContain('--add-label "ralphai-standalone:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone"');
-
-    // Should NOT contain subissue labels
-    expect(cmd).not.toContain("ralphai-subissue");
+    expect(cmd).toContain('--add-label "in-progress"');
+    // Family label is not touched during pull
+    expect(cmd).not.toContain("--remove-label");
   });
 });

--- a/src/pull-prd-sub-issue.test.ts
+++ b/src/pull-prd-sub-issue.test.ts
@@ -52,13 +52,7 @@ function defaultOptions(dir: string): PullIssueOptions {
     cwd: dir,
     issueSource: "github",
     standaloneLabel: "ralphai-standalone",
-    standaloneInProgressLabel: "ralphai-standalone:in-progress",
-    standaloneDoneLabel: "ralphai-standalone:done",
-    standaloneStuckLabel: "ralphai-standalone:stuck",
     subissueLabel: "ralphai-subissue",
-    subissueInProgressLabel: "ralphai-subissue:in-progress",
-    subissueDoneLabel: "ralphai-subissue:done",
-    subissueStuckLabel: "ralphai-subissue:stuck",
     issueRepo: "owner/repo",
     issueCommentProgress: false,
   };
@@ -270,10 +264,9 @@ describe("pullPrdSubIssue — sub-issues via REST API", () => {
         JSON.stringify(subIssues),
       // #201 has in-progress label
       'gh issue view 201 --repo "owner/repo" --json labels': () =>
-        "ralphai-subissue:in-progress",
+        "in-progress",
       // #202 has done label
-      'gh issue view 202 --repo "owner/repo" --json labels': () =>
-        "ralphai-subissue:done",
+      'gh issue view 202 --repo "owner/repo" --json labels': () => "done",
       // #203 has no skip labels
       'gh issue view 203 --repo "owner/repo" --json labels': () => "",
       'gh issue view 203 --repo "owner/repo" --json title --jq': () =>
@@ -314,9 +307,8 @@ describe("pullPrdSubIssue — sub-issues via REST API", () => {
       "gh api repos/owner/repo/issues/100/sub_issues": () =>
         JSON.stringify(subIssues),
       'gh issue view 201 --repo "owner/repo" --json labels': () =>
-        "ralphai-subissue:in-progress",
-      'gh issue view 202 --repo "owner/repo" --json labels': () =>
-        "ralphai-subissue:done",
+        "in-progress",
+      'gh issue view 202 --repo "owner/repo" --json labels': () => "done",
     });
 
     const dir = makeTempDir();
@@ -339,8 +331,7 @@ describe("pullPrdSubIssue — sub-issues via REST API", () => {
       "gh api repos/owner/repo/issues/100/sub_issues": () =>
         JSON.stringify(subIssues),
       // #201 has stuck label — should be skipped
-      'gh issue view 201 --repo "owner/repo" --json labels': () =>
-        "ralphai-subissue:stuck",
+      'gh issue view 201 --repo "owner/repo" --json labels': () => "stuck",
       // #202 has no skip labels
       'gh issue view 202 --repo "owner/repo" --json labels': () => "",
       'gh issue view 202 --repo "owner/repo" --json title --jq': () =>
@@ -743,111 +734,7 @@ describe("pullPrdSubIssue — PRD in-progress label on parent", () => {
 
     // Verify an edit call was made to add the in-progress label to PRD parent #100
     const prdEditCall = editCalls.find(
-      (c) => c.includes("100") && c.includes("ralphai-prd:in-progress"),
-    );
-    expect(prdEditCall).toBeDefined();
-    expect(prdEditCall).toContain("--add-label");
-  });
-
-  it("uses custom issuePrdInProgressLabel when provided", () => {
-    const prdIssues = [{ number: 100, title: "Feature PRD" }];
-    const subIssues = [{ number: 201, title: "Sub A", state: "open" }];
-
-    const editCalls: string[] = [];
-    mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd === "gh --version" || cmd === "gh auth status") {
-        return "ok";
-      }
-      if (typeof cmd === "string" && cmd.includes("gh issue edit")) {
-        editCalls.push(cmd);
-        return "";
-      }
-      if (cmd.includes("gh issue list")) return JSON.stringify(prdIssues);
-      if (cmd.includes("gh api repos/owner/repo/issues/100/sub_issues"))
-        return JSON.stringify(subIssues);
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json labels"))
-        return "";
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json title"))
-        return "Sub A";
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json body"))
-        return "Sub A body";
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json url"))
-        return "https://github.com/owner/repo/issues/201";
-      if (cmd.includes("gh api repos/owner/repo/issues/201/parent"))
-        return JSON.stringify({
-          number: 100,
-          labels: [{ name: "ralphai-prd" }],
-        });
-      if (cmd.includes("gh api graphql"))
-        return JSON.stringify({
-          data: { repository: { issue: { blockedBy: { nodes: [] } } } },
-        });
-      throw new Error(`Unexpected command: ${cmd}`);
-    });
-
-    const dir = makeTempDir();
-    const opts = {
-      ...defaultOptions(dir),
-      issuePrdInProgressLabel: "custom-prd:wip",
-    };
-    const result = pullPrdSubIssue(opts);
-    expect(result.pulled).toBe(true);
-
-    // Verify the custom label was used
-    const prdEditCall = editCalls.find(
-      (c) => c.includes("100") && c.includes("custom-prd:wip"),
-    );
-    expect(prdEditCall).toBeDefined();
-    expect(prdEditCall).toContain("--add-label");
-  });
-
-  it("uses custom issuePrdInProgressLabel when provided", () => {
-    const prdIssues = [{ number: 100, title: "Feature PRD" }];
-    const subIssues = [{ number: 201, title: "Sub A", state: "open" }];
-
-    const editCalls: string[] = [];
-    mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd === "gh --version" || cmd === "gh auth status") {
-        return "ok";
-      }
-      if (typeof cmd === "string" && cmd.includes("gh issue edit")) {
-        editCalls.push(cmd);
-        return "";
-      }
-      if (cmd.includes("gh issue list")) return JSON.stringify(prdIssues);
-      if (cmd.includes("gh api repos/owner/repo/issues/100/sub_issues"))
-        return JSON.stringify(subIssues);
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json labels"))
-        return "";
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json title"))
-        return "Sub A";
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json body"))
-        return "Sub A body";
-      if (cmd.includes("gh issue view 201") && cmd.includes("--json url"))
-        return "https://github.com/owner/repo/issues/201";
-      if (cmd.includes("gh api repos/owner/repo/issues/201/parent"))
-        return JSON.stringify({
-          number: 100,
-          labels: [{ name: "ralphai-prd" }],
-        });
-      if (cmd.includes("gh api graphql"))
-        return JSON.stringify({
-          data: { repository: { issue: { blockedBy: { nodes: [] } } } },
-        });
-      throw new Error(`Unexpected command: ${cmd}`);
-    });
-
-    const dir = makeTempDir();
-    const opts = {
-      ...defaultOptions(dir),
-      issuePrdInProgressLabel: "custom-prd:wip",
-    };
-    const result = pullPrdSubIssue(opts);
-    expect(result.pulled).toBe(true);
-
-    // Verify the custom label was used
-    const prdEditCall = editCalls.find(
-      (c) => c.includes("100") && c.includes("custom-prd:wip"),
+      (c) => c.includes("100") && c.includes('"in-progress"'),
     );
     expect(prdEditCall).toBeDefined();
     expect(prdEditCall).toContain("--add-label");
@@ -905,16 +792,9 @@ describe("pullPrdSubIssue — subissue label family in transitionPull", () => {
     );
     expect(subIssueEditCall).toBeDefined();
 
-    // Verify subissue labels were used
-    expect(subIssueEditCall).toContain(
-      '--add-label "ralphai-subissue:in-progress"',
-    );
-    expect(subIssueEditCall).toContain('--remove-label "ralphai-subissue"');
-
-    // Should NOT contain standalone labels in the sub-issue transition
-    expect(subIssueEditCall).not.toContain("ralphai-standalone:in-progress");
-    expect(subIssueEditCall).not.toContain(
-      '--remove-label "ralphai-standalone"',
-    );
+    // Verify shared state labels were used (same for all families)
+    expect(subIssueEditCall).toContain('--add-label "in-progress"');
+    // Family label is not touched during pull
+    expect(subIssueEditCall).not.toContain("--remove-label");
   });
 });

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -47,7 +47,7 @@ import {
   DEFAULTS,
 } from "./config.ts";
 import { formatShowConfig } from "./show-config.ts";
-import { deriveLabels, type DerivedLabels } from "./labels.ts";
+import { IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL } from "./labels.ts";
 import {
   prdTransitionInProgress,
   prdTransitionDone,
@@ -318,9 +318,9 @@ interface LabelResult {
 }
 
 interface LabelNames {
-  standalone: DerivedLabels;
-  subissue: DerivedLabels;
-  prd: DerivedLabels;
+  standalone: string;
+  subissue: string;
+  prd: string;
 }
 
 /** Build a `gh label create` command string for a given label. */
@@ -336,9 +336,10 @@ function ghLabelCreateCmd(
 
 /** The label definitions with their descriptions and colors.
  *
- * Produces 12 labels: 3 families (standalone, subissue, prd) × 4 states
- * (intake, in-progress, done, stuck). Each family has a distinct intake
- * color; state colors (yellow, green, red) are shared across families.
+ * Produces 6 labels: 3 family labels (standalone, subissue, prd) with
+ * distinct colors, plus 3 shared state labels (in-progress, done, stuck)
+ * with shared colors. Issues carry their family label through all states;
+ * state labels are added/removed as the issue progresses.
  */
 function labelDefs(names: LabelNames) {
   // Intake colors — one per family
@@ -352,67 +353,36 @@ function labelDefs(names: LabelNames) {
   const STUCK_COLOR = "d93f0b"; // red
 
   return [
-    // Standalone family
+    // Family labels
     {
-      name: names.standalone.intake,
+      name: names.standalone,
       description: "Ralphai picks up this standalone issue",
       color: STANDALONE_INTAKE_COLOR,
     },
     {
-      name: names.standalone.inProgress,
-      description: "Ralphai is working on this standalone issue",
-      color: IN_PROGRESS_COLOR,
-    },
-    {
-      name: names.standalone.done,
-      description: "Ralphai finished this standalone issue",
-      color: DONE_COLOR,
-    },
-    {
-      name: names.standalone.stuck,
-      description: "Ralphai is stuck on this standalone issue",
-      color: STUCK_COLOR,
-    },
-    // Subissue family
-    {
-      name: names.subissue.intake,
+      name: names.subissue,
       description: "Ralphai picks up this PRD sub-issue",
       color: SUBISSUE_INTAKE_COLOR,
     },
     {
-      name: names.subissue.inProgress,
-      description: "Ralphai is working on this PRD sub-issue",
-      color: IN_PROGRESS_COLOR,
-    },
-    {
-      name: names.subissue.done,
-      description: "Ralphai finished this PRD sub-issue",
-      color: DONE_COLOR,
-    },
-    {
-      name: names.subissue.stuck,
-      description: "Ralphai is stuck on this PRD sub-issue",
-      color: STUCK_COLOR,
-    },
-    // PRD family
-    {
-      name: names.prd.intake,
+      name: names.prd,
       description: "Ralphai PRD — groups sub-issues for drain runs",
       color: PRD_INTAKE_COLOR,
     },
+    // Shared state labels
     {
-      name: names.prd.inProgress,
-      description: "Ralphai is processing this PRD's sub-issues",
+      name: IN_PROGRESS_LABEL,
+      description: "Ralphai is working on this issue",
       color: IN_PROGRESS_COLOR,
     },
     {
-      name: names.prd.done,
-      description: "Ralphai finished all sub-issues for this PRD",
+      name: DONE_LABEL,
+      description: "Ralphai finished this issue",
       color: DONE_COLOR,
     },
     {
-      name: names.prd.stuck,
-      description: "Ralphai is stuck processing this PRD",
+      name: STUCK_LABEL,
+      description: "Ralphai is stuck on this issue",
       color: STUCK_COLOR,
     },
   ];
@@ -540,9 +510,9 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
 
   // Create GitHub labels if issues integration is enabled
   const initLabelNames: LabelNames = {
-    standalone: deriveLabels(configObj.standaloneLabel as string),
-    subissue: deriveLabels(configObj.subissueLabel as string),
-    prd: deriveLabels(configObj.prdLabel as string),
+    standalone: configObj.standaloneLabel as string,
+    subissue: configObj.subissueLabel as string,
+    prd: configObj.prdLabel as string,
   };
   let labelResult: LabelResult | null = null;
   if (answers.issueSource === "github") {
@@ -571,19 +541,19 @@ function scaffold(answers: WizardAnswers, cwd: string): void {
   if (labelResult) {
     if (labelResult.success) {
       console.log(
-        `  GitHub labels              ${DIM}Created 12 labels across 3 families:${RESET}`,
+        `  GitHub labels              ${DIM}Created 6 labels (3 family + 3 shared state):${RESET}`,
       );
       console.log(
-        `    ${TEXT}${configObj.standaloneLabel}${RESET}       ${DIM}Intake label for standalone issues${RESET}`,
+        `    ${TEXT}${configObj.standaloneLabel}${RESET}       ${DIM}Family label for standalone issues${RESET}`,
       );
       console.log(
-        `    ${TEXT}${configObj.subissueLabel}${RESET}         ${DIM}Intake label for PRD sub-issues${RESET}`,
+        `    ${TEXT}${configObj.subissueLabel}${RESET}         ${DIM}Family label for PRD sub-issues${RESET}`,
       );
       console.log(
-        `    ${TEXT}${configObj.prdLabel}${RESET}              ${DIM}Intake label for PRD parent issues${RESET}`,
+        `    ${TEXT}${configObj.prdLabel}${RESET}              ${DIM}Family label for PRD parent issues${RESET}`,
       );
       console.log(
-        `                             ${DIM}Each has :in-progress, :done, and :stuck variants${RESET}`,
+        `                             ${DIM}Shared state: in-progress, done, stuck${RESET}`,
       );
     } else {
       console.log();
@@ -714,14 +684,8 @@ async function runRalphaiReset(
 
   let actions = 0;
 
-  // Load config to get label names for GitHub issue restoration.
+  // Load config to get issue repo for GitHub issue restoration.
   // Best-effort: if config resolution fails we skip label restoration.
-  let standaloneLabel = "";
-  let standaloneInProgressLabel = "";
-  let standaloneStuckLabel = "";
-  let subissueLabel = "";
-  let subissueInProgressLabel = "";
-  let subissueStuckLabel = "";
   let issueRepo = "";
   try {
     const cfgResult = resolveConfig({
@@ -729,18 +693,6 @@ async function runRalphaiReset(
       envVars: process.env,
       cliArgs: [],
     });
-    const standaloneLabelsResolved = deriveLabels(
-      cfgResult.config.standaloneLabel.value,
-    );
-    standaloneLabel = standaloneLabelsResolved.intake;
-    standaloneInProgressLabel = standaloneLabelsResolved.inProgress;
-    standaloneStuckLabel = standaloneLabelsResolved.stuck;
-    const subissueLabelsResolved = deriveLabels(
-      cfgResult.config.subissueLabel.value,
-    );
-    subissueLabel = subissueLabelsResolved.intake;
-    subissueInProgressLabel = subissueLabelsResolved.inProgress;
-    subissueStuckLabel = subissueLabelsResolved.stuck;
     issueRepo = cfgResult.config.issueRepo.value;
   } catch {
     // Config resolution failure is not critical — skip label restoration.
@@ -754,15 +706,9 @@ async function runRalphaiReset(
     mkdirSync(backlogDir, { recursive: true });
 
     // Restore GitHub issue labels before moving the file (needs frontmatter).
-    if (standaloneLabel && standaloneInProgressLabel && existsSync(planFile)) {
+    if (existsSync(planFile)) {
       const labelResult = restoreIssueLabels({
         planPath: planFile,
-        standaloneLabel,
-        standaloneInProgressLabel,
-        standaloneStuckLabel,
-        subissueLabel,
-        subissueInProgressLabel,
-        subissueStuckLabel,
         issueRepo,
         cwd,
       });
@@ -874,34 +820,14 @@ export function resetPlanBySlug(cwd: string, slug: string): void {
         envVars: process.env,
         cliArgs: [],
       });
-      const standaloneLabelsResolved = deriveLabels(
-        cfgResult.config.standaloneLabel.value,
-      );
-      const standaloneLabel = standaloneLabelsResolved.intake;
-      const standaloneInProgressLabel = standaloneLabelsResolved.inProgress;
-      const standaloneStuckLabel = standaloneLabelsResolved.stuck;
-      const subissueLabelsResolved = deriveLabels(
-        cfgResult.config.subissueLabel.value,
-      );
-      const subissueLabel = subissueLabelsResolved.intake;
-      const subissueInProgressLabel = subissueLabelsResolved.inProgress;
-      const subissueStuckLabel = subissueLabelsResolved.stuck;
       const issueRepo = cfgResult.config.issueRepo.value;
-      if (standaloneLabel && standaloneInProgressLabel) {
-        const labelResult = restoreIssueLabels({
-          planPath: planFile,
-          standaloneLabel,
-          standaloneInProgressLabel,
-          standaloneStuckLabel,
-          subissueLabel,
-          subissueInProgressLabel,
-          subissueStuckLabel,
-          issueRepo,
-          cwd,
-        });
-        if (labelResult.restored) {
-          console.log(`  ${DIM}${labelResult.message}${RESET}`);
-        }
+      const labelResult = restoreIssueLabels({
+        planPath: planFile,
+        issueRepo,
+        cwd,
+      });
+      if (labelResult.restored) {
+        console.log(`  ${DIM}${labelResult.message}${RESET}`);
       }
     } catch {
       // Config resolution failure is not critical — skip label restoration.
@@ -1854,12 +1780,7 @@ async function runIssueTarget(
     backlogDir,
     cwd: resolvedWorktreeDir,
     issueSource: "github",
-    standaloneLabel: deriveLabels(worktreeConfig.standaloneLabel.value).intake,
-    standaloneInProgressLabel: deriveLabels(
-      worktreeConfig.standaloneLabel.value,
-    ).inProgress,
-    standaloneDoneLabel: deriveLabels(worktreeConfig.standaloneLabel.value)
-      .done,
+    standaloneLabel: worktreeConfig.standaloneLabel.value,
     issueRepo: worktreeConfig.issueRepo.value || repo,
     issueCommentProgress: worktreeConfig.issueCommentProgress.value === "true",
     issueNumber,
@@ -1991,14 +1912,7 @@ async function runPrdIssueTarget(
   // --- PRD with unchecked sub-issues: work through sequentially ---
 
   // Best-effort: mark the PRD parent as in-progress before processing sub-issues.
-  const prdInProgressLabel = deriveLabels(
-    worktreeConfig.prdLabel?.value ?? DEFAULTS.prdLabel,
-  ).inProgress;
-  prdTransitionInProgress(
-    { number: prd.number, repo },
-    prdInProgressLabel,
-    cwd,
-  );
+  prdTransitionInProgress({ number: prd.number, repo }, cwd);
 
   console.log(
     `PRD #${prd.number} — ${prd.title}: ${subIssues.length} sub-issue(s) to work through.`,
@@ -2024,19 +1938,8 @@ async function runPrdIssueTarget(
       backlogDir,
       cwd: resolvedWorktreeDir,
       issueSource: "github",
-      standaloneLabel: deriveLabels(worktreeConfig.standaloneLabel.value)
-        .intake,
-      standaloneInProgressLabel: deriveLabels(
-        worktreeConfig.standaloneLabel.value,
-      ).inProgress,
-      standaloneDoneLabel: deriveLabels(worktreeConfig.standaloneLabel.value)
-        .done,
+      standaloneLabel: worktreeConfig.standaloneLabel.value,
       subissueLabel: worktreeConfig.subissueLabel.value,
-      subissueInProgressLabel: deriveLabels(worktreeConfig.subissueLabel.value)
-        .inProgress,
-      subissueDoneLabel: deriveLabels(worktreeConfig.subissueLabel.value).done,
-      subissueStuckLabel: deriveLabels(worktreeConfig.subissueLabel.value)
-        .stuck,
       issueRepo: worktreeConfig.issueRepo.value || repo,
       issueCommentProgress:
         worktreeConfig.issueCommentProgress.value === "true",
@@ -2132,18 +2035,10 @@ async function runPrdIssueTarget(
     stuckSubIssues.length === 0 &&
     subIssues.length > 0
   ) {
-    const prdLabels = deriveLabels(
-      worktreeConfig.prdLabel?.value ?? DEFAULTS.prdLabel,
-    );
     console.log(
       `All sub-issues of PRD #${prd.number} are done — transitioning PRD to done.`,
     );
-    prdTransitionDone(
-      { number: prd.number, repo },
-      prdLabels.inProgress,
-      prdLabels.done,
-      cwd,
-    );
+    prdTransitionDone({ number: prd.number, repo }, cwd);
   }
 
   // --- Create aggregate PRD pull request ---
@@ -2282,14 +2177,8 @@ async function runRalphaiInManagedWorktree(
   // Resolve config from config/env/CLI (read-only, safe for dry-run)
   let setupCommand = "";
   let resolvedIssueSource = "none";
-  const defaultStandaloneLabels = deriveLabels(DEFAULTS.standaloneLabel);
-  const defaultPrdLabels = deriveLabels(DEFAULTS.prdLabel);
   let resolvedIssueLabel = DEFAULTS.standaloneLabel;
-  let resolvedIssueInProgressLabel = defaultStandaloneLabels.inProgress;
-  let resolvedIssueDoneLabel = defaultStandaloneLabels.done;
-  let resolvedIssueStuckLabel = defaultStandaloneLabels.stuck;
   let resolvedIssuePrdLabel = DEFAULTS.prdLabel;
-  let resolvedIssuePrdInProgressLabel = defaultPrdLabels.inProgress;
   let resolvedSubissueLabel = DEFAULTS.subissueLabel;
   let resolvedIssueRepo = "";
   let resolvedIssueCommentProgress = false;
@@ -2303,16 +2192,8 @@ async function runRalphaiInManagedWorktree(
     resolvedConfig = cfgResult.config;
     setupCommand = cfgResult.config.setupCommand.value;
     resolvedIssueSource = cfgResult.config.issueSource.value;
-    const standaloneLabels = deriveLabels(
-      cfgResult.config.standaloneLabel.value,
-    );
-    const prdLabels = deriveLabels(cfgResult.config.prdLabel.value);
     resolvedIssueLabel = cfgResult.config.standaloneLabel.value;
-    resolvedIssueInProgressLabel = standaloneLabels.inProgress;
-    resolvedIssueDoneLabel = standaloneLabels.done;
-    resolvedIssueStuckLabel = standaloneLabels.stuck;
     resolvedIssuePrdLabel = cfgResult.config.prdLabel.value;
-    resolvedIssuePrdInProgressLabel = prdLabels.inProgress;
     resolvedSubissueLabel = cfgResult.config.subissueLabel.value;
     resolvedIssueRepo = cfgResult.config.issueRepo.value;
     resolvedIssueCommentProgress =
@@ -2617,13 +2498,10 @@ async function runRalphaiInManagedWorktree(
               cwd,
               issueSource: resolvedIssueSource,
               standaloneLabel: resolvedIssueLabel,
-              standaloneInProgressLabel: resolvedIssueInProgressLabel,
-              standaloneDoneLabel: resolvedIssueDoneLabel,
-              standaloneStuckLabel: resolvedIssueStuckLabel,
+              subissueLabel: resolvedSubissueLabel,
               issueRepo: resolvedIssueRepo,
               issueCommentProgress: resolvedIssueCommentProgress,
               issuePrdLabel: resolvedIssuePrdLabel,
-              issuePrdInProgressLabel: resolvedIssuePrdInProgressLabel,
             };
             // Priority chain: try PRD sub-issues first, then regular issues
             const prdResult = pullPrdSubIssue(pullOpts);
@@ -2862,9 +2740,9 @@ async function runRalphaiRunner(
   if (!isDryRun && config.issueSource.value === "github") {
     try {
       ensureGitHubLabels(cwd, {
-        standalone: deriveLabels(config.standaloneLabel.value),
-        subissue: deriveLabels(config.subissueLabel.value),
-        prd: deriveLabels(config.prdLabel.value),
+        standalone: config.standaloneLabel.value,
+        subissue: config.subissueLabel.value,
+        prd: config.prdLabel.value,
       });
     } catch {
       // Intentionally swallowed — label creation is best-effort.

--- a/src/reset-labels.test.ts
+++ b/src/reset-labels.test.ts
@@ -3,9 +3,13 @@
  *
  * Uses mock.module to control `child_process.execSync` so we can verify
  * `gh issue edit` calls without requiring a real GitHub repo.
+ *
+ * restoreIssueLabels reads frontmatter to find the issue number/repo,
+ * then calls transitionReset to remove the shared state labels
+ * (in-progress, stuck). The family label is never touched.
  */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { mkdirSync, writeFileSync } from "fs";
+import { writeFileSync } from "fs";
 import { join } from "path";
 import { useTempDir } from "./test-utils.ts";
 
@@ -90,7 +94,7 @@ beforeEach(() => {
 });
 
 describe("restoreIssueLabels", () => {
-  it("calls gh issue edit to restore intake label for a GitHub-sourced plan", () => {
+  it("calls gh issue edit to remove state labels for a GitHub-sourced plan", () => {
     mockGhAvailable();
 
     const planPath = writePlanFile(
@@ -101,9 +105,6 @@ describe("restoreIssueLabels", () => {
 
     const result = restoreIssueLabels({
       planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
@@ -119,9 +120,8 @@ describe("restoreIssueLabels", () => {
     const cmd = ghEditCalls[0]![0] as string;
     expect(cmd).toContain("gh issue edit 42");
     expect(cmd).toContain('--repo "owner/repo"');
-    expect(cmd).toContain('--add-label "ralphai-standalone"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:stuck"');
+    expect(cmd).toContain('--remove-label "in-progress"');
+    expect(cmd).toContain('--remove-label "stuck"');
   });
 
   it("does not call gh issue edit for a non-GitHub plan", () => {
@@ -135,9 +135,6 @@ describe("restoreIssueLabels", () => {
 
     const result = restoreIssueLabels({
       planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
@@ -172,9 +169,6 @@ describe("restoreIssueLabels", () => {
 
     const result = restoreIssueLabels({
       planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
@@ -199,9 +193,6 @@ describe("restoreIssueLabels", () => {
 
     const result = restoreIssueLabels({
       planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
@@ -221,9 +212,6 @@ describe("restoreIssueLabels", () => {
 
     const result = restoreIssueLabels({
       planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
       issueRepo: "",
       cwd: ctx.dir,
     });
@@ -244,9 +232,6 @@ describe("restoreIssueLabels", () => {
 
     const result = restoreIssueLabels({
       planPath: join(ctx.dir, "nonexistent.md"),
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
@@ -256,11 +241,11 @@ describe("restoreIssueLabels", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Sub-issue reset tests
+// Sub-issue reset uses the same shared state labels
 // ---------------------------------------------------------------------------
 
-describe("restoreIssueLabels — sub-issue label selection", () => {
-  it("uses subissue labels when plan has prd frontmatter and subissue labels are provided", () => {
+describe("restoreIssueLabels — sub-issue reset", () => {
+  it("removes the same shared state labels for sub-issue plans", () => {
     mockGhAvailable();
 
     const planPath = writePlanFile(
@@ -271,19 +256,12 @@ describe("restoreIssueLabels — sub-issue label selection", () => {
 
     const result = restoreIssueLabels({
       planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
-      subissueLabel: "ralphai-subissue",
-      subissueInProgressLabel: "ralphai-subissue:in-progress",
-      subissueStuckLabel: "ralphai-subissue:stuck",
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
 
     expect(result.restored).toBe(true);
 
-    // Verify gh issue edit was called with subissue labels
     const ghEditCalls = mockExecSync.mock.calls.filter(
       (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("gh issue edit"),
@@ -291,134 +269,53 @@ describe("restoreIssueLabels — sub-issue label selection", () => {
     expect(ghEditCalls.length).toBe(1);
     const cmd = ghEditCalls[0]![0] as string;
     expect(cmd).toContain("gh issue edit 201");
-    // Primary: subissue intake label is restored
-    expect(cmd).toContain('--add-label "ralphai-subissue"');
-    // Removes subissue state labels
-    expect(cmd).toContain('--remove-label "ralphai-subissue:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-subissue:stuck"');
-    // Defensive: also removes standalone state labels (cross-family cleanup)
-    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:stuck"');
+    // Removes shared state labels — same for all families
+    expect(cmd).toContain('--remove-label "in-progress"');
+    expect(cmd).toContain('--remove-label "stuck"');
   });
 
-  it("uses standalone labels when plan has no prd frontmatter even with subissue labels provided", () => {
+  it("uses the same transition for standalone and sub-issue plans", () => {
     mockGhAvailable();
 
-    const planPath = writePlanFile(
+    // Standalone plan
+    const standalonePath = writePlanFile(
       ctx.dir,
-      "gh-42-standalone-issue",
+      "gh-42-standalone",
       githubPlanContent(42),
     );
 
-    const result = restoreIssueLabels({
-      planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
-      subissueLabel: "ralphai-subissue",
-      subissueInProgressLabel: "ralphai-subissue:in-progress",
-      subissueStuckLabel: "ralphai-subissue:stuck",
+    const standaloneResult = restoreIssueLabels({
+      planPath: standalonePath,
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
+    expect(standaloneResult.restored).toBe(true);
 
-    expect(result.restored).toBe(true);
-
-    // Verify gh issue edit was called with standalone labels
-    const ghEditCalls = mockExecSync.mock.calls.filter(
-      (call: unknown[]) =>
-        typeof call[0] === "string" && call[0].includes("gh issue edit"),
-    );
-    expect(ghEditCalls.length).toBe(1);
-    const cmd = ghEditCalls[0]![0] as string;
-    expect(cmd).toContain("gh issue edit 42");
-    expect(cmd).toContain('--add-label "ralphai-standalone"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:stuck"');
-    // Standalone issues don't need cross-family cleanup (subissue labels
-    // would never be erroneously applied to a standalone issue)
-    expect(cmd).not.toContain("ralphai-subissue");
-  });
-
-  it("falls back to standalone labels for sub-issue when subissue labels not provided", () => {
+    mockExecSync.mockReset();
     mockGhAvailable();
 
-    const planPath = writePlanFile(
+    // Sub-issue plan
+    const subIssuePath = writePlanFile(
       ctx.dir,
-      "gh-201-sub-no-labels",
+      "gh-201-subissue",
       githubSubIssuePlanContent(201, 100),
     );
 
-    // Do NOT pass subissue label options — should fall back to standalone
-    const result = restoreIssueLabels({
-      planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
+    const subIssueResult = restoreIssueLabels({
+      planPath: subIssuePath,
       issueRepo: "owner/repo",
       cwd: ctx.dir,
     });
+    expect(subIssueResult.restored).toBe(true);
 
-    expect(result.restored).toBe(true);
-
+    // Both should use the same gh issue edit pattern (shared state labels)
     const ghEditCalls = mockExecSync.mock.calls.filter(
       (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("gh issue edit"),
     );
     expect(ghEditCalls.length).toBe(1);
     const cmd = ghEditCalls[0]![0] as string;
-    // Falls back to standalone since subissue labels not provided
-    expect(cmd).toContain('--add-label "ralphai-standalone"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Cross-family reset cleanup
-// ---------------------------------------------------------------------------
-
-describe("restoreIssueLabels — cross-family label cleanup", () => {
-  it("removes labels from both families for sub-issues, cleaning up erroneously-applied standalone labels", () => {
-    mockGhAvailable();
-
-    // This simulates the bug scenario: a sub-issue that had
-    // ralphai-standalone:in-progress erroneously applied instead
-    // of ralphai-subissue:in-progress. Reset should remove both.
-    const planPath = writePlanFile(
-      ctx.dir,
-      "gh-201-cross-family",
-      githubSubIssuePlanContent(201, 100),
-    );
-
-    const result = restoreIssueLabels({
-      planPath,
-      standaloneLabel: "ralphai-standalone",
-      standaloneInProgressLabel: "ralphai-standalone:in-progress",
-      standaloneStuckLabel: "ralphai-standalone:stuck",
-      subissueLabel: "ralphai-subissue",
-      subissueInProgressLabel: "ralphai-subissue:in-progress",
-      subissueStuckLabel: "ralphai-subissue:stuck",
-      issueRepo: "owner/repo",
-      cwd: ctx.dir,
-    });
-
-    expect(result.restored).toBe(true);
-
-    const ghEditCalls = mockExecSync.mock.calls.filter(
-      (call: unknown[]) =>
-        typeof call[0] === "string" && call[0].includes("gh issue edit"),
-    );
-    expect(ghEditCalls.length).toBe(1);
-    const cmd = ghEditCalls[0]![0] as string;
-
-    // Primary family: subissue intake restored, subissue state labels removed
-    expect(cmd).toContain('--add-label "ralphai-subissue"');
-    expect(cmd).toContain('--remove-label "ralphai-subissue:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-subissue:stuck"');
-
-    // Defensive cleanup: standalone state labels also removed
-    // (these may have been erroneously applied by the old bug)
-    expect(cmd).toContain('--remove-label "ralphai-standalone:in-progress"');
-    expect(cmd).toContain('--remove-label "ralphai-standalone:stuck"');
+    expect(cmd).toContain('--remove-label "in-progress"');
+    expect(cmd).toContain('--remove-label "stuck"');
   });
 });

--- a/src/reset-labels.ts
+++ b/src/reset-labels.ts
@@ -2,12 +2,12 @@
  * Label restoration for GitHub issues when plans are reset.
  *
  * When a plan sourced from a GitHub issue is moved back to the backlog
- * (via `ralphai reset` or the interactive menu), the in-progress label
- * should be removed and the intake label restored — returning the issue
- * to the pickup queue.
+ * (via `ralphai reset` or the interactive menu), the in-progress and
+ * stuck labels should be removed — returning the issue to the pickup
+ * queue. The family label stays (it was never removed during pull).
  *
- * This is the reverse of the intake → in-progress transition performed
- * in issues.ts when an issue is pulled into the pipeline.
+ * This is the reverse of the pull transition performed in issues.ts
+ * when an issue is pulled into the pipeline.
  */
 import { execSync } from "child_process";
 import { extractIssueFrontmatter } from "./frontmatter.ts";
@@ -20,18 +20,6 @@ import { transitionReset } from "./label-lifecycle.ts";
 export interface RestoreIssueLabelsOptions {
   /** Path to the plan .md file (must still exist on disk). */
   planPath: string;
-  /** The intake label to restore (e.g. "ralphai-standalone"). */
-  standaloneLabel: string;
-  /** The in-progress label to remove (e.g. "ralphai-standalone:in-progress"). */
-  standaloneInProgressLabel: string;
-  /** The stuck label to remove (e.g. "ralphai-standalone:stuck"). */
-  standaloneStuckLabel: string;
-  /** Sub-issue intake label (e.g. "ralphai-subissue"). */
-  subissueLabel?: string;
-  /** Sub-issue in-progress label (e.g. "ralphai-subissue:in-progress"). */
-  subissueInProgressLabel?: string;
-  /** Sub-issue stuck label (e.g. "ralphai-subissue:stuck"). */
-  subissueStuckLabel?: string;
   /** Configured issue repo (owner/repo), or "" to auto-detect from issue-url. */
   issueRepo: string;
   /** Working directory for gh CLI calls. */
@@ -80,11 +68,12 @@ function repoFromUrl(issueUrl: string): string | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Restore the intake label on a GitHub issue when its plan is reset.
+ * Restore labels on a GitHub issue when its plan is reset.
  *
  * Reads frontmatter from the plan file. If the plan is GitHub-sourced
  * (`source: github` with an issue number), calls `gh issue edit` to
- * remove the in-progress label and add the intake label.
+ * remove the in-progress and stuck state labels (shared labels).
+ * The family label is left untouched since it was never removed.
  *
  * Best-effort: failures are reported in the result but never thrown.
  */
@@ -99,22 +88,6 @@ export function restoreIssueLabels(
   if (fm.source !== "github" || !fm.issue) {
     return { restored: false, message: "not a GitHub-sourced plan" };
   }
-
-  // Choose the correct label family: sub-issues (prd present in frontmatter)
-  // use subissue labels when available, standalone issues use standalone labels.
-  const isSubIssue = fm.prd !== undefined;
-  const issueLabel =
-    isSubIssue && options.subissueLabel
-      ? options.subissueLabel
-      : options.standaloneLabel;
-  const issueInProgressLabel =
-    isSubIssue && options.subissueInProgressLabel
-      ? options.subissueInProgressLabel
-      : options.standaloneInProgressLabel;
-  const issueStuckLabel =
-    isSubIssue && options.subissueStuckLabel
-      ? options.subissueStuckLabel
-      : options.standaloneStuckLabel;
 
   // Check gh CLI availability
   if (!isGhAvailable()) {
@@ -136,27 +109,9 @@ export function restoreIssueLabels(
     };
   }
 
-  // Reverse the label transition: remove in-progress and stuck, add intake.
-  // For sub-issues, also defensively remove standalone state labels in case
-  // the wrong family was applied (the pullGithubIssueByNumber bug).
-  // gh issue edit --remove-label is a no-op for labels that aren't present.
-  const extraRemoveLabels: string[] = [];
-  if (isSubIssue && options.subissueLabel) {
-    // We're resetting a sub-issue with subissue labels — also remove
-    // any standalone state labels that may have been erroneously applied.
-    extraRemoveLabels.push(options.standaloneInProgressLabel);
-    extraRemoveLabels.push(options.standaloneStuckLabel);
-  }
-
-  const transitionResult = transitionReset(
-    { number: fm.issue, repo },
-    issueLabel,
-    issueInProgressLabel,
-    issueStuckLabel,
-    cwd,
-    false,
-    extraRemoveLabels,
-  );
+  // Remove shared state labels (in-progress and stuck).
+  // The family label stays — it was never removed during pull.
+  const transitionResult = transitionReset({ number: fm.issue, repo }, cwd);
 
   return {
     restored: transitionResult.ok,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -36,7 +36,7 @@ import {
   detectCompletion,
   extractNoncedBlock,
 } from "./sentinel.ts";
-import { deriveLabels } from "./labels.ts";
+import { IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL } from "./labels.ts";
 import {
   transitionStuck,
   prdTransitionStuck,
@@ -561,21 +561,9 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
   const agentCommand = config.agentCommand.value;
   const autoCommit = config.autoCommit.value === "true";
   const issueSource = config.issueSource.value;
-  const standaloneLabels = deriveLabels(config.standaloneLabel.value);
-  const standaloneLabel = standaloneLabels.intake;
-  const standaloneInProgressLabel = standaloneLabels.inProgress;
-  const standaloneDoneLabel = standaloneLabels.done;
-  const standaloneStuckLabel = standaloneLabels.stuck;
-  const subissueLabels = deriveLabels(config.subissueLabel.value);
-  const subissueLabel = subissueLabels.intake;
-  const subissueInProgressLabel = subissueLabels.inProgress;
-  const subissueDoneLabel = subissueLabels.done;
-  const subissueStuckLabel = subissueLabels.stuck;
-  const prdLabels = deriveLabels(config.prdLabel.value);
-  const issuePrdLabel = prdLabels.intake;
-  const issuePrdInProgressLabel = prdLabels.inProgress;
-  const prdDoneLabel = prdLabels.done;
-  const prdStuckLabel = prdLabels.stuck;
+  const standaloneLabel = config.standaloneLabel.value;
+  const subissueLabel = config.subissueLabel.value;
+  const issuePrdLabel = config.prdLabel.value;
   const issueRepo = config.issueRepo.value;
   const issueCommentProgress = config.issueCommentProgress.value === "true";
 
@@ -638,17 +626,10 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
           cwd,
           issueSource,
           standaloneLabel,
-          standaloneInProgressLabel,
-          standaloneDoneLabel,
-          standaloneStuckLabel,
           subissueLabel,
-          subissueInProgressLabel,
-          subissueDoneLabel,
-          subissueStuckLabel,
           issueRepo,
           issueCommentProgress,
           issuePrdLabel,
-          issuePrdInProgressLabel,
         };
 
         // Priority chain: try PRD sub-issues first, then regular issues
@@ -963,17 +944,6 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
 
           // Swap in-progress → stuck label on linked GitHub issue
           if (issueFm.source === "github" && issueFm.issue) {
-            // Choose the correct label family: sub-issues (prd present in
-            // frontmatter) use subissue labels, standalone issues use
-            // standalone labels.
-            const isSubIssue = issueFm.prd !== undefined;
-            const activeInProgressLabel = isSubIssue
-              ? subissueInProgressLabel
-              : standaloneInProgressLabel;
-            const activeStuckLabel = isSubIssue
-              ? subissueStuckLabel
-              : standaloneStuckLabel;
-
             let repo = issueRepo || null;
             if (!repo && issueFm.issueUrl) {
               const m = issueFm.issueUrl.match(
@@ -982,20 +952,11 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
               repo = m?.[1] ?? null;
             }
             if (repo) {
-              transitionStuck(
-                { number: issueFm.issue, repo },
-                activeInProgressLabel,
-                activeStuckLabel,
-                cwd,
-              );
+              transitionStuck({ number: issueFm.issue, repo }, cwd);
 
               // Propagate stuck to PRD parent when a sub-issue gets stuck
-              if (isSubIssue && issueFm.prd) {
-                prdTransitionStuck(
-                  { number: issueFm.prd, repo },
-                  prdStuckLabel,
-                  cwd,
-                );
+              if (issueFm.prd) {
+                prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
               }
             }
           }
@@ -1135,10 +1096,6 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         archiveRun({
           wipFiles: [planFile],
           archiveDir: dirs.archiveDir,
-          standaloneInProgressLabel,
-          standaloneDoneLabel,
-          subissueInProgressLabel,
-          subissueDoneLabel,
           cwd,
         });
 
@@ -1155,22 +1112,12 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
             prdRepo = m?.[1] ?? null;
           }
           if (prdRepo) {
-            const allDone = checkAllPrdSubIssuesDone(
-              prdRepo,
-              issueFm.prd,
-              subissueDoneLabel,
-              cwd,
-            );
+            const allDone = checkAllPrdSubIssuesDone(prdRepo, issueFm.prd, cwd);
             if (allDone) {
               console.log(
                 `All sub-issues of PRD #${issueFm.prd} are done — transitioning PRD to done.`,
               );
-              prdTransitionDone(
-                { number: issueFm.prd, repo: prdRepo },
-                issuePrdInProgressLabel,
-                prdDoneLabel,
-                cwd,
-              );
+              prdTransitionDone({ number: issueFm.prd, repo: prdRepo }, cwd);
             }
           }
         }


### PR DESCRIPTION
## Summary

Replaces the old 12-label scheme (3 families × 4 colon-suffixed states like `ralphai-standalone:in-progress`) with a simpler 6-label scheme:

- **3 family labels** (`ralphai-standalone`, `ralphai-subissue`, `ralphai-prd`) — persist through all states
- **3 shared state labels** (`in-progress`, `done`, `stuck`) — added/removed as issues transition

Issues now carry **two labels** (family + state) instead of one compound label.

## Changes

### Core abstractions removed
- `DerivedLabels` type and `deriveLabels()` function eliminated from `src/labels.ts`
- Replaced with fixed constants: `IN_PROGRESS_LABEL`, `DONE_LABEL`, `STUCK_LABEL`, `STATE_LABELS`

### Simplified interfaces
- `ArchiveRunOptions` reduced to `{wipFiles, archiveDir, cwd}`
- `PullIssueOptions` no longer carries per-family state label strings
- `RestoreIssueLabelsOptions` reduced to `{planPath, issueRepo, cwd}`
- All transition functions (`transitionPull`, `transitionDone`, `transitionStuck`, `transitionReset`) use fixed constants instead of label string parameters

### Files changed
- **8 source files** modified across labels, lifecycle, dispatch, issues, PR lifecycle, runner, and CLI
- **11 test files** updated/rewritten for new label scheme
- **5 doc files** updated (README, CLI reference, architecture, workflows, how-it-works)

### Impact
- Net **-946 lines** (447 added, 1,393 removed)
- All 344 tests pass (184 in modified test files + 160 in unmodified)
- Zero TypeScript errors