### PR TITLE
feat: auto-pull Docker image at run start

### DIFF
--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -533,6 +533,8 @@ Ralphai publishes pre-built Docker images for supported agents:
 
 Images are based on `debian:bookworm-slim` and include git, curl, Node.js (LTS), pnpm (via corepack), Bun, and the agent CLI. The image is auto-resolved from the agent command (e.g., `claude -p` → `:claude`). Unrecognized agents fall back to the `:latest` tag. Override with the `dockerImage` config key for custom images.
 
+At the start of each run, Ralphai pulls the resolved image (`docker pull --quiet`) to ensure the local cache is up to date. The pull is fail-open: if it fails (e.g., no network), the run continues with whatever image is cached locally.
+
 ### Stdio-based progress extraction
 
 Because the container's stdout and stderr are piped back to the runner process, all existing progress extraction, learnings extraction, and completion sentinel detection work unchanged. The `<progress>`, `<learnings>`, `<promise>`, and `<pr-summary>` sentinel tags are parsed from the container's output stream the same way they are parsed from a local process.

--- a/src/docker-executor.test.ts
+++ b/src/docker-executor.test.ts
@@ -15,6 +15,7 @@ import {
   buildSetupDockerArgs,
   checkDockerAvailability,
   formatDockerCommand,
+  pullDockerImage,
   resolveDockerImage,
   DockerExecutor,
 } from "./executor/docker.ts";
@@ -672,5 +673,45 @@ describe("buildSetupDockerArgs", () => {
       dockerMounts: ["/host/cache:/container/cache"],
     });
     expect(args).toContain("/host/cache:/container/cache");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pullDockerImage
+// ---------------------------------------------------------------------------
+
+describe("pullDockerImage", () => {
+  it("resolves auto-detected image in result", () => {
+    // Use a definitely-nonexistent image so the pull fails fast
+    // without attempting a real network pull
+    const result = pullDockerImage(
+      "claude -p",
+      "localhost:1/nonexistent:never",
+    );
+    expect(result.image).toBe("localhost:1/nonexistent:never");
+  });
+
+  it("uses custom dockerImage when provided", () => {
+    const result = pullDockerImage("claude -p", "localhost:1/my-image:v1");
+    expect(result.image).toBe("localhost:1/my-image:v1");
+  });
+
+  it("returns success: false when docker pull fails", () => {
+    const result = pullDockerImage(
+      "claude -p",
+      "localhost:1/nonexistent:never",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("auto-resolves image from agent command when no override", () => {
+    // Verify image resolution is correct without triggering a real pull.
+    // We can't call pullDockerImage with a real registry image in tests
+    // (it would timeout), so verify via resolveDockerImage instead —
+    // pullDockerImage delegates to it for image resolution.
+    expect(resolveDockerImage("opencode run --agent build")).toBe(
+      "ghcr.io/mfaux/ralphai-sandbox:opencode",
+    );
   });
 });

--- a/src/executor/docker.ts
+++ b/src/executor/docker.ts
@@ -247,6 +247,46 @@ export function checkDockerAvailability(
 }
 
 // ---------------------------------------------------------------------------
+// Image pull
+// ---------------------------------------------------------------------------
+
+/** Result of a Docker image pull attempt. */
+export interface DockerPullResult {
+  /** Whether the pull succeeded. */
+  success: boolean;
+  /** The image that was pulled (or attempted). */
+  image: string;
+  /** Error message on failure. */
+  error?: string;
+}
+
+/**
+ * Pull the Docker image to ensure the local cache is up to date.
+ *
+ * Runs `docker pull --quiet <image>` synchronously. This is fail-open:
+ * if the pull fails (e.g. no network), the run continues with whatever
+ * image is cached locally. This avoids blocking offline use while still
+ * keeping images fresh when connectivity is available.
+ */
+export function pullDockerImage(
+  agentCommand: string,
+  dockerImage?: string,
+): DockerPullResult {
+  const image = resolveDockerImage(agentCommand, dockerImage);
+
+  try {
+    require("child_process").execSync(`docker pull --quiet ${image}`, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { success: true, image };
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error ? err.message : "Unknown error during docker pull";
+    return { success: false, image, error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Command construction
 // ---------------------------------------------------------------------------
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -25,6 +25,7 @@ import { execQuiet, execOk } from "./exec.ts";
 import { createExecutor, type AgentExecutor } from "./executor/index.ts";
 import {
   checkDockerAvailability,
+  pullDockerImage,
   buildDockerArgs,
   formatDockerCommand,
 } from "./executor/docker.ts";
@@ -603,6 +604,23 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         console.error(`ERROR: ${dockerCheck.error}`);
         process.exit(1);
       }
+    }
+  }
+
+  // --- Pull Docker image to ensure local cache is up to date ---
+  // Fail-open: if the pull fails (e.g. no network), continue with the
+  // cached image. Skipped in dry-run mode (no side effects).
+  if (config.sandbox.value === "docker" && !dryRun) {
+    const pullResult = pullDockerImage(
+      agentCommand,
+      config.dockerImage.value || undefined,
+    );
+    if (pullResult.success) {
+      console.log(`Docker image up to date: ${pullResult.image}`);
+    } else {
+      console.warn(
+        `WARNING: Failed to pull ${pullResult.image} — using cached image if available.`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- **Auto-pull Docker image on every run**: Adds a `docker pull --quiet` step at runner startup (after the Docker availability check, before worktree creation) so users always get the latest sandbox image without manual intervention. No more stale cached images after a release.
- **Fail-open design**: If the pull fails (no network, registry down), the run continues with the cached image and logs a warning. This preserves offline use.
- **Respects --dry-run**: The pull is skipped in dry-run mode per the project's dry-run safety convention.
- **Works with custom images**: `--docker-image` overrides are also pulled, keeping custom images fresh too.

## Files changed

| File | Change |
|------|--------|
| `src/executor/docker.ts` | New `pullDockerImage()` function with `DockerPullResult` type |
| `src/runner.ts` | Call `pullDockerImage()` after Docker availability check |
| `src/docker-executor.test.ts` | Tests for `pullDockerImage()` — image resolution, custom override, failure handling |
| `docs/how-ralphai-works.md` | Document the auto-pull behavior |