### PR TITLE
fix: prevent IPC socket path truncation on long plan slugs

### DIFF
--- a/src/ipc-protocol.test.ts
+++ b/src/ipc-protocol.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, test, expect } from "bun:test";
 import { join } from "path";
+import { tmpdir } from "os";
 import {
   serialize,
   deserialize,
@@ -274,17 +275,63 @@ describe("multi-message chunk parsing", () => {
 // ---------------------------------------------------------------------------
 
 describe("getSocketPath", () => {
-  test("returns path under wipDir/slug", () => {
-    const wipDir = join(
-      "/home/user/.ralphai/repos/my-repo/pipeline/in-progress",
-    );
+  test("returns co-located path when under the socket length limit", () => {
+    const wipDir = "/tmp/wip";
     const result = getSocketPath(wipDir, "my-plan");
     expect(result).toBe(join(wipDir, "my-plan", "runner.sock"));
   });
 
-  test("handles slug with special characters", () => {
-    const wipDir = join("/tmp/wip");
+  test("returns co-located path for typical short slug", () => {
+    const wipDir = "/tmp/wip";
     const result = getSocketPath(wipDir, "feat-add-auth-flow");
     expect(result).toBe(join(wipDir, "feat-add-auth-flow", "runner.sock"));
   });
+
+  describe.skipIf(process.platform === "win32")(
+    "Unix socket path length limit",
+    () => {
+      test("falls back to temp-dir path when path exceeds limit", () => {
+        const wipDir =
+          "/home/user/.ralphai/repos/github-com-some-org-some-long-repo-name/pipeline/in-progress";
+        const slug =
+          "gh-279-feat-menu-items-selectable-list-component-main-menu-screen";
+        const result = getSocketPath(wipDir, slug);
+
+        // Should NOT be the co-located path
+        const colocated = join(wipDir, slug, "runner.sock");
+        expect(result).not.toBe(colocated);
+
+        // Should be under tmpdir with a deterministic hash
+        expect(result).toMatch(
+          new RegExp(`^${tmpdir()}/ralphai-[0-9a-f]{16}\\.sock$`),
+        );
+
+        // Must fit within the Unix socket path limit
+        expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(103);
+      });
+
+      test("produces deterministic path for the same inputs", () => {
+        const wipDir =
+          "/home/user/.ralphai/repos/some-very-long-repo-slug-name/pipeline/in-progress";
+        const slug = "gh-999-some-extremely-long-plan-slug-that-exceeds-limits";
+        const a = getSocketPath(wipDir, slug);
+        const b = getSocketPath(wipDir, slug);
+        expect(a).toBe(b);
+      });
+
+      test("produces different paths for different inputs", () => {
+        const wipDir =
+          "/home/user/.ralphai/repos/some-very-long-repo-slug-name/pipeline/in-progress";
+        const a = getSocketPath(
+          wipDir,
+          "gh-100-some-extremely-long-plan-slug-that-exceeds-limits-aaa",
+        );
+        const b = getSocketPath(
+          wipDir,
+          "gh-200-some-extremely-long-plan-slug-that-exceeds-limits-bbb",
+        );
+        expect(a).not.toBe(b);
+      });
+    },
+  );
 });

--- a/src/ipc-protocol.ts
+++ b/src/ipc-protocol.ts
@@ -12,6 +12,8 @@
  */
 
 import { join } from "path";
+import { tmpdir } from "os";
+import { createHash } from "crypto";
 
 // ---------------------------------------------------------------------------
 // Message types
@@ -99,11 +101,40 @@ export function deserialize(line: string): IpcMessage | null {
 // ---------------------------------------------------------------------------
 
 /**
+ * Maximum safe socket path length in bytes.
+ *
+ * Linux `sun_path` is 108 bytes (including null terminator → 107 usable).
+ * macOS `sun_path` is 104 bytes (including null terminator → 103 usable).
+ * We use 103 as the safe cross-platform limit.
+ */
+const MAX_SOCKET_PATH_BYTES = 103;
+
+/**
  * Compute the IPC socket path for a plan.
  *
- * Layout: `<wipDir>/<slug>/runner.sock`
- * Co-located with `runner.pid` and other plan artifacts.
+ * Preferred layout: `<wipDir>/<slug>/runner.sock`
+ * (co-located with `runner.pid` and other plan artifacts).
+ *
+ * When the preferred path exceeds the Unix domain socket path length limit
+ * (104 bytes on macOS, 108 on Linux), falls back to a deterministic
+ * temp-directory path: `<tmpdir>/ralphai-<hash>.sock`.
+ *
+ * On Windows, named pipes have no path length restriction, so the
+ * preferred path is always used.
  */
 export function getSocketPath(wipDir: string, slug: string): string {
-  return join(wipDir, slug, "runner.sock");
+  const preferred = join(wipDir, slug, "runner.sock");
+
+  if (process.platform === "win32") return preferred;
+
+  if (Buffer.byteLength(preferred, "utf8") <= MAX_SOCKET_PATH_BYTES) {
+    return preferred;
+  }
+
+  // Deterministic hash so both server and client resolve the same path.
+  const hash = createHash("sha256")
+    .update(preferred)
+    .digest("hex")
+    .slice(0, 16);
+  return join(tmpdir(), `ralphai-${hash}.sock`);
 }


### PR DESCRIPTION
## Summary

- Fix silent Unix domain socket path truncation when plan slugs produce paths longer than 108 bytes (Linux) / 104 bytes (macOS)
- When the preferred co-located path (`<wipDir>/<slug>/runner.sock`) exceeds the `sun_path` limit, fall back to a deterministic `/tmp`-based path using a SHA-256 hash
- On Windows (named pipes, no limit), always use the co-located path

## Problem

The kernel silently truncates Unix socket paths to 108 bytes. For long plan slugs (e.g., `gh-279-feat-menu-items-selectable-list-component-main-menu-screen`), this creates a socket file like `gh-279-feat-menu-items-selectable-` directly under `pipeline/in-progress/` instead of `runner.sock` inside the slug directory. This stale socket:

1. Is never cleaned up (cleanup uses the full path, which doesn't match)
2. Cannot be read as a regular file, confusing tooling
3. Persists across runs

## Changes

- `src/ipc-protocol.ts`: `getSocketPath()` now checks the byte length and falls back to `<tmpdir>/ralphai-<hash>.sock` when it exceeds 103 bytes
- `src/ipc-protocol.test.ts`: Added tests for the fallback path, determinism, and uniqueness (skipped on Windows)