### PR TITLE
fix: ensure bun binary is world-executable in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 # Install Bun to a global path (not /root/.bun)
+# Explicit chmod ensures the binary is world-executable for non-root
+# container users (the --user flag sets an arbitrary UID at runtime).
 ENV BUN_INSTALL=/usr/local
-RUN curl -fsSL https://bun.sh/install | bash
+RUN curl -fsSL https://bun.sh/install | bash && \
+    chmod 755 /usr/local/bin/bun
 
 # ---------------------------------------------------------------------------
 # Agent CLI installation (conditional on AGENT build arg)


### PR DESCRIPTION
## Summary

- The bun install script (`bun.sh/install`) does not guarantee world-execute permissions on the binary it installs. When the sandbox container runs as a non-root host user (via `--user UID:GID`), this causes `sh: 1: bun: Permission denied` during setup command execution.
- Adds explicit `chmod 755 /usr/local/bin/bun` after installation, matching the pattern already used for the opencode binary (line 72).

## Repro

Run `ralphai` on a project with `sandbox: "docker"` and `setupCommand: "bun install"`:

```
Running setup command in Docker: bun install
sh: 1: bun: Permission denied
Error: Setup command failed in Docker container: bun install
```