### PR TITLE
feat: conventional commit branch names and PRD PR summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ This shows a pipeline summary header and an interactive menu. From here you can 
 
 ### 3. Run headlessly
 
-Ralphai always creates or reuses a managed worktree on **`ralphai/<plan-slug>`** (or **`feat/<prd-slug>`** for PRD runs), so there is no need to create a feature branch yourself.
+Ralphai always creates or reuses a managed worktree on a **`<type>/<slug>`** branch (e.g. `feat/add-dark-mode`, `fix/broken-login`), so there is no need to create a feature branch yourself.
 
 ```bash
 ralphai run
 ```
 
-Each run creates or reuses an isolated worktree, works on a `ralphai/<plan-slug>` branch, runs build/test/lint, commits, pushes, and opens a draft PR when `gh` is available.
+Each run creates or reuses an isolated worktree, works on a `<type>/<slug>` branch (conventional commit style), runs build/test/lint, commits, pushes, and opens a draft PR when `gh` is available.
 
 ```bash
 ralphai run              # drain the backlog: one branch/PR per plan

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -131,7 +131,7 @@ Use it for headless execution, automation, or when you want to kick off work dir
 What it does:
 
 1. Picks a plan from `backlog/` or resumes one from `in-progress/`
-2. Creates or reuses a worktree on `ralphai/<slug>` (or `feat/<prd-slug>` for PRD-driven runs)
+2. Creates or reuses a worktree on a `<type>/<slug>` branch (e.g. `feat/add-dark-mode`)
 3. Runs the agent inside that worktree
 4. Commits and pushes the branch
 5. Opens or updates a draft PR when `gh` is available

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -173,7 +173,7 @@ Under the hood, `ralphai run` is the headless execution command. It always runs 
 For a normal run, Ralphai:
 
 1. Picks the next plan from `backlog/` or resumes one from `in-progress/`
-2. Creates or reuses a worktree on branch `ralphai/<slug>` (or `feat/<prd-slug>` for PRD-driven runs)
+2. Creates or reuses a worktree on a conventional-commit-style branch (`<type>/<slug>`, e.g. `feat/add-dark-mode`)
 3. Runs the agent inside that worktree
 4. Commits the results there
 5. Pushes the branch
@@ -237,7 +237,7 @@ When `ralphai run` (auto-detect, no target) encounters a plan with `prd: N` fron
 
 | Aspect         | Standalone plan / issue          | PRD                                         |
 | -------------- | -------------------------------- | ------------------------------------------- |
-| Branch         | `ralphai/<slug>` per plan        | `feat/<prd-slug>` for the whole PRD         |
+| Branch         | `<type>/<slug>` per plan         | `<type>/<prd-slug>` for the whole PRD       |
 | PR             | One draft PR per plan            | One aggregate draft PR for all sub-issues   |
 | Stuck handling | Plan is skipped, drain continues | Sub-issue is skipped, PRD continues to next |
 
@@ -257,6 +257,7 @@ Ralphai fetches sub-issues from the GitHub API and processes them in order. Sub-
 
 Per-sub-issue PRs are suppressed. When all sub-issues complete (or are skipped), Ralphai opens a single draft PR with:
 
+- A high-level **Summary** section with agent-generated descriptions of each completed sub-issue
 - A `Closes #N` block for the PRD and each completed sub-issue
 - A checklist of completed sub-issues
 - A checklist of stuck sub-issues (if any)
