### PR TITLE
fix(docker): bind-mount feedback wrapper script into container

### DIFF
--- a/src/docker-executor.test.ts
+++ b/src/docker-executor.test.ts
@@ -165,6 +165,49 @@ describe("buildDockerArgs", () => {
     const hasNonce = args.some((a) => a.includes("RALPHAI_NONCE"));
     expect(hasNonce).toBe(false);
   });
+
+  describe("feedbackWrapperPath — bind-mount feedback script", () => {
+    const ctx = useTempDir();
+
+    it("bind-mounts feedback script read-only when file exists", () => {
+      const scriptPath = join(ctx.dir, "_ralphai_feedback.sh");
+      writeFileSync(scriptPath, "#!/bin/bash\nbun test", { mode: 0o755 });
+
+      const args = buildDockerArgs({
+        agentCommand: "claude -p",
+        prompt: "do stuff",
+        cwd: "/work/my-project",
+        feedbackWrapperPath: scriptPath,
+      });
+
+      const mountArg = args.find((a) => a.includes("_ralphai_feedback.sh"));
+      expect(mountArg).toBeDefined();
+      expect(mountArg).toBe(`${scriptPath}:${scriptPath}:ro`);
+    });
+
+    it("does NOT mount when feedbackWrapperPath is not set", () => {
+      const args = buildDockerArgs({
+        agentCommand: "claude -p",
+        prompt: "do stuff",
+        cwd: "/work/my-project",
+      });
+
+      const hasFeedback = args.some((a) => a.includes("_ralphai_feedback"));
+      expect(hasFeedback).toBe(false);
+    });
+
+    it("does NOT mount when feedbackWrapperPath file does not exist", () => {
+      const args = buildDockerArgs({
+        agentCommand: "claude -p",
+        prompt: "do stuff",
+        cwd: "/work/my-project",
+        feedbackWrapperPath: "/nonexistent/path/_ralphai_feedback.sh",
+      });
+
+      const hasFeedback = args.some((a) => a.includes("_ralphai_feedback"));
+      expect(hasFeedback).toBe(false);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/executor/docker.ts
+++ b/src/executor/docker.ts
@@ -306,6 +306,14 @@ export interface DockerCommandOptions {
   dockerMounts?: string[];
   /** Optional nonce for RALPHAI_NONCE env var. */
   nonce?: string;
+  /**
+   * Optional absolute path to the feedback wrapper script on the host.
+   *
+   * When set, the script is bind-mounted read-only into the container
+   * at the same path so the agent can invoke it. Without this, the
+   * script lives in pipeline state (~/.ralphai/…) which is not mounted.
+   */
+  feedbackWrapperPath?: string;
 }
 
 /**
@@ -329,6 +337,7 @@ export function buildDockerArgs(opts: DockerCommandOptions): string[] {
     dockerEnvVars = [],
     dockerMounts = [],
     nonce,
+    feedbackWrapperPath,
   } = opts;
 
   const agentType = detectAgentType(agentCommand);
@@ -339,6 +348,13 @@ export function buildDockerArgs(opts: DockerCommandOptions): string[] {
   // Worktree bind mount (read-write so the agent can modify files)
   args.push("-v", `${cwd}:${cwd}`);
   args.push("-w", cwd);
+
+  // Feedback wrapper script: lives in pipeline state (~/.ralphai/…)
+  // which is not otherwise mounted. Bind-mount the single file
+  // read-only so the agent can invoke it from inside the container.
+  if (feedbackWrapperPath && existsSync(feedbackWrapperPath)) {
+    args.push("-v", `${feedbackWrapperPath}:${feedbackWrapperPath}:ro`);
+  }
 
   // Env var forwarding
   const envFlags = buildEnvFlags(agentType, dockerEnvVars);
@@ -484,6 +500,7 @@ export class DockerExecutor implements AgentExecutor {
       outputLogPath,
       ipcBroadcast,
       nonce,
+      feedbackWrapperPath,
     } = opts;
 
     const dockerArgs = buildDockerArgs({
@@ -494,6 +511,7 @@ export class DockerExecutor implements AgentExecutor {
       dockerEnvVars: this.config.dockerEnvVars,
       dockerMounts: this.config.dockerMounts,
       nonce,
+      feedbackWrapperPath,
     });
 
     return new Promise((resolve) => {

--- a/src/executor/types.ts
+++ b/src/executor/types.ts
@@ -28,6 +28,8 @@ export interface ExecutorSpawnOptions {
   ipcBroadcast?: (msg: IpcMessage) => void;
   /** Optional nonce injected as RALPHAI_NONCE env var. */
   nonce?: string;
+  /** Optional path to the feedback wrapper script (bind-mounted into Docker). */
+  feedbackWrapperPath?: string;
 }
 
 /** Result returned by `AgentExecutor.spawn()`. */

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -967,6 +967,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
           ? (msg) => ipcServer!.broadcast(msg)
           : undefined,
         nonce,
+        feedbackWrapperPath: wrapperPath,
       });
 
       if (timedOut) {


### PR DESCRIPTION
## Summary

- Bind-mount the feedback wrapper script (`_ralphai_feedback.sh`) read-only into Docker containers so the agent can invoke it
- The script lives in pipeline state (`~/.ralphai/…`) which is not otherwise mounted, causing "No such file or directory" errors on every Docker sandbox iteration
- Adds `feedbackWrapperPath` to `ExecutorSpawnOptions` and `DockerCommandOptions`, threaded from the runner through the Docker executor

## Problem

After PR #360 moved the feedback wrapper out of the worktree into pipeline state (`~/.ralphai/repos/<id>/pipeline/in-progress/<slug>/`), Docker sandbox runs broke: the prompt tells the agent to run the script at its absolute host path, but `~/.ralphai/` is intentionally not mounted into the container. Both gh-369 and gh-370 agent runs hit this repeatedly.

## Fix

When `feedbackWrapperPath` is set and the file exists, `buildDockerArgs` adds a single `-v /path/to/script:/path/to/script:ro` bind-mount. This is minimal (one read-only file, no directory exposure) and transparent (same absolute path inside and outside the container).