### PR TITLE
fix: add opencode install path to Docker image PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,4 +55,8 @@ RUN if [ "$AGENT" = "codex" ]; then \
 # Configure git defaults for container use
 RUN git config --system --add safe.directory '*'
 
+# Ensure agent install paths are on PATH (install scripts only update .bashrc,
+# which isn't sourced in non-interactive shells)
+ENV PATH="/root/.opencode/bin:${PATH}"
+
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Add `/root/.opencode/bin` to the Docker image `PATH` via `ENV`
- The OpenCode install script only updates `~/.bashrc`, which isn't sourced in non-interactive shells (like the smoke test's `sh -c`)
- Mirrors the existing pattern used for Bun on line 32