@@ -321,7 +322,7 @@ Receipt files are plain text, one `key=value` per line:
 ```
 started_at=2026-03-08T14:22:00Z
 worktree_path=/home/user/.ralphai-worktrees/dark-mode
-branch=ralphai/dark-mode
+branch=feat/dark-mode
 slug=dark-mode
 plan_file=dark-mode.md
 tasks_completed=2
@@ -333,7 +334,7 @@ tasks_completed=2
 | ----------------- | ----------------------------------------- | --------------------------------------------------------------- |
 | `started_at`      | `2026-03-08T14:22:00Z`                    | ISO 8601 UTC timestamp of when the run started                  |
 | `worktree_path`   | `/home/user/.ralphai-worktrees/dark-mode` | Absolute path to the managed worktree                           |
-| `branch`          | `ralphai/dark-mode`                       | Git branch the run is on                                        |
+| `branch`          | `feat/dark-mode`                          | Git branch the run is on                                        |
 | `slug`            | `dark-mode`                               | Plan slug, filename minus `.md`                                 |
 | `plan_file`       | `dark-mode.md`                            | Source plan filename                                            |
 | `tasks_completed` | `2`                                       | Number of plan tasks marked complete, parsed from `progress.md` |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -201,7 +201,7 @@ Drains the entire backlog on one worktree per plan and opens/updates a draft PR 
 ralphai run --plan=dark-mode.md
 ```
 
-Targets a specific backlog plan instead of letting Ralphai pick. Creates an isolated worktree with a `ralphai/dark-mode` branch.
+Targets a specific backlog plan instead of letting Ralphai pick. Creates an isolated worktree with a `feat/dark-mode` branch (type derived from the plan title).
 
 ## Manage multiple repos
 

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -25,8 +25,8 @@ Run `ralphai run` from the **main repository**, not from inside a worktree.
 
 ## How it works
 
-1. `ralphai run` creates a git worktree with a `ralphai/<plan-slug>` branch.
-   PRD-driven runs (`ralphai run <number>`) use a `feat/<prd-slug>` branch instead.
+1. `ralphai run` creates a git worktree with a conventional-commit-style branch
+   (e.g. `feat/add-dark-mode`, `fix/broken-login`).
    It reuses existing worktrees for in-progress plans.
 2. If a `setupCommand` is configured, it runs in the worktree directory
    immediately after creation (e.g. `bun install`). This ensures

--- a/src/auto-detect-drain.test.ts
+++ b/src/auto-detect-drain.test.ts
@@ -3,7 +3,7 @@
  * branch and worktree when processed via `ralphai run` (no target).
  *
  * Covers:
- *   - Each plan gets a unique ralphai/<slug> branch
+ *   - Each plan gets a unique <type>/<slug> branch (conventional commit style)
  *   - --once processes exactly one plan
  *   - Worktrees are cleaned up between plans
  *   - Plans with prd: frontmatter route through the PRD flow, not standalone
@@ -147,8 +147,8 @@ describe.skipIf(process.platform === "win32")(
         encoding: "utf-8",
       });
 
-      expect(branches).toContain("ralphai/aaa-first");
-      expect(branches).toContain("ralphai/bbb-second");
+      expect(branches).toContain("feat/plan-first-plan");
+      expect(branches).toContain("feat/plan-second-plan");
     });
 
     test("--once processes exactly one plan when two are available", () => {
@@ -166,8 +166,8 @@ describe.skipIf(process.platform === "win32")(
         encoding: "utf-8",
       });
 
-      expect(branches).toContain("ralphai/aaa-first");
-      expect(branches).not.toContain("ralphai/bbb-second");
+      expect(branches).toContain("feat/plan-first-plan");
+      expect(branches).not.toContain("feat/plan-second-plan");
       expect(existsSync(join(backlogDir, "bbb-second.md"))).toBe(true);
     });
 
@@ -186,7 +186,7 @@ describe.skipIf(process.platform === "win32")(
       expect(existsSync(join(worktreeBase, "aaa-first"))).toBe(false);
     });
 
