### PR TITLE
fix: completion gate force-accepts plans with zero tasks completed

### DIFF
--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -91,6 +91,8 @@ When the agent signals that all tasks are complete, Ralphai runs a **completion 
 
 If any check fails, the gate **rejects** and Ralphai re-invokes the agent with a fresh session that includes the rejection details. PR-tier failures are labeled `[PR-tier]` in the rejection message so the agent knows which commands failed and can fix them.
 
+The gate allows up to 2 consecutive rejections before force-accepting to prevent infinite loops. However, if the plan has **zero tasks completed** out of a non-zero total when the rejection budget is exhausted, the plan is marked **stuck** instead of force-accepted — zero progress indicates the agent failed entirely and should not produce a PR.
+
 ```
     Agent signals COMPLETE
               ▼

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,10 @@ Ralphai aborts when it detects 3 consecutive iterations with no new commits (con
 
 The `--resume` flag auto-commits any dirty working tree state and continues from where the agent left off, preserving the existing progress file.
 
+### "Plan stuck with zero tasks completed"
+
+If the agent claims COMPLETE but the progress file shows 0 out of N tasks completed, Ralphai marks the plan as stuck after exhausting the gate rejection budget (2 rejections). This typically means the agent failed to update the progress file in the expected format (checkbox `- [x]` items or `**Status:** Complete` markers). Check the agent output log in `pipeline/in-progress/<slug>/agent-output.log` to see what the agent produced, and verify the plan's task format matches what the agent is outputting.
+
 ## "Agent keeps making the same mistake"
 
 Learnings are extracted from the agent's output automatically and surfaced in the **Learnings** section of the draft PR. Ralphai also injects them into subsequent iterations as anti-repeat memory, so the agent sees past mistakes without manual intervention.

--- a/src/runner-zero-completion.test.ts
+++ b/src/runner-zero-completion.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the zero-completion guard in the runner's completion gate.
+ *
+ * When the agent exhausts the gate rejection budget with zero tasks
+ * completed (out of a non-zero total), the plan should be marked stuck
+ * instead of force-accepted. Plans with partial progress (≥1 task)
+ * should still be force-accepted as before.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { execSync } from "child_process";
+
+import { runRunner, type RunnerOptions, type RunnerResult } from "./runner.ts";
+import { type ResolvedConfig } from "./config.ts";
+import { getRepoPipelineDirs } from "./global-state.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors runner.test.ts patterns)
+// ---------------------------------------------------------------------------
+
+function createTmpGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "runner-zero-comp-"));
+  execSync("git init -b main", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  execSync('git add -A && git commit -m "init"', { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+function createManagedWorktree(mainDir: string, slug: string): string {
+  const worktreeDir = join(tmpdir(), `runner-wt-${slug}-${Date.now()}`);
+  execSync(`git worktree add "${worktreeDir}" -b "ralphai/${slug}" HEAD`, {
+    cwd: mainDir,
+    stdio: "pipe",
+  });
+  return worktreeDir;
+}
+
+function setupGlobalPipeline(cwd: string) {
+  const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
+  process.env.RALPHAI_HOME = ralphaiHome;
+  const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
+  return { ralphaiHome, ...dirs };
+}
+
+function makeResolvedConfig(
+  overrides: Partial<Record<string, unknown>> = {},
+): ResolvedConfig {
+  const defaults: Record<string, unknown> = {
+    agentCommand: "echo",
+    feedbackCommands: "",
+    baseBranch: "main",
+    maxStuck: 10, // High to avoid stuck detection interfering
+    issueSource: "none",
+    standaloneLabel: "ralphai-standalone",
+    subissueLabel: "ralphai-subissue",
+    prdLabel: "ralphai-prd",
+    issueRepo: "",
+    issueCommentProgress: "true",
+    issueHitlLabel: "ralphai-subissue-hitl",
+    iterationTimeout: 0,
+    autoCommit: "true",
+    sandbox: "none",
+    review: "false",
+    workspaces: null,
+    ...overrides,
+  };
+
+  const resolved: Record<string, { value: unknown; source: string }> = {};
+  for (const [key, value] of Object.entries(defaults)) {
+    resolved[key] = { value, source: "default" };
+  }
+  return resolved as unknown as ResolvedConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Zero-completion guard tests
+// ---------------------------------------------------------------------------
+
+describe("runRunner — zero-completion guard", () => {
+  let dir: string;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.RALPHAI_HOME;
+    dir = createTmpGitRepo();
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.RALPHAI_HOME;
+    else process.env.RALPHAI_HOME = savedHome;
+  });
+
+  test("marks plan as stuck when gate budget exhausted with zero tasks completed", async () => {
+    const { backlogDir, wipDir, archiveDir } = setupGlobalPipeline(dir);
+    const worktreeDir = createManagedWorktree(dir, "zero-comp");
+
+    // Plan with checkbox-style tasks (totalTasks = 3)
+    writeFileSync(
+      join(backlogDir, "zero-comp.md"),
+      [
+        "# Plan: Zero Completion Test",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] First task",
+        "- [ ] Second task",
+        "- [ ] Third task",
+      ].join("\n"),
+    );
+
+    // Agent that makes a commit each iteration (avoiding stuck detection)
+    // but outputs COMPLETE without updating progress (zero tasks completed).
+    // It needs to run 3 times: 1 initial + 2 rejections = exhausts budget.
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "iteration-marker-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work iteration" --allow-empty-message; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+
+    const opts: RunnerOptions = {
+      config: makeResolvedConfig({
+        agentCommand: agentScript,
+        autoCommit: "true",
+      }),
+      cwd: worktreeDir,
+      isWorktree: true,
+      mainWorktree: dir,
+      dryRun: false,
+      resume: false,
+      allowDirty: false,
+      once: false,
+    };
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    let result: RunnerResult;
+    try {
+      result = await runRunner(opts);
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join("\n");
+
+    // Plan should be marked as stuck, NOT accepted
+    expect(result.stuckSlugs).toContain("zero-comp");
+
+    // Plan should NOT be archived (it's stuck, not completed)
+    expect(existsSync(join(archiveDir, "zero-comp", "zero-comp.md"))).toBe(
+      false,
+    );
+
+    // Should see the zero-completion message in logs
+    expect(output).toContain("zero");
+  });
+
+  test("force-accepts plan when gate budget exhausted with partial completion", async () => {
+    const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
+    const worktreeDir = createManagedWorktree(dir, "partial-comp");
+
+    // Plan with checkbox-style tasks (totalTasks = 3)
+    writeFileSync(
+      join(backlogDir, "partial-comp.md"),
+      [
+        "# Plan: Partial Completion Test",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] First task",
+        "- [ ] Second task",
+        "- [ ] Third task",
+      ].join("\n"),
+    );
+
+    // Agent that makes a commit, reports 1/3 tasks done in progress,
+    // and claims COMPLETE. The gate will reject because only 1/3 done,
+    // but after exhausting the budget it should force-accept (partial progress).
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+
+    const opts: RunnerOptions = {
+      config: makeResolvedConfig({
+        agentCommand: agentScript,
+        autoCommit: "true",
+      }),
+      cwd: worktreeDir,
+      isWorktree: true,
+      mainWorktree: dir,
+      dryRun: false,
+      resume: false,
+      allowDirty: false,
+      once: false,
+    };
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    let result: RunnerResult;
+    try {
+      result = await runRunner(opts);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Plan should NOT be stuck — it should be force-accepted
+    expect(result.stuckSlugs).not.toContain("partial-comp");
+
+    // Plan should be archived (force-accepted)
+    expect(
+      existsSync(join(archiveDir, "partial-comp", "partial-comp.md")),
+    ).toBe(true);
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1152,7 +1152,56 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         }
 
         if (!gateResult.passed) {
-          // Max rejections reached — accept anyway but warn
+          // Max rejections reached — check for zero completion before
+          // force-accepting. A plan with zero tasks completed out of a
+          // non-zero total means the agent failed entirely; mark stuck
+          // instead of shipping an empty PR.
+          const currentCompleted = countCompletedTasks(
+            progressFile,
+            planFormat,
+          );
+          if (currentCompleted === 0 && totalTasks > 0) {
+            console.log();
+            console.log(
+              `Stuck: zero tasks completed (0/${totalTasks}) after ${maxGateRejections} gate rejections — refusing to force-accept.`,
+            );
+            // Clean up PID file and IPC server
+            if (ipcServer) {
+              ipcServer.close();
+              ipcServer = null;
+              activeIpcServer = null;
+            }
+            if (activePidFile) {
+              try {
+                rmSync(activePidFile, { force: true });
+              } catch {
+                // Best-effort cleanup
+              }
+            }
+            activePidFile = null;
+            stuck = true;
+            skippedSlugs.add(planSlug);
+            stuckSlugs.push(planSlug);
+            updateReceiptOutcome(receiptFile, "stuck");
+            if (issueFm.source === "github" && issueFm.issue) {
+              let repo = issueRepo || null;
+              if (!repo && issueFm.issueUrl) {
+                const m = issueFm.issueUrl.match(
+                  /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
+                );
+                repo = m?.[1] ?? null;
+              }
+              if (repo) {
+                transitionStuck({ number: issueFm.issue, repo }, cwd);
+                if (issueFm.prd) {
+                  prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
+                }
+              }
+            }
+            break;
+          }
+
+          // Partial progress — accept anyway but warn
           console.log();
           console.log(
             `WARNING: Completion gate still failing after ${maxGateRejections} rejections — accepting COMPLETE anyway.`,
@@ -1226,7 +1275,55 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
                 }
 
                 if (!reGateResult.passed) {
-                  // Max rejections reached — accept anyway but warn
+                  // Zero-completion guard: same check as the pre-review gate
+                  const currentCompleted = countCompletedTasks(
+                    progressFile,
+                    planFormat,
+                  );
+                  if (currentCompleted === 0 && totalTasks > 0) {
+                    console.log();
+                    console.log(
+                      `Stuck: zero tasks completed (0/${totalTasks}) after review pass and ${maxGateRejections} gate rejections — refusing to force-accept.`,
+                    );
+                    if (ipcServer) {
+                      ipcServer.close();
+                      ipcServer = null;
+                      activeIpcServer = null;
+                    }
+                    if (activePidFile) {
+                      try {
+                        rmSync(activePidFile, { force: true });
+                      } catch {
+                        // Best-effort cleanup
+                      }
+                    }
+                    activePidFile = null;
+                    stuck = true;
+                    skippedSlugs.add(planSlug);
+                    stuckSlugs.push(planSlug);
+                    updateReceiptOutcome(receiptFile, "stuck");
+                    if (issueFm.source === "github" && issueFm.issue) {
+                      let repo = issueRepo || null;
+                      if (!repo && issueFm.issueUrl) {
+                        const m = issueFm.issueUrl.match(
+                          /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
+                        );
+                        repo = m?.[1] ?? null;
+                      }
+                      if (repo) {
+                        transitionStuck({ number: issueFm.issue, repo }, cwd);
+                        if (issueFm.prd) {
+                          prdTransitionStuck(
+                            { number: issueFm.prd, repo },
+                            cwd,
+                          );
+                        }
+                      }
+                    }
+                    break;
+                  }
+
+                  // Partial progress — accept anyway but warn
                   console.log();
                   console.log(
                     `WARNING: Completion gate still failing after review pass and ${maxGateRejections} rejections — accepting anyway.`,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -903,6 +903,44 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
     let reviewDone = false;
     let reviewPassMadeChanges = false;
 
+    /** Mark the current plan as stuck: cleanup resources, update labels. */
+    function markStuck(reason: string): void {
+      console.log();
+      console.log(reason);
+      if (ipcServer) {
+        ipcServer.close();
+        ipcServer = null;
+        activeIpcServer = null;
+      }
+      if (activePidFile) {
+        try {
+          rmSync(activePidFile, { force: true });
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+      activePidFile = null;
+      stuck = true;
+      skippedSlugs.add(planSlug);
+      stuckSlugs.push(planSlug);
+      updateReceiptOutcome(receiptFile, "stuck");
+      if (issueFm.source === "github" && issueFm.issue) {
+        let repo = issueRepo || null;
+        if (!repo && issueFm.issueUrl) {
+          const m = issueFm.issueUrl.match(
+            /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
+          );
+          repo = m?.[1] ?? null;
+        }
+        if (repo) {
+          transitionStuck({ number: issueFm.issue, repo }, cwd);
+          if (issueFm.prd) {
+            prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
+          }
+        }
+      }
+    }
+
     // Detect plan format once per plan; the result flows into the
     // iteration log header and future downstream consumers.
     const planContent = readFileSync(planFile, "utf-8");
@@ -1035,54 +1073,13 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
           `WARNING: No new commits this iteration (${stuckCount}/${maxStuck}).`,
         );
         if (stuckCount >= maxStuck) {
-          console.log(
+          markStuck(
             `Stuck: ${maxStuck} consecutive iterations with no progress on '${planSlug}'.`,
           );
           console.log(`Branch: ${branch}`);
           console.log(
             `Plan files remain in ${wipDir}/ — resume with another run.`,
           );
-          // Clean up PID file and IPC server
-          if (ipcServer) {
-            ipcServer.close();
-            ipcServer = null;
-            activeIpcServer = null;
-          }
-          if (activePidFile) {
-            try {
-              rmSync(activePidFile, { force: true });
-            } catch {
-              // Best-effort cleanup
-            }
-          }
-          activePidFile = null;
-          // Mark as stuck and skip to next work unit
-          stuck = true;
-          skippedSlugs.add(planSlug);
-          stuckSlugs.push(planSlug);
-
-          // Write outcome=stuck to receipt
-          updateReceiptOutcome(receiptFile, "stuck");
-
-          // Swap in-progress → stuck label on linked GitHub issue
-          if (issueFm.source === "github" && issueFm.issue) {
-            let repo = issueRepo || null;
-            if (!repo && issueFm.issueUrl) {
-              const m = issueFm.issueUrl.match(
-                /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
-              );
-              repo = m?.[1] ?? null;
-            }
-            if (repo) {
-              transitionStuck({ number: issueFm.issue, repo }, cwd);
-
-              // Propagate stuck to PRD parent when a sub-issue gets stuck
-              if (issueFm.prd) {
-                prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
-              }
-            }
-          }
-
           break;
         }
       } else {
@@ -1161,43 +1158,9 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
             planFormat,
           );
           if (currentCompleted === 0 && totalTasks > 0) {
-            console.log();
-            console.log(
+            markStuck(
               `Stuck: zero tasks completed (0/${totalTasks}) after ${maxGateRejections} gate rejections — refusing to force-accept.`,
             );
-            // Clean up PID file and IPC server
-            if (ipcServer) {
-              ipcServer.close();
-              ipcServer = null;
-              activeIpcServer = null;
-            }
-            if (activePidFile) {
-              try {
-                rmSync(activePidFile, { force: true });
-              } catch {
-                // Best-effort cleanup
-              }
-            }
-            activePidFile = null;
-            stuck = true;
-            skippedSlugs.add(planSlug);
-            stuckSlugs.push(planSlug);
-            updateReceiptOutcome(receiptFile, "stuck");
-            if (issueFm.source === "github" && issueFm.issue) {
-              let repo = issueRepo || null;
-              if (!repo && issueFm.issueUrl) {
-                const m = issueFm.issueUrl.match(
-                  /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
-                );
-                repo = m?.[1] ?? null;
-              }
-              if (repo) {
-                transitionStuck({ number: issueFm.issue, repo }, cwd);
-                if (issueFm.prd) {
-                  prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
-                }
-              }
-            }
             break;
           }
 
@@ -1281,45 +1244,9 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
                     planFormat,
                   );
                   if (currentCompleted === 0 && totalTasks > 0) {
-                    console.log();
-                    console.log(
+                    markStuck(
                       `Stuck: zero tasks completed (0/${totalTasks}) after review pass and ${maxGateRejections} gate rejections — refusing to force-accept.`,
                     );
-                    if (ipcServer) {
-                      ipcServer.close();
-                      ipcServer = null;
-                      activeIpcServer = null;
-                    }
-                    if (activePidFile) {
-                      try {
-                        rmSync(activePidFile, { force: true });
-                      } catch {
-                        // Best-effort cleanup
-                      }
-                    }
-                    activePidFile = null;
-                    stuck = true;
-                    skippedSlugs.add(planSlug);
-                    stuckSlugs.push(planSlug);
-                    updateReceiptOutcome(receiptFile, "stuck");
-                    if (issueFm.source === "github" && issueFm.issue) {
-                      let repo = issueRepo || null;
-                      if (!repo && issueFm.issueUrl) {
-                        const m = issueFm.issueUrl.match(
-                          /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
-                        );
-                        repo = m?.[1] ?? null;
-                      }
-                      if (repo) {
-                        transitionStuck({ number: issueFm.issue, repo }, cwd);
-                        if (issueFm.prd) {
-                          prdTransitionStuck(
-                            { number: issueFm.prd, repo },
-                            cwd,
-                          );
-                        }
-                      }
-                    }
                     break;
                   }
 


### PR DESCRIPTION
Prevent the completion gate from force-accepting plans where zero tasks were completed, marking them as stuck instead. Plans with partial progress (at least one task done) continue to be force-accepted after exhausting the rejection budget, preserving the existing safety valve for nearly-complete runs.

Closes #384

## Changes

### Bug Fixes

- prevent force-accept of plans with zero tasks completed

### Refactoring

- extract duplicated stuck-marking logic into markStuck helper


## Learnings

- The completion gate force-accept logic lives in `src/runner.ts` at two locations: the pre-review gate (~line 1154) and the post-review gate (~line 1228). Both share a single `gateRejectionCount` counter compared against `maxGateRejections = 2`. The stuck-handling pattern (cleanup PID file, IPC server, set `stuck = true`, push to `stuckSlugs`, call `updateReceiptOutcome`, transition GitHub issue labels) is duplicated from the stuck-detection block at ~line 1037. When adding guards to force-accept paths, both locations must be updated in parallel. The `countCompletedTasks(progressFile, planFormat)` function reads fresh from the progress file and should be called at the decision point rather than relying on the stale value from the top of the iteration loop. Runner integration tests in `src/runner.test.ts` use `createTmpGitRepo`, `createManagedWorktree`, `setupGlobalPipeline`, and `makeResolvedConfig` helper patterns — these are local to the test file and must be duplicated in new test files (no shared test-utils module for runner tests). New runner test files that spawn real agents are slow but not slow enough to need the SLOW array in `scripts/test.ts` — they complete in ~600ms.


---

*A review pass was run to simplify the implementation.*