### PR TITLE
fix: wire real data into TUI dashboard and show explicit plan targets

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -239,9 +239,9 @@ export function App({
    */
   const dispatchViaConfirm = useCallback(
     (backScreen: Screen) => (result: DispatchResult) => {
-      dispatch(toConfirmNav(result, runConfig, backScreen));
+      dispatch(toConfirmNav(result, runConfig, backScreen, pipeline.state));
     },
-    [dispatch, runConfig],
+    [dispatch, runConfig, pipeline.state],
   );
 
   const handleMenuAction = useCallback(
@@ -254,14 +254,18 @@ export function App({
       // All other exit-to-runner actions (e.g. "run-next") route
       // through confirm.
       if (action === "run-with-options") {
-        dispatch(toOptionsNav(result, runConfig, { type: "menu" }));
+        dispatch(
+          toOptionsNav(result, runConfig, { type: "menu" }, pipeline.state),
+        );
       } else if (action === "settings") {
         dispatch(result);
       } else {
-        dispatch(toConfirmNav(result, runConfig, { type: "menu" }));
+        dispatch(
+          toConfirmNav(result, runConfig, { type: "menu" }, pipeline.state),
+        );
       }
     },
-    [dispatch, runConfig],
+    [dispatch, runConfig, pipeline.state],
   );
 
   // -----------------------------------------------------------------------

--- a/src/tui/components/detail-pane.test.ts
+++ b/src/tui/components/detail-pane.test.ts
@@ -570,8 +570,40 @@ describe("detailForItem — run-next", () => {
       backlog: [{ filename: "next-plan.md", scope: "", dependsOn: [] }],
     });
     const detail = detailForItem("run-next", state, false);
-    expect(detail.lines[0]!.text).toContain("next-plan");
+    expect(detail.lines[0]!.text).toBe("next-plan");
     expect(detail.lines[0]!.bold).toBe(true);
+  });
+
+  it("shows scope when available", () => {
+    const state = makeState({
+      backlog: [
+        { filename: "next-plan.md", scope: "packages/web", dependsOn: [] },
+      ],
+    });
+    const detail = detailForItem("run-next", state, false);
+    expect(detail.lines[0]!.text).toBe("next-plan");
+    expect(detail.lines[1]!.text).toContain("packages/web");
+  });
+
+  it("shows dependency status for next plan", () => {
+    const state = makeState({
+      backlog: [{ filename: "next-plan.md", scope: "", dependsOn: ["dep-a"] }],
+      completedSlugs: ["dep-a"],
+    });
+    const detail = detailForItem("run-next", state, false);
+    expect(detail.lines[0]!.text).toBe("next-plan");
+    expect(detail.lines[1]!.text).toContain("dep-a");
+    expect(detail.lines[1]!.color).toBe("green");
+  });
+
+  it("shows blocked plans when all backlog has unmet deps", () => {
+    const state = makeState({
+      backlog: [
+        { filename: "blocked.md", scope: "", dependsOn: ["unfinished"] },
+      ],
+    });
+    const detail = detailForItem("run-next", state, false);
+    expect(detail.lines[0]!.text).toContain("blocked by unmet dependencies");
   });
 
   it("shows in-progress message when backlog is empty but plans running", () => {
@@ -580,6 +612,41 @@ describe("detailForItem — run-next", () => {
     });
     const detail = detailForItem("run-next", state, false);
     expect(detail.lines[0]!.text).toContain("all plans are in progress");
+  });
+
+  it("shows GitHub fallback when no local plans but issues available", () => {
+    const state = makeState();
+    const ctx: MenuContext = {
+      hasGitHubIssues: true,
+      githubIssueCount: 7,
+    };
+    const detail = detailForItem("run-next", state, false, ctx);
+    expect(detail.lines.some((l) => l.text.includes("7 issues"))).toBe(true);
+  });
+
+  it("shows loading hint when GitHub issues are loading and no local plans", () => {
+    const state = makeState();
+    const ctx: MenuContext = {
+      hasGitHubIssues: true,
+      githubIssueLoading: true,
+    };
+    const detail = detailForItem("run-next", state, false, ctx);
+    expect(detail.loading).toBe(true);
+    expect(detail.lines.some((l) => l.text.includes("Checking GitHub"))).toBe(
+      true,
+    );
+  });
+
+  it("skips first ready plan to find dependency-ready one", () => {
+    const state = makeState({
+      backlog: [
+        { filename: "blocked.md", scope: "", dependsOn: ["dep-x"] },
+        { filename: "ready.md", scope: "", dependsOn: [] },
+      ],
+    });
+    const detail = detailForItem("run-next", state, false);
+    expect(detail.lines[0]!.text).toBe("ready");
+    expect(detail.lines[0]!.bold).toBe(true);
   });
 });
 

