### PR TITLE
fix: auto-clean stale _path-* repo entries on startup

### DIFF
--- a/src/global-state.test.ts
+++ b/src/global-state.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "bun:test";
 import { execSync } from "child_process";
-import { existsSync, mkdirSync, rmSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { useTempDir, useTempGitDir } from "./test-utils.ts";
+import { useTempDir, useTempGitDir, runCliInProcess } from "./test-utils.ts";
 import {
   getRalphaiHome,
   getRepoId,
@@ -183,5 +183,55 @@ describe("getRepoPipelineDirs", () => {
     expect(dirs.backlogDir).toContain(join("pipeline", "backlog"));
     expect(dirs.wipDir).toContain(join("pipeline", "in-progress"));
     expect(dirs.archiveDir).toContain(join("pipeline", "out"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: no leaks to the real ~/.ralphai/repos/ directory
+// ---------------------------------------------------------------------------
+
+describe("no global state leak to real ~/.ralphai", () => {
+  const ctx = useTempGitDir();
+
+  /** Snapshot entry names in the real repos directory. */
+  function snapshotRealRepos(): Set<string> {
+    const realReposDir = join(homedir(), ".ralphai", "repos");
+    if (!existsSync(realReposDir)) return new Set();
+    return new Set(readdirSync(realReposDir));
+  }
+
+  it("ensureRepoStateDir with RALPHAI_HOME does not write to ~/.ralphai", () => {
+    const before = snapshotRealRepos();
+
+    const home = join(ctx.dir, "ralphai-home-leak-test");
+    ensureRepoStateDir(ctx.dir, { RALPHAI_HOME: home });
+
+    const after = snapshotRealRepos();
+    const leaked = [...after].filter((e) => !before.has(e));
+    expect(leaked).toEqual([]);
+  });
+
+  it("getRepoPipelineDirs with RALPHAI_HOME does not write to ~/.ralphai", () => {
+    const before = snapshotRealRepos();
+
+    const home = join(ctx.dir, "ralphai-home-leak-test");
+    getRepoPipelineDirs(ctx.dir, { RALPHAI_HOME: home });
+
+    const after = snapshotRealRepos();
+    const leaked = [...after].filter((e) => !before.has(e));
+    expect(leaked).toEqual([]);
+  });
+
+  it("runCliInProcess init --yes with RALPHAI_HOME does not leak to ~/.ralphai", async () => {
+    const before = snapshotRealRepos();
+
+    const home = join(ctx.dir, "ralphai-home-leak-test");
+    await runCliInProcess(["init", "--yes"], ctx.dir, {
+      RALPHAI_HOME: home,
+    });
+
+    const after = snapshotRealRepos();
+    const leaked = [...after].filter((e) => !before.has(e));
+    expect(leaked).toEqual([]);
   });
 });

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -29,6 +29,7 @@ import {
 import {
   getRepoPipelineDirs,
   resolveRepoByNameOrPath,
+  removeStaleRepos,
 } from "./global-state.ts";
 import {
   detectFeedbackCommands,
@@ -1058,6 +1059,17 @@ export async function runRalphai(args: string[]): Promise<void> {
       `${DIM}Use ${TEXT}ralphai repos${DIM} to see your initialized repos.${RESET}`,
     );
     process.exit(1);
+  }
+
+  // Housekeeping: remove stale repo entries (dead paths with empty pipelines).
+  // Skip on --help (keep help output fast) and --dry-run (no side effects).
+  const isDryRunGlobal = args.includes("--dry-run") || args.includes("-n");
+  if (!helpRequested && !isDryRunGlobal) {
+    try {
+      removeStaleRepos();
+    } catch {
+      // Non-fatal — don't block the command if cleanup fails.
+    }
   }
 
   switch (options.subcommand) {

--- a/src/repos.test.ts
+++ b/src/repos.test.ts
@@ -49,22 +49,20 @@ describe("repos command", () => {
       JSON.stringify({ repoPath: "/tmp/nonexistent-dir-xyz" }),
     );
 
-    // Verify it shows up as stale
-    const beforeOutput = stripLogo(
+    // Stale repos are auto-cleaned on every command invocation, so the entry
+    // is already gone by the time `repos` renders its listing.  Verify that
+    // the auto-cleanup worked — the directory should no longer exist.
+    const listOutput = stripLogo(
       await runCliOutputInProcess(["repos"], ctx.dir, env()),
     );
-    expect(beforeOutput).toContain("_path-deadbeef1234");
-    expect(beforeOutput).toContain("[stale]");
+    expect(listOutput).not.toContain("_path-deadbeef1234");
+    expect(existsSync(staleDir)).toBe(false);
 
-    // Run --clean
+    // Explicit --clean on an already-clean state reports nothing to remove.
     const cleanOutput = stripLogo(
       await runCliOutputInProcess(["repos", "--clean"], ctx.dir, env()),
     );
-    expect(cleanOutput).toContain("Removed");
-    expect(cleanOutput).toContain("_path-deadbeef1234");
-
-    // Verify it's gone
-    expect(existsSync(staleDir)).toBe(false);
+    expect(cleanOutput).toContain("No stale repos to remove");
   });
 
   it("--clean preserves stale repos that have plans", async () => {


### PR DESCRIPTION
## Summary

- **Auto-cleanup on startup:** `removeStaleRepos()` now runs at the start of every `ralphai` invocation (skipped on `--help` and `--dry-run`), preventing accumulation of orphaned `_path-<hash>` directories under `~/.ralphai/repos/`.
- **Regression tests:** Three new tests verify that `ensureRepoStateDir`, `getRepoPipelineDirs`, and `runCliInProcess(["init", ...])` with `RALPHAI_HOME` never leak entries to the real `~/.ralphai/repos/`.
- **Test update:** Updated `repos --clean` test to reflect that stale entries are now auto-cleaned before `repos` renders its listing.

## Background

The `_path-<hash>` directories were originally created by a now-fixed bug where `getRepoStateDir()` (a single function) both resolved paths AND created directories — so any read-only check would accidentally create `~/.ralphai/repos/_path-<hash>/` for repos with no git remote. That creation bug was fixed in the `resolveRepoStateDir`/`ensureRepoStateDir` split, but the stale directories were never cleaned up automatically. This change adds the missing self-healing behavior.