### PR TITLE
feat: add pnpm/yarn support to Docker sandbox images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,7 @@ jobs:
             sh -c "
               git --version && \
               node --version && \
+              pnpm --version && \
               bun --version && \
               ${{ matrix.agent }} --version
             "

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+# Enable corepack for pnpm and yarn support
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
 # Install Bun
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -531,7 +531,7 @@ Ralphai publishes pre-built Docker images for supported agents:
 - `ghcr.io/mfaux/ralphai-sandbox:opencode`
 - `ghcr.io/mfaux/ralphai-sandbox:codex`
 
-Images are based on `debian:bookworm-slim` and include git, curl, Node.js (LTS), Bun, and the agent CLI. The image is auto-resolved from the agent command (e.g., `claude -p` → `:claude`). Unrecognized agents fall back to the `:latest` tag. Override with the `dockerImage` config key for custom images.
+Images are based on `debian:bookworm-slim` and include git, curl, Node.js (LTS), pnpm (via corepack), Bun, and the agent CLI. The image is auto-resolved from the agent command (e.g., `claude -p` → `:claude`). Unrecognized agents fall back to the `:latest` tag. Override with the `dockerImage` config key for custom images.
 
 ### Stdio-based progress extraction
 

--- a/src/worktree/management.ts
+++ b/src/worktree/management.ts
@@ -119,7 +119,13 @@ export function executeSetupCommand(
         console.error(`  ${result.error.message}`);
       }
       console.error(
-        `\nFix the issue and re-run, or set ${TEXT}setupCommand${RESET} to "" in config to disable.`,
+        `\nThe sandbox image may be missing tools your project needs.`,
+      );
+      console.error(
+        `Use ${TEXT}--docker-image${RESET} to specify a custom image with your project's dependencies,`,
+      );
+      console.error(
+        `or set ${TEXT}setupCommand${RESET} to "" in config to disable setup.`,
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

- **Add pnpm/yarn to sandbox image**: Enable corepack and pre-download pnpm in the Dockerfile so projects using `pnpm` or `yarn` work out of the box in Docker sandbox mode. Previously, `pnpm install` setup commands failed with `sh: 1: pnpm: not found`.
- **Improve Docker setup error message**: When a setup command fails inside Docker, the error now suggests `--docker-image` for projects needing runtimes not in the base image (e.g., .NET, Go, Rust) instead of the generic "fix the issue and re-run" message.
- **Add pnpm to CI smoke test**: Verify pnpm is available in all published sandbox images.
- **Update docs**: Mention pnpm in the image contents description.

## Files changed

| File | Change |
|------|--------|
| `docker/Dockerfile` | `corepack enable && corepack prepare pnpm@latest --activate` after Node.js install |
| `src/worktree/management.ts` | Actionable error message suggesting `--docker-image` |
| `.github/workflows/docker.yml` | `pnpm --version` in smoke test |
| `docs/how-ralphai-works.md` | Mention pnpm in image contents |