### PR TITLE
fix: handle EACCES when removing orphaned worktree directories

### DIFF
--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -2626,85 +2626,18 @@ async function runRalphaiInManagedWorktree(
       }
 
       // --- Real PRD run: create worktree with PRD-derived branch ---
-      try {
-        execSync("git rev-parse HEAD", { cwd, stdio: "ignore" });
-      } catch {
-        console.error(
-          `This repository has no commits yet. Git worktrees require at least one commit.`,
-        );
-        console.error(
-          `\n  ${TEXT}git add . && git commit -m "initial commit"${RESET}`,
-        );
-        console.error(`\nThen re-run ${TEXT}ralphai run${RESET}.`);
-        process.exit(1);
-      }
-
+      ensureRepoHasCommit(cwd);
       const baseBranch = detectBaseBranch(cwd);
-      const worktreeBase = join(cwd, "..", ".ralphai-worktrees");
-      const desiredWorktreeDir = join(worktreeBase, prdSlug);
-      mkdirSync(worktreeBase, { recursive: true });
-
-      // Check for active worktree on this branch
       const activeWorktrees = listRalphaiWorktrees(cwd);
       const activeWorktree = activeWorktrees.find((wt) => wt.branch === branch);
-
-      let resolvedWorktreeDir = desiredWorktreeDir;
-      if (activeWorktree) {
-        resolvedWorktreeDir = activeWorktree.path;
-        console.log(`Reusing existing worktree: ${resolvedWorktreeDir}`);
-        console.log(`Branch: ${branch}`);
-      } else {
-        if (existsSync(resolvedWorktreeDir)) {
-          console.log(
-            `Cleaning up orphaned worktree directory: ${resolvedWorktreeDir}`,
-          );
-          execSync("git worktree prune", { cwd, stdio: "ignore" });
-          rmSync(resolvedWorktreeDir, { recursive: true, force: true });
-        }
-
-        let branchExists = false;
-        try {
-          execSync(`git show-ref --verify --quiet refs/heads/${branch}`, {
-            cwd,
-            stdio: "ignore",
-          });
-          branchExists = true;
-        } catch {
-          branchExists = false;
-        }
-
-        try {
-          if (branchExists) {
-            console.log(`Recreating worktree: ${resolvedWorktreeDir}`);
-            console.log(`Branch: ${branch}`);
-            execSync(`git worktree add "${resolvedWorktreeDir}" "${branch}"`, {
-              cwd,
-              stdio: ["inherit", "pipe", "pipe"],
-            });
-          } else {
-            console.log(`Creating worktree: ${resolvedWorktreeDir}`);
-            console.log(`Branch: ${branch} (from ${baseBranch})`);
-            execSync(
-              `git worktree add "${resolvedWorktreeDir}" -b "${branch}" "${baseBranch}"`,
-              { cwd, stdio: ["inherit", "pipe", "pipe"] },
-            );
-          }
-        } catch (err: unknown) {
-          const stderr = extractExecStderr(err);
-          console.error(`${TEXT}Error:${RESET} Failed to prepare worktree.`);
-          if (stderr) console.error(`  git: ${stderr}`);
-          process.exit(1);
-        }
-      }
-
-      // Run setup command in freshly-created worktrees (not reused ones)
-      if (!activeWorktree) {
-        executeSetupCommand(
-          setupCommand,
-          resolvedWorktreeDir,
-          setupSandboxConfig,
-        );
-      }
+      const resolvedWorktreeDir = prepareWorktree(
+        cwd,
+        prdSlug,
+        branch,
+        baseBranch,
+        setupCommand,
+        setupSandboxConfig,
+      );
 
       // NOTE: The feedback wrapper script is written by the runner to the
       // WIP slug directory (pipeline state), not the worktree. No wrapper

--- a/src/worktree/management.ts
+++ b/src/worktree/management.ts
@@ -206,7 +206,27 @@ export function prepareWorktree(
         `Cleaning up orphaned worktree directory: ${resolvedWorktreeDir}`,
       );
       execSync("git worktree prune", { cwd, stdio: "ignore" });
-      rmSync(resolvedWorktreeDir, { recursive: true, force: true });
+      try {
+        rmSync(resolvedWorktreeDir, { recursive: true, force: true });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EACCES") {
+          // Retry after fixing permissions (common with node_modules/.bin)
+          try {
+            execSync(`chmod -R u+rwx "${resolvedWorktreeDir}"`, {
+              stdio: "ignore",
+            });
+            rmSync(resolvedWorktreeDir, { recursive: true, force: true });
+          } catch {
+            throw new Error(
+              `Could not remove orphaned worktree directory: ${resolvedWorktreeDir}\n` +
+                `Fix manually:\n\n` +
+                `  sudo rm -rf "${resolvedWorktreeDir}"\n`,
+            );
+          }
+        } else {
+          throw err;
+        }
+      }
     }
 
     let branchExists = false;


### PR DESCRIPTION
## Summary

- Fixes `EACCES: permission denied, rmdir` crash when ralphai tries to clean up an orphaned worktree directory containing files with restrictive permissions (e.g., `node_modules/.bin` or Docker-owned files).
- Wraps `rmSync` in a try/catch with a `chmod -R u+rwx` retry. On persistent failure, throws a descriptive error with a `sudo rm -rf` recovery command instead of crashing.
- Deduplicates the PRD code path in `ralphai.ts` that inlined the same worktree preparation logic — it now delegates to `prepareWorktree()`, matching how all other code paths already work.