### PR TITLE
fix: add high-level summaries to aggregate PR bodies

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -205,7 +205,7 @@ PRD behavior:
 - Per-sub-issue PRs are suppressed; one aggregate draft PR is opened at the end
 - Stuck sub-issues are skipped and listed in the PR body; the PRD continues to the next
 - HITL sub-issues (labeled with `issueHitlLabel`, default `ralphai-subissue-hitl`) and sub-issues blocked by HITL dependencies are skipped; the PRD continues to the next eligible sub-issue
-- The aggregate PR title uses `feat: <PRD title>` and includes completed/stuck/HITL checklists
+- The aggregate PR title uses `feat: <PRD title>` and the body starts with a high-level summary followed by completed/stuck/HITL checklists
 
 The `ralphai run <number>` form uses label-driven dispatch: it reads the issue's labels to classify it as standalone (`ralphai-standalone`), sub-issue (`ralphai-subissue`), or PRD (`ralphai-prd`). Sub-issues automatically discover their parent PRD and process through the PRD flow. Issues with no recognized label produce an error with guidance. The old unified `ralphai` label is not recognized.
 

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -228,6 +228,7 @@ Ralphai fetches sub-issues from the GitHub API and processes them in order. Sub-
 
 Per-sub-issue PRs are suppressed. When all sub-issues complete (or are skipped), Ralphai opens a single draft PR with:
 
+- A high-level summary of the branch's completed work
 - A `Closes #N` block for the PRD and each completed sub-issue
 - A checklist of completed sub-issues
 - A checklist of stuck sub-issues (if any)

--- a/src/pr-description.test.ts
+++ b/src/pr-description.test.ts
@@ -4,6 +4,7 @@ import { writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { useTempDir } from "./test-utils.ts";
 import {
+  buildHighLevelSummaryFromCommits,
   categorizeCommits,
   formatCommitsByCategory,
   buildCommitLog,
@@ -157,6 +158,46 @@ describe("formatCommitsByCategory", () => {
     const commits = categorizeCommits("");
     const formatted = formatCommitsByCategory(commits);
     expect(formatted).toBe("_No commits._");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHighLevelSummaryFromCommits
+// ---------------------------------------------------------------------------
+
+describe("buildHighLevelSummaryFromCommits", () => {
+  it("summarizes feature and fix work for reviewers", () => {
+    const summary = buildHighLevelSummaryFromCommits(
+      categorizeCommits(
+        ["abc1234 feat: add dashboard", "def5678 fix: handle empty state"].join(
+          "\n",
+        ),
+      ),
+    );
+
+    expect(summary).toBe(
+      "Adds the main feature work in this branch. Includes a bug fix to improve correctness and stability.",
+    );
+  });
+
+  it("summarizes maintenance-only branches", () => {
+    const summary = buildHighLevelSummaryFromCommits(
+      categorizeCommits(
+        [
+          "abc1234 refactor: simplify runner wiring",
+          "def5678 test: add regression coverage",
+          "aaa1111 docs: update CLI reference",
+        ].join("\n"),
+      ),
+    );
+
+    expect(summary).toBe(
+      "Focuses on maintenance work across refactoring, tests, documentation, and supporting cleanup.",
+    );
+  });
+
+  it("returns null when there are no commits to summarize", () => {
+    expect(buildHighLevelSummaryFromCommits(categorizeCommits(""))).toBeNull();
   });
 });
 

--- a/src/pr-description.ts
+++ b/src/pr-description.ts
@@ -165,6 +165,54 @@ export function buildClosesBlock(options: {
 }
 
 // ---------------------------------------------------------------------------
+// High-level summary generation
+// ---------------------------------------------------------------------------
+
+/** Build a reviewer-facing PR summary from categorized commits. */
+export function buildHighLevelSummaryFromCommits(
+  commits: CategorizedCommits,
+): string | null {
+  const parts: string[] = [];
+
+  if (commits.features.length > 0) {
+    parts.push(
+      commits.features.length === 1
+        ? "Adds the main feature work in this branch."
+        : `Adds ${commits.features.length} feature updates in this branch.`,
+    );
+  }
+
+  if (commits.fixes.length > 0) {
+    parts.push(
+      commits.fixes.length === 1
+        ? "Includes a bug fix to improve correctness and stability."
+        : `Includes ${commits.fixes.length} bug fixes to improve correctness and stability.`,
+    );
+  }
+
+  const maintenanceCount =
+    commits.refactors.length +
+    commits.tests.length +
+    commits.docs.length +
+    commits.chores.length +
+    commits.other.length;
+  if (maintenanceCount > 0) {
+    const focusedOnly = parts.length === 0;
+    if (focusedOnly) {
+      parts.push(
+        "Focuses on maintenance work across refactoring, tests, documentation, and supporting cleanup.",
+      );
+    } else {
+      parts.push(
+        "Also includes supporting maintenance work across refactoring, tests, documentation, or tooling.",
+      );
+    }
+  }
+
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+// ---------------------------------------------------------------------------
 // Body builders
 // ---------------------------------------------------------------------------
 

--- a/src/pr-lifecycle-stdin.test.ts
+++ b/src/pr-lifecycle-stdin.test.ts
@@ -180,6 +180,7 @@ describe("PR body shell-safety", () => {
       completedPlans: ["plan-a"],
       backlogDir,
       cwd: repoDir,
+      summary: DANGEROUS_BODY,
     });
 
     expect(result.ok).toBe(true);
@@ -194,6 +195,7 @@ describe("PR body shell-safety", () => {
     expect(cmd).toContain("--body-file -");
     expect(cmd).not.toContain('--body "');
     expect(typeof opts.input).toBe("string");
+    expect(opts.input).toContain(DANGEROUS_BODY);
   });
 
   it("updateContinuousPr pipes body via stdin on edit", () => {
@@ -303,6 +305,7 @@ describe("PR body shell-safety", () => {
     expect(cmd).toContain("--body-file -");
     expect(cmd).not.toContain('--body "');
     expect(typeof opts.input).toBe("string");
+    expect(opts.input).toContain("Adds the main feature work in this branch.");
   });
 
   it("createPrdPr pipes body via stdin on edit (existing PR)", () => {

--- a/src/pr-lifecycle.test.ts
+++ b/src/pr-lifecycle.test.ts
@@ -400,6 +400,61 @@ describe("buildPrdPrBody", () => {
     expect(body).toContain("add dashboard widget");
   });
 
+  it("leads with a generated high-level summary when commits exist", () => {
+    initRepo(ctx.dir);
+    execSync("git checkout -b feat/test-prd-summary", {
+      cwd: ctx.dir,
+      stdio: "ignore",
+    });
+    writeFileSync(join(ctx.dir, "feature.txt"), "feature\n");
+    execSync('git add -A && git commit -m "feat: add dashboard widget"', {
+      cwd: ctx.dir,
+      stdio: "ignore",
+    });
+    writeFileSync(join(ctx.dir, "fix.txt"), "fix\n");
+    execSync(
+      'git add -A && git commit -m "fix: handle empty dashboard state"',
+      {
+        cwd: ctx.dir,
+        stdio: "ignore",
+      },
+    );
+
+    const body = buildPrdPrBody({
+      prd: { number: 42, title: "Add user dashboard" },
+      completedSubIssues: [10],
+      stuckSubIssues: [],
+      baseBranch: "main",
+      headBranch: "feat/test-prd-summary",
+      cwd: ctx.dir,
+    });
+
+    expect(
+      body.startsWith(
+        "Adds the main feature work in this branch. Includes a bug fix to improve correctness and stability.",
+      ),
+    ).toBe(true);
+    const closesIdx = body.indexOf("Closes #42");
+    const completedIdx = body.indexOf("## Completed Sub-Issues");
+    expect(closesIdx).toBeGreaterThan(-1);
+    expect(completedIdx).toBeGreaterThan(closesIdx);
+  });
+
+  it("falls back to the PRD title when no summary is provided", () => {
+    initRepo(ctx.dir);
+
+    const body = buildPrdPrBody({
+      prd: { number: 42, title: "Add user dashboard" },
+      completedSubIssues: [10],
+      stuckSubIssues: [],
+      baseBranch: "main",
+      headBranch: "main",
+      cwd: ctx.dir,
+    });
+
+    expect(body.startsWith("PRD #42: Add user dashboard")).toBe(true);
+  });
+
   it("renders Waiting on Human section when hitlSubIssues is non-empty", () => {
     initRepo(ctx.dir);
 

--- a/src/pr-lifecycle.ts
+++ b/src/pr-lifecycle.ts
@@ -22,6 +22,7 @@ import {
   buildContinuousPrBodyStructured,
   buildClosesBlock,
   buildCommitLog,
+  buildHighLevelSummaryFromCommits,
   categorizeCommits,
   formatCommitsByCategory,
 } from "./pr-description.ts";
@@ -285,7 +286,13 @@ export function createContinuousPr(
     baseBranch,
     branch,
     cwd,
-    { prdNumber: prd?.number, issueRepo, prRepo, learnings: options.learnings },
+    {
+      prdNumber: prd?.number,
+      issueRepo,
+      prRepo,
+      summary: options.summary,
+      learnings: options.learnings,
+    },
   );
   const esc = (s: string) => s.replace(/"/g, '\\"');
   const prTitle = prd
@@ -397,6 +404,7 @@ export interface PrdPrBodyOptions {
   cwd: string;
   issueRepo?: string;
   prRepo?: string;
+  summary?: string;
 }
 
 /** Build a PR body for an aggregate PRD pull request. */
@@ -412,12 +420,20 @@ export function buildPrdPrBody(options: PrdPrBodyOptions): string {
     cwd,
     issueRepo,
     prRepo,
+    summary,
   } = options;
 
+  const commitLog = buildCommitLog(baseBranch, headBranch, cwd);
+  const categorized = categorizeCommits(commitLog);
+  const formattedCommits = formatCommitsByCategory(categorized);
   const parts: string[] = [];
 
   // Title / description
-  parts.push(`PRD #${prd.number}: ${prd.title}\n`);
+  parts.push(
+    (summary ??
+      buildHighLevelSummaryFromCommits(categorized) ??
+      `PRD #${prd.number}: ${prd.title}`) + "\n",
+  );
 
   // Closes references — PRD + completed sub-issues only
   // Exclude stuck, HITL, and blocked sub-issues from auto-close
@@ -470,9 +486,6 @@ export function buildPrdPrBody(options: PrdPrBodyOptions): string {
   }
 
   // Changes
-  const commitLog = buildCommitLog(baseBranch, headBranch, cwd);
-  const categorized = categorizeCommits(commitLog);
-  const formattedCommits = formatCommitsByCategory(categorized);
   parts.push("\n## Changes\n", formattedCommits);
 
   return parts.join("\n");
@@ -488,6 +501,7 @@ export interface CreatePrdPrOptions {
   blockedSubIssues?: BlockedSubIssue[];
   cwd: string;
   issueRepo?: string;
+  summary?: string;
 }
 
 /** Push branch and create (or update) a draft PR for a PRD aggregate run. */
@@ -502,6 +516,7 @@ export function createPrdPr(options: CreatePrdPrOptions): CreatePrResult {
     blockedSubIssues,
     cwd,
     issueRepo,
+    summary,
   } = options;
 
   const push = pushBranch(branch, cwd, true);
@@ -526,6 +541,7 @@ export function createPrdPr(options: CreatePrdPrOptions): CreatePrResult {
     cwd,
     issueRepo,
     prRepo,
+    summary,
   });
   const esc = (s: string) => s.replace(/"/g, '\\"');
   const prTitle = formatPrTitle(prd.title);


### PR DESCRIPTION
## Summary
- add a high-level, commit-derived summary to PRD aggregate PR bodies before the closes block and checklists
- pass through the agent-generated summary when creating continuous-mode PRs so the initial draft matches later updates
- cover the new PR body behavior with targeted tests and document the updated aggregate PR format

Closes #358