### PR TITLE
fix: detect agent type from binary name only, not flag values

### DIFF
--- a/src/show-config.test.ts
+++ b/src/show-config.test.ts
@@ -79,6 +79,21 @@ describe("detectAgentType", () => {
   it("is case-insensitive", () => {
     expect(detectAgentType("CLAUDE -p")).toBe("claude");
   });
+
+  it("matches only the binary name, not flag values", () => {
+    // opencode command with a --model flag that contains "claude" should
+    // detect as opencode, not claude.
+    expect(
+      detectAgentType(
+        "opencode run --agent build --model github-copilot/claude-opus-4.6",
+      ),
+    ).toBe("opencode");
+  });
+
+  it("ignores agent names appearing in non-binary arguments", () => {
+    expect(detectAgentType("my-tool --backend claude")).toBe("unknown");
+    expect(detectAgentType("codex --model opencode-v2")).toBe("codex");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/show-config.ts
+++ b/src/show-config.ts
@@ -25,12 +25,17 @@ const AGENT_PATTERNS: ReadonlyArray<[pattern: string, type: string]> = [
 
 /**
  * Detect the agent type from the agent command string.
+ *
+ * Only the binary/command portion (first token) is matched so that flag
+ * values like `--model github-copilot/claude-opus-4` don't cause a
+ * false match.
  */
 export function detectAgentType(agentCommand: string): string {
   if (!agentCommand) return "unknown";
-  const lower = agentCommand.toLowerCase();
+  // Extract the first token (the binary name) and match against that.
+  const binary = (agentCommand.trim().split(/\s+/)[0] ?? "").toLowerCase();
   for (const [pattern, type] of AGENT_PATTERNS) {
-    if (lower.includes(pattern)) return type;
+    if (binary.includes(pattern)) return type;
   }
   return "unknown";
 }


### PR DESCRIPTION
## Summary

- `detectAgentType()` matched against the full command string, so `opencode run --model github-copilot/claude-opus-4.6` matched `"claude"` (from the `--model` flag value) before `"opencode"`, causing the wrong Docker sandbox image (`:claude` instead of `:opencode`) to be selected.
- Now only the first token (the binary name) is used for pattern matching, preventing flag values from causing false matches.
- Adds test cases covering the exact bug scenario and other argument-position edge cases.