-    test("plan with prd: frontmatter does not get a standalone ralphai/ branch", () => {
+    test("plan with prd: frontmatter does not get a standalone branch", () => {
       initWithAgent(dir, testEnv());
       process.env.RALPHAI_HOME = ralphaiHome;
 
@@ -195,7 +195,7 @@ describe.skipIf(process.platform === "win32")(
 
       // Run auto-detect. Since there's no GitHub remote, PRD discovery
       // will fail, but the drain loop should NOT process this as a
-      // standalone plan on a ralphai/ branch.
+      // standalone plan on a feature branch.
       const result = runCli(["run"], dir, testEnv(), 60000);
 
       const branches = execSync("git branch --list", {
@@ -204,15 +204,15 @@ describe.skipIf(process.platform === "win32")(
       });
 
       // The plan has prd: frontmatter, so it must NOT be processed as
-      // standalone (which would create a ralphai/gh-99-prd-sub-task branch).
-      expect(branches).not.toContain("ralphai/gh-99-prd-sub-task");
+      // standalone (which would create a feat/plan-gh-99-prd-sub-task branch).
+      expect(branches).not.toContain("feat/plan-gh-99-prd-sub-task");
 
       // The combined output should indicate PRD routing was attempted
       const combined = result.stdout + result.stderr;
       expect(combined).toMatch(/PRD|prd/i);
     });
 
-    test("plan without prd: frontmatter still gets standalone ralphai/ branch", () => {
+    test("plan without prd: frontmatter still gets standalone branch", () => {
       initWithAgent(dir, testEnv());
       process.env.RALPHAI_HOME = ralphaiHome;
       addPlans(dir, testEnv(), [
@@ -227,7 +227,7 @@ describe.skipIf(process.platform === "win32")(
       });
 
       // Plan without prd: should still be processed as standalone
-      expect(branches).toContain("ralphai/standalone-task");
+      expect(branches).toContain("feat/plan-standalone-task");
     });
   },
 );

--- a/src/issues.test.ts
+++ b/src/issues.test.ts
@@ -351,6 +351,34 @@ describe("commitTypeFromTitle", () => {
       description: "update: something",
     });
   });
+
+  it("strips leading PRD: prefix (uppercase)", () => {
+    expect(commitTypeFromTitle("PRD: Add dark mode")).toEqual({
+      type: "feat",
+      description: "Add dark mode",
+    });
+  });
+
+  it("strips leading PRD: prefix before matching CC type", () => {
+    expect(commitTypeFromTitle("PRD: fix: broken login")).toEqual({
+      type: "fix",
+      description: "broken login",
+    });
+  });
+
+  it("strips leading prd: prefix (lowercase)", () => {
+    expect(commitTypeFromTitle("prd: Refactor auth")).toEqual({
+      type: "feat",
+      description: "Refactor auth",
+    });
+  });
+
+  it("strips leading PRD prefix without colon (just space)", () => {
+    expect(commitTypeFromTitle("PRD Add dark mode")).toEqual({
+      type: "feat",
+      description: "Add dark mode",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -399,6 +427,14 @@ describe("issueBranchName", () => {
 
   it("handles empty title", () => {
     expect(issueBranchName("")).toBe("feat/");
+  });
+
+  it("strips PRD: prefix from title", () => {
+    expect(issueBranchName("PRD: Add dark mode")).toBe("feat/add-dark-mode");
+  });
+
+  it("strips PRD: prefix and extracts CC type", () => {
+    expect(issueBranchName("PRD: fix: broken login")).toBe("fix/broken-login");
   });
 });
 

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -151,21 +151,37 @@ const CC_TITLE_PATTERN =
   /^(feat|fix|refactor|test|docs|chore|ci|build|perf|style|revert)(?:\([^)]*\))?!?:\s+(.+)$/i;
 
 /**
+ * Strip a leading "PRD:" or "PRD " prefix (case-insensitive) from a title.
+ *
+ * PRD titles like `"PRD: Add dark mode"` should not leak the "PRD" label
+ * into branch names or PR titles.  Stripping it early lets the rest of the
+ * pipeline treat them like any other title.
+ */
+function stripPrdPrefix(title: string): string {
+  return title.replace(/^prd[:\s]+/i, "").trim();
+}
+
+/**
  * Extract the conventional-commit type and remaining description from a title.
  *
  * If the title starts with a recognised prefix (e.g. `"fix: broken login"`),
  * returns `{ type: "fix", description: "broken login" }`.
  * Otherwise defaults to `{ type: "feat", description: <original title> }`.
+ *
+ * A leading `"PRD:"` label is stripped before matching so that PRD titles
+ * like `"PRD: Add dark mode"` produce `feat/add-dark-mode` instead of
+ * `feat/prd-add-dark-mode`.
  */
 export function commitTypeFromTitle(title: string): {
   type: string;
   description: string;
 } {
-  const m = title.match(CC_TITLE_PATTERN);
+  const cleaned = stripPrdPrefix(title);
+  const m = cleaned.match(CC_TITLE_PATTERN);
   if (m) {
     return { type: m[1]!.toLowerCase(), description: m[2]!.trim() };
   }
-  return { type: "feat", description: title };
+  return { type: "feat", description: cleaned };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pr-lifecycle.test.ts
+++ b/src/pr-lifecycle.test.ts
@@ -506,4 +506,60 @@ describe("buildPrdPrBody", () => {
     expect(matches).toHaveLength(1);
     expect(body).toContain("- [ ] #12 — blocked by HITL #20");
   });
+
+  it("includes Summary section when summaries are provided", () => {
+    initRepo(ctx.dir);
+
+    const summaries = new Map<number, string>();
+    summaries.set(
+      10,
+      "Added JWT-based authentication with login/logout endpoints.",
+    );
+    summaries.set(11, "Implemented rate limiting on auth routes.");
+
+    const body = buildPrdPrBody({
+      prd: { number: 42, title: "Add user dashboard" },
+      completedSubIssues: [10, 11],
+      stuckSubIssues: [],
+      baseBranch: "main",
+      headBranch: "feat/add-user-dashboard",
+      cwd: ctx.dir,
+      summaries,
+    });
+
+    expect(body).toContain("## Summary");
+    expect(body).toContain("**#10:** Added JWT-based authentication");
+    expect(body).toContain("**#11:** Implemented rate limiting");
+  });
+
+  it("omits Summary section when no summaries are provided", () => {
+    initRepo(ctx.dir);
+
+    const body = buildPrdPrBody({
+      prd: { number: 42, title: "Add user dashboard" },
+      completedSubIssues: [10],
+      stuckSubIssues: [],
+      baseBranch: "main",
+      headBranch: "feat/add-user-dashboard",
+      cwd: ctx.dir,
+    });
+
+    expect(body).not.toContain("## Summary");
+  });
+
+  it("omits Summary section when summaries map is empty", () => {
+    initRepo(ctx.dir);
+
+    const body = buildPrdPrBody({
+      prd: { number: 42, title: "Add user dashboard" },
+      completedSubIssues: [10],
+      stuckSubIssues: [],
+      baseBranch: "main",
+      headBranch: "feat/add-user-dashboard",
+      cwd: ctx.dir,
+      summaries: new Map(),
+    });
+
+    expect(body).not.toContain("## Summary");
+  });
 });

--- a/src/pr-lifecycle.ts
+++ b/src/pr-lifecycle.ts
@@ -201,10 +201,11 @@ export function createPr(options: CreatePrOptions): CreatePrResult {
     reviewPassMadeChanges: options.reviewPassMadeChanges,
   });
   const esc = (s: string) => s.replace(/"/g, '\\"');
+  const prTitle = formatPrTitle(planDescription);
 
   const prUrl = execWithStdin(
     `gh pr create --base "${baseBranch}" --head "${branch}" ` +
-      `--title "${esc(planDescription)}" --body-file - --draft`,
+      `--title "${esc(prTitle)}" --body-file - --draft`,
     prBody,
     cwd,
   );
@@ -400,6 +401,8 @@ export interface PrdPrBodyOptions {
   cwd: string;
   issueRepo?: string;
   prRepo?: string;
+  /** Agent-generated summaries keyed by sub-issue number. */
+  summaries?: Map<number, string>;
 }
 
 /** Build a PR body for an aggregate PRD pull request. */
@@ -415,12 +418,22 @@ export function buildPrdPrBody(options: PrdPrBodyOptions): string {
     cwd,
     issueRepo,
     prRepo,
+    summaries,
   } = options;
 
   const parts: string[] = [];
 
   // Title / description
   parts.push(`PRD #${prd.number}: ${prd.title}\n`);
+
+  // High-level summary from agent-generated PR summaries
+  if (summaries && summaries.size > 0) {
+    parts.push("## Summary\n");
+    for (const [issueNum, summary] of summaries) {
+      parts.push(`- **#${issueNum}:** ${summary}`);
+    }
+    parts.push("");
+  }
 
   // Closes references — PRD + completed sub-issues only
   // Exclude stuck, HITL, and blocked sub-issues from auto-close
@@ -491,6 +504,8 @@ export interface CreatePrdPrOptions {
   blockedSubIssues?: BlockedSubIssue[];
   cwd: string;
   issueRepo?: string;
+  /** Agent-generated summaries keyed by sub-issue number. */
+  summaries?: Map<number, string>;
 }
 
 /** Push branch and create (or update) a draft PR for a PRD aggregate run. */
@@ -505,6 +520,7 @@ export function createPrdPr(options: CreatePrdPrOptions): CreatePrResult {
     blockedSubIssues,
     cwd,
     issueRepo,
+    summaries,
   } = options;
 
   const push = pushBranch(branch, cwd, true);
@@ -529,6 +545,7 @@ export function createPrdPr(options: CreatePrdPrOptions): CreatePrResult {
     cwd,
     issueRepo,
     prRepo,
+    summaries,
   });
   const esc = (s: string) => s.replace(/"/g, '\\"');
   const prTitle = formatPrTitle(prd.title);

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -21,6 +21,7 @@ import {
   resolvePlanPath,
   planExistsForSlug,
   countCompletedTasks,
+  getPlanDescription,
 } from "./plan-detection.ts";
 import {
   parseReceipt,
@@ -2137,6 +2138,7 @@ async function runPrdIssueTarget(
   const stuckSubIssues: number[] = [];
   const completedSubIssues: number[] = [];
   const blockedSubIssues: BlockedSubIssue[] = [];
+  const subIssueSummaries = new Map<number, string>();
   let completedCount = 0;
 
   for (const subIssueNumber of eligibleSubIssues) {
@@ -2235,6 +2237,9 @@ async function runPrdIssueTarget(
       } else {
         completedCount++;
         completedSubIssues.push(subIssueNumber);
+        if (result.lastPrSummary) {
+          subIssueSummaries.set(subIssueNumber, result.lastPrSummary);
+        }
       }
     } catch (error) {
       // Runner may exit on stuck detection or other errors
@@ -2293,6 +2298,7 @@ async function runPrdIssueTarget(
       blockedSubIssues,
       cwd: resolvedWorktreeDir,
       issueRepo,
+      summaries: subIssueSummaries,
     });
     console.log(prResult.message);
   } else {
@@ -2877,7 +2883,10 @@ async function runRalphaiInManagedWorktree(
       }
     }
 
-    const branch = `ralphai/${plan.slug}`;
+    const planDesc = planFullPath
+      ? getPlanDescription(planFullPath)
+      : plan.planFile;
+    const branch = issueBranchName(planDesc);
     const resolvedWorktreeDir = prepareWorktree(
       cwd,
       plan.slug,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -61,6 +61,7 @@ import {
   pullGithubIssues,
   pullPrdSubIssue,
   checkAllPrdSubIssuesDone,
+  issueBranchName,
 } from "./issues.ts";
 import { archiveRun, createPr } from "./pr-lifecycle.ts";
 import { runCompletionGate, formatGateRejection } from "./completion-gate.ts";
@@ -97,6 +98,8 @@ import { type ResolvedConfig } from "./config.ts";
 export interface RunnerResult {
   /** Slugs of plans that got stuck during this run. */
   stuckSlugs: string[];
+  /** Agent-generated PR summary from the last completed plan (if any). */
+  lastPrSummary?: string;
 }
 
 /** Options passed from the CLI layer to the runner. */
@@ -487,7 +490,7 @@ function runDryRun(opts: RunnerOptions, dirs: PipelineDirs): void {
     console.log(`[dry-run] Scope: ${planScope}`);
   }
 
-  const branch = `ralphai/${planSlug}`;
+  const branch = issueBranchName(planDesc);
   const progressFile = join(dirs.wipDir, planSlug, "progress.md");
   const worktreeDir = join(cwd, "..", ".ralphai-worktrees", planSlug);
 
@@ -500,15 +503,6 @@ function runDryRun(opts: RunnerOptions, dirs: PipelineDirs): void {
     );
   } else {
     console.log(`[dry-run] Would create worktree: ${worktreeDir}`);
-  }
-
-  if (execOk('git show-ref --verify --quiet "refs/heads/ralphai"', cwd)) {
-    console.log(
-      `[dry-run] WARNING: Branch 'ralphai' exists and would block creation of '${branch}'.`,
-    );
-    console.log(
-      "[dry-run] Fix: git branch -m ralphai ralphai-legacy  OR  git branch -D ralphai",
-    );
   }
 
   const collision = branchHasOpenWork(branch, cwd);
@@ -803,7 +797,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         execQuiet("git rev-parse --abbrev-ref HEAD", cwd) ?? "unknown";
       if (currentBranch === baseBranch) {
         console.error(
-          `ERROR: Resuming requires being on a ralphai/* branch, not '${baseBranch}'.`,
+          `ERROR: Resuming requires being on a feature branch, not '${baseBranch}'.`,
         );
         console.error(
           "Checkout the branch you want to resume, then run again.",
@@ -822,7 +816,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         );
         console.error("Create a worktree on a feature branch instead:");
         console.error(
-          `  git worktree add ../<dir> -b ralphai/${planSlug} ${baseBranch}`,
+          `  git worktree add ../<dir> -b ${issueBranchName(planDesc)} ${baseBranch}`,
         );
         rollbackPlan(planFile, dirs.backlogDir);
         process.exit(1);
@@ -1360,5 +1354,5 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
   process.removeListener("SIGINT", handleSignal);
   process.removeListener("SIGTERM", handleSignal);
 
-  return { stuckSlugs };
+  return { stuckSlugs, lastPrSummary };
 }


### PR DESCRIPTION
## Summary

- Switch all branch naming from `ralphai/<slug>` to `<type>/<slug>` (conventional commit style, e.g. `feat/add-dark-mode`, `fix/broken-login`) for both plan-based and issue-driven runs
- Strip `PRD:` prefix from issue titles before branch/slug generation so PRD titles no longer leak "prd" into branch names
- Normalize single-plan PR titles with `formatPrTitle()` so they consistently use conventional commit format
- Add a `## Summary` section to PRD aggregate PR bodies containing agent-generated summaries from each completed sub-issue, providing high-level context about the work done

## Details

### Branch naming
- `commitTypeFromTitle()` now strips leading `PRD:` / `PRD ` prefix before matching conventional commit types
- Plan-based runs (backlog drain) derive branch names from plan title via `issueBranchName(planDesc)` instead of hardcoded `ralphai/<slug>`
- Backward compat: existing `ralphai/` prefixed branches are still recognized by cleanup, pipeline state, and worktree management code

### PR improvements
- `createPr()` now uses `formatPrTitle()` for the PR title (was raw plan description)
- `RunnerResult` now includes `lastPrSummary` so the PRD flow can collect summaries
- `buildPrdPrBody()` renders a `## Summary` section with bullet points per sub-issue when agent summaries are available

### Docs
Updated README.md, cli-reference.md, how-ralphai-works.md, workflows.md, and worktrees.md to reflect the new branch naming convention and PR summary feature.