--- a/src/tui/components/detail-pane.tsx
+++ b/src/tui/components/detail-pane.tsx
@@ -14,6 +14,10 @@ import { Box, Text } from "ink";
 import type { PipelineState, InProgressPlan } from "../../pipeline-state.ts";
 import type { MenuContext } from "../menu-items.ts";
 import type { ResolvedConfig } from "../../config.ts";
+import {
+  findNextPlanName,
+  unmetDependencies,
+} from "../../interactive/run-actions.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -145,7 +149,7 @@ export function detailForItem(
       return settingsDetail(resolvedConfig);
 
     case "run-next":
-      return runNextDetail(state, stateLoading);
+      return runNextDetail(state, stateLoading, menuContext);
 
     case "resume-stalled":
       return resumeStalledDetail(state, stateLoading);
@@ -456,12 +460,39 @@ function settingsDetail(resolvedConfig?: ResolvedConfig): DetailContent {
 function runNextDetail(
   state: PipelineState | null,
   stateLoading: boolean,
+  menuContext?: MenuContext,
 ): DetailContent {
   if (stateLoading || !state) {
     return { title: "Run Next", lines: [], loading: true };
   }
 
   if (state.backlog.length === 0 && state.inProgress.length === 0) {
+    // No local plans at all — check if GitHub can supply one
+    if (menuContext?.hasGitHubIssues) {
+      if (menuContext.githubIssueLoading) {
+        return {
+          title: "Run Next",
+          lines: [
+            { text: "No local plans", dim: true },
+            { text: "Checking GitHub for issues…", dim: true },
+          ],
+          loading: true,
+        };
+      }
+      const count = menuContext.githubIssueCount ?? 0;
+      if (count > 0) {
+        return {
+          title: "Run Next",
+          lines: [
+            { text: "No local plans", dim: true },
+            {
+              text: `Will pull oldest of ${count} issue${count === 1 ? "" : "s"} from GitHub`,
+            },
+            { text: "Press Enter to start", dim: true },
+          ],
+        };
+      }
+    }
     return {
       title: "Run Next",
       lines: [
@@ -474,17 +505,59 @@ function runNextDetail(
     };
   }
 
+  // Find the dependency-aware next plan (mirrors the runner algorithm)
+  const nextPlanName = findNextPlanName(state);
+
+  if (nextPlanName) {
+    const plan = state.backlog.find((p) => p.filename === nextPlanName)!;
+    const name = plan.filename.replace(/\.md$/, "");
+    const lines: DetailLine[] = [{ text: name, bold: true }];
+
+    if (plan.scope) {
+      lines.push({ text: `  Scope: ${plan.scope}`, dim: true });
+    }
+
+    if (plan.dependsOn.length > 0) {
+      for (const dep of plan.dependsOn) {
+        lines.push({
+          text: `  ${formatDependency(dep, state.completedSlugs)}`,
+          color: state.completedSlugs.some(
+            (s) => s === dep || s.startsWith(`${dep}-`),
+          )
+            ? "green"
+            : undefined,
+          dim: !state.completedSlugs.some(
+            (s) => s === dep || s.startsWith(`${dep}-`),
+          ),
+        });
+      }
+    }
+
+    lines.push({ text: "Press Enter to start this plan", dim: true });
+    return { title: "Run Next", lines };
+  }
+
+  // Backlog exists but nothing is ready (all blocked by dependencies)
   if (state.backlog.length > 0) {
-    const next = state.backlog[0]!;
-    const name = next.filename.replace(/\.md$/, "");
+    const lines: DetailLine[] = [];
+    for (const plan of state.backlog) {
+      const name = plan.filename.replace(/\.md$/, "");
+      const unmet = unmetDependencies(plan, state.completedSlugs);
+      lines.push({ text: name });
+      lines.push({
+        text: `  Blocked by: ${unmet.join(", ")}`,
+        dim: true,
+        color: "yellow",
+      });
+    }
     return {
       title: "Run Next",
       lines: [
-        { text: `Next: ${name}`, bold: true },
         {
-          text: "Press Enter to start this plan",
-          dim: true,
+          text: "All backlog plans are blocked by unmet dependencies",
+          color: "yellow",
         },
+        ...lines,
       ],
     };
   }

--- a/src/tui/run-tui.tsx
+++ b/src/tui/run-tui.tsx
@@ -26,6 +26,9 @@ import {
   ENTER_ALT_SCREEN,
 } from "./terminal-safety.ts";
 import { applyNoColorOverride } from "./color-support.ts";
+import { gatherPipelineState } from "../pipeline-state.ts";
+import { listRalphaiWorktrees } from "../worktree/parsing.ts";
+import { peekGithubIssues, peekPrdIssues } from "../issues.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -80,7 +83,11 @@ export function buildAppProps(cwd: string): Omit<AppProps, "onExitToRunner"> {
     // Config resolution failure — proceed with defaults
   }
 
-  const pipelineOpts = { cwd };
+  const pipelineOpts = {
+    cwd,
+    gatherState: gatherPipelineState,
+    listWorktrees: listRalphaiWorktrees,
+  };
 
   const githubOpts = hasGitHubIssues
     ? {
@@ -91,6 +98,8 @@ export function buildAppProps(cwd: string): Omit<AppProps, "onExitToRunner"> {
           issueRepo,
           issuePrdLabel,
         },
+        peekGithub: peekGithubIssues,
+        peekPrd: peekPrdIssues,
       }
     : undefined;
 

--- a/src/tui/types.test.ts
+++ b/src/tui/types.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./types.ts";
 import type { ActionType, DispatchResult, Screen, RunConfig } from "./types.ts";
 import type { ConfirmData } from "./screens/confirm.tsx";
+import type { PipelineState } from "../pipeline-state.ts";
 
 // ---------------------------------------------------------------------------
 // isActionType
@@ -364,6 +365,46 @@ describe("titleFromRunArgs", () => {
   it("handles large issue numbers", () => {
     expect(titleFromRunArgs(["run", "9999"])).toBe("Issue #9999");
   });
+
+  it("resolves next plan name from pipeline state for bare run", () => {
+    const state: PipelineState = {
+      backlog: [{ filename: "my-feature.md", scope: "", dependsOn: [] }],
+      inProgress: [],
+      completedSlugs: [],
+      worktrees: [],
+      problems: [],
+    };
+    expect(titleFromRunArgs(["run"], state)).toBe("my-feature");
+  });
+
+  it("skips blocked plans and resolves ready one from state", () => {
+    const state: PipelineState = {
+      backlog: [
+        { filename: "blocked.md", scope: "", dependsOn: ["dep-x"] },
+        { filename: "ready.md", scope: "", dependsOn: [] },
+      ],
+      inProgress: [],
+      completedSlugs: [],
+      worktrees: [],
+      problems: [],
+    };
+    expect(titleFromRunArgs(["run"], state)).toBe("ready");
+  });
+
+  it("falls back to auto-detect when state has no ready plan", () => {
+    const state: PipelineState = {
+      backlog: [{ filename: "blocked.md", scope: "", dependsOn: ["dep-x"] }],
+      inProgress: [],
+      completedSlugs: [],
+      worktrees: [],
+      problems: [],
+    };
+    expect(titleFromRunArgs(["run"], state)).toBe("Auto-detect (next plan)");
+  });
+
+  it("falls back to auto-detect when state is null", () => {
+    expect(titleFromRunArgs(["run"], null)).toBe("Auto-detect (next plan)");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -432,6 +473,18 @@ describe("buildConfirmDataFromArgs", () => {
     const data = buildConfirmDataFromArgs(["run"], emptyConfig);
     expect(data.agentCommand).toBe("");
     expect(data.feedbackCommands).toBe("");
+  });
+
+  it("resolves next plan name when state is provided", () => {
+    const state: PipelineState = {
+      backlog: [{ filename: "my-plan.md", scope: "", dependsOn: [] }],
+      inProgress: [],
+      completedSlugs: [],
+      worktrees: [],
+      problems: [],
+    };
+    const data = buildConfirmDataFromArgs(["run"], config, state);
+    expect(data.title).toBe("my-plan");
   });
 });
 

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -14,6 +14,8 @@
  */
 
 import type { ConfirmData } from "./screens/confirm.tsx";
+import type { PipelineState } from "../pipeline-state.ts";
+import { findNextPlanName } from "../interactive/run-actions.ts";
 
 // ---------------------------------------------------------------------------
 // Actions
@@ -191,17 +193,27 @@ export interface RunConfig {
 /**
  * Derive a human-readable title from CLI run args.
  *
- * - `["run"]` → "Auto-detect (next plan)"
+ * - `["run"]` → next plan name from state, or "Auto-detect (next plan)"
  * - `["run", "42"]` → "Issue #42"
  * - `["run", "--plan", "feat-login.md"]` → "feat-login.md"
  *
- * Falls back to joining the args for unexpected shapes.
+ * When `state` is provided and the args indicate auto-detection,
+ * resolves the actual next plan name using the same dependency-aware
+ * algorithm the runner uses. Falls back to the generic label when no
+ * state is available or no ready plan is found.
  */
-export function titleFromRunArgs(args: string[]): string {
+export function titleFromRunArgs(
+  args: string[],
+  state?: PipelineState | null,
+): string {
   // Strip leading "run" if present
   const rest = args[0] === "run" ? args.slice(1) : args;
 
-  if (rest.length === 0) return "Auto-detect (next plan)";
+  if (rest.length === 0) {
+    const nextPlan = state ? findNextPlanName(state) : undefined;
+    if (nextPlan) return nextPlan.replace(/\.md$/, "");
+    return "Auto-detect (next plan)";
+  }
 
   // --plan <filename>
   const planIdx = rest.indexOf("--plan");
@@ -239,9 +251,10 @@ export function branchFromRunArgs(_args: string[]): string {
 export function buildConfirmDataFromArgs(
   args: string[],
   config: RunConfig,
+  state?: PipelineState | null,
 ): ConfirmData {
   return {
-    title: titleFromRunArgs(args),
+    title: titleFromRunArgs(args, state),
     agentCommand: config.agentCommand,
     branch: branchFromRunArgs(args),
     feedbackCommands: config.feedbackCommands,
@@ -264,6 +277,7 @@ export function toConfirmNav(
   result: DispatchResult,
   config: RunConfig,
   backScreen: Screen,
+  state?: PipelineState | null,
 ): DispatchResult {
   if (result.type !== "exit-to-runner") return result;
 
@@ -271,7 +285,7 @@ export function toConfirmNav(
     type: "navigate",
     screen: {
       type: "confirm",
-      data: buildConfirmDataFromArgs(result.args, config),
+      data: buildConfirmDataFromArgs(result.args, config, state),
       backScreen,
     },
   };
@@ -291,6 +305,7 @@ export function toOptionsNav(
   result: DispatchResult,
   config: RunConfig,
   backScreen: Screen,
+  state?: PipelineState | null,
 ): DispatchResult {
   if (result.type !== "exit-to-runner") return result;
 
@@ -298,7 +313,7 @@ export function toOptionsNav(
     type: "navigate",
     screen: {
       type: "options",
-      data: buildConfirmDataFromArgs(result.args, config),
+      data: buildConfirmDataFromArgs(result.args, config, state),
       backScreen,
     },
   };


### PR DESCRIPTION
## Summary

- **Fix: dashboard showed empty data.** `buildAppProps()` wasn't injecting the real `gatherPipelineState`, `listRalphaiWorktrees`, `peekGithubIssues`, or `peekPrdIssues` into the TUI hooks — both fell back silently to empty/zero results. The front page now shows actual worktree counts and GitHub issue availability.
- **Enrich "Run next plan" detail pane.** Uses the dependency-aware `findNextPlanName` algorithm (same as the runner) instead of blindly showing `backlog[0]`. Shows scope, dependency status with color-coded indicators, blocked-plan diagnostics, and GitHub issue fallback info.
- **Show explicit plan name on confirm screen.** `titleFromRunArgs` now accepts optional `PipelineState` to resolve the actual next plan name instead of displaying "Auto-detect (next plan)". Threads state through `buildConfirmDataFromArgs` → `toConfirmNav` / `toOptionsNav` from `App` where pipeline state is already available.

All new parameters are optional with backward-compatible defaults. 785 TUI tests pass, 0 type errors.