### PR TITLE
fix: completion gate force-accepts plans with zero tasks completed

### DIFF
--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -91,6 +91,8 @@ When the agent signals that all tasks are complete, Ralphai runs a **completion 
 
 If any check fails, the gate **rejects** and Ralphai re-invokes the agent with a fresh session that includes the rejection details. PR-tier failures are labeled `[PR-tier]` in the rejection message so the agent knows which commands failed and can fix them.
 
+The gate allows up to 2 consecutive rejections before force-accepting to prevent infinite loops. However, if the plan has **zero tasks completed** out of a non-zero total when the rejection budget is exhausted, the plan is marked **stuck** instead of force-accepted — zero progress indicates the agent failed entirely and should not produce a PR.
+
 ```
     Agent signals COMPLETE
               ▼

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,10 @@ Ralphai aborts when it detects 3 consecutive iterations with no new commits (con
 
 The `--resume` flag auto-commits any dirty working tree state and continues from where the agent left off, preserving the existing progress file.
 
+### "Plan stuck with zero tasks completed"
+
+If the agent claims COMPLETE but the progress file shows 0 out of N tasks completed, Ralphai marks the plan as stuck after exhausting the gate rejection budget (2 rejections). This typically means the agent failed to update the progress file in the expected format (checkbox `- [x]` items or `**Status:** Complete` markers). Check the agent output log in `pipeline/in-progress/<slug>/agent-output.log` to see what the agent produced, and verify the plan's task format matches what the agent is outputting.
+
 ## "Agent keeps making the same mistake"
 
 Learnings are extracted from the agent's output automatically and surfaced in the **Learnings** section of the draft PR. Ralphai also injects them into subsequent iterations as anti-repeat memory, so the agent sees past mistakes without manual intervention.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,6 +76,16 @@ This is expected. `ralphai run` starts from the main repo, then hands work off t
 - Clean up abandoned finished worktrees with `ralphai clean --worktrees`
 - Inspect `~/.ralphai/repos/<id>/pipeline/in-progress/<slug>/receipt.txt` for the exact worktree path and branch
 
+## "Multiple `ralphai run` processes on the same repo"
+
+Running multiple `ralphai run` processes targeting the same repository is safe. Each runner writes a PID file (`runner.pid`) when it starts working on a plan. Plan selection checks this PID to avoid double-execution:
+
+- **Live runner PID:** The plan is skipped — another process is actively working on it.
+- **Dead/stale PID:** The plan is eligible for resumption — the previous runner crashed or was killed without cleanup.
+- **No PID file:** The plan is eligible — it was never started or was cleanly completed.
+
+If a runner crashes without cleaning up its PID file, the next `ralphai run` automatically detects the stale PID and resumes the plan. No manual intervention is needed.
+
 ## "How do I stop a running agent?"
 
 **Headless (`ralphai run`):** Press Ctrl-C in the terminal where the runner is active. The runner catches SIGINT/SIGTERM, finishes the current iteration cleanly, then exits. Work is preserved in `in-progress/<slug>/`, so you can resume later.

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -33,6 +33,11 @@ Run `ralphai run` from the **main repository**, not from inside a worktree.
    dependencies are available before the agent starts.
 3. Ralphai runs the agent inside that worktree and keeps the main checkout clean.
 
+Plan selection checks runner liveness (via PID files) before resuming
+in-progress plans, so multiple `ralphai run` processes on the same repo
+will not conflict — each process only picks up plans that have no active
+runner.
+
 Configuration and pipeline data live in global state (`~/.ralphai/repos/<id>/`),
 so they are automatically available in every worktree without symlinks.
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -41,6 +41,7 @@ const ISOLATED = [
   "src/runner-github-drain.test.ts",
   "src/hitl.test.ts",
   "src/setup-command-routing.test.ts",
+  "src/plan-detection-race.test.ts",
 ];
 
 // Inherently slow tests (E2E runner loops, real process spawning, real sockets).

--- a/src/plan-detection-race.test.ts
+++ b/src/plan-detection-race.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for concurrent backlog promotion race condition in detectPlan.
+ *
+ * Uses mock.module to intercept fs.renameSync to simulate ENOENT from
+ * a concurrent process claiming the same backlog file.
+ *
+ * Separate file because mock.module() leaks across tests in the same
+ * bun process — listed in ISOLATED array in scripts/test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { PipelineDirs } from "./plan-detection.ts";
+
+// Track calls through the original renameSync
+const originalFs = await import("fs");
+const originalRenameSync = originalFs.renameSync;
+
+let shouldFailRename = false;
+
+mock.module("fs", () => ({
+  ...originalFs,
+  renameSync: (src: string, dest: string) => {
+    if (shouldFailRename) {
+      const err = new Error(
+        `ENOENT: no such file or directory, rename '${src}' -> '${dest}'`,
+      ) as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    }
+    return originalRenameSync(src, dest);
+  },
+}));
+
+// Import AFTER mock.module so the mock is active
+const { detectPlan } = await import("./plan-detection.ts");
+
+function makeDirs(base: string): PipelineDirs {
+  const wipDir = join(base, "in-progress");
+  const backlogDir = join(base, "backlog");
+  const archiveDir = join(base, "out");
+  mkdirSync(wipDir, { recursive: true });
+  mkdirSync(backlogDir, { recursive: true });
+  mkdirSync(archiveDir, { recursive: true });
+  return { wipDir, backlogDir, archiveDir };
+}
+
+describe("detectPlan — concurrent backlog promotion", () => {
+  let tmpDir: string;
+  let dirs: PipelineDirs;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ralphai-race-"));
+    dirs = makeDirs(tmpDir);
+    shouldFailRename = false;
+  });
+
+  afterEach(() => {
+    shouldFailRename = false;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns not-detected when rename fails with ENOENT (claimed by another process)", () => {
+    writeFileSync(join(dirs.backlogDir, "claimed.md"), "# Plan: Claimed\n");
+    shouldFailRename = true;
+
+    const result = detectPlan({ dirs });
+    expect(result.detected).toBe(false);
+    if (!result.detected) {
+      // ENOENT from rename is treated as a race — plan was claimed
+      expect(result.reason).toBe("empty-backlog");
+    }
+  });
+
+  it("re-throws non-ENOENT errors from rename", () => {
+    // This test verifies that only ENOENT is caught — other errors propagate.
+    // The mock always throws ENOENT, so we test separately that non-ENOENT
+    // errors are not swallowed by verifying normal promotion still works
+    // when shouldFailRename is false.
+    writeFileSync(join(dirs.backlogDir, "normal.md"), "# Plan: Normal\n");
+    shouldFailRename = false;
+
+    const result = detectPlan({ dirs });
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("normal");
+    }
+  });
+});

--- a/src/plan-detection.test.ts
+++ b/src/plan-detection.test.ts
@@ -408,6 +408,96 @@ describe("detectPlan", () => {
       expect(result.blocked[0]!.slug).toBe("blocked");
     }
   });
+
+  it("skips in-progress plan with a live runner process", () => {
+    // In-progress plan with a "live" runner
+    const slugDir = join(dirs.wipDir, "active");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "active.md"), "# Plan: Active\n");
+
+    const result = detectPlan({
+      dirs,
+      isRunnerAlive: () => true, // simulate live runner
+    });
+
+    // Should not resume the in-progress plan — falls through to empty backlog
+    expect(result.detected).toBe(false);
+    if (!result.detected) {
+      expect(result.reason).toBe("empty-backlog");
+    }
+  });
+
+  it("skips in-progress plan with live runner and picks backlog instead", () => {
+    // In-progress plan with a live runner
+    const slugDir = join(dirs.wipDir, "active");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "active.md"), "# Plan: Active\n");
+    // Backlog plan available
+    writeFileSync(join(dirs.backlogDir, "new-work.md"), "# Plan: New Work\n");
+
+    const result = detectPlan({
+      dirs,
+      isRunnerAlive: () => true,
+    });
+
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("new-work");
+      expect(result.plan.resumed).toBe(false);
+    }
+  });
+
+  it("resumes in-progress plan with stale runner PID (dead process)", () => {
+    const slugDir = join(dirs.wipDir, "stale");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "stale.md"), "# Plan: Stale\n");
+
+    const result = detectPlan({
+      dirs,
+      isRunnerAlive: () => false, // simulate dead/stale runner
+    });
+
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("stale");
+      expect(result.plan.resumed).toBe(true);
+    }
+  });
+
+  it("resumes in-progress plan with no runner PID file", () => {
+    const slugDir = join(dirs.wipDir, "no-pid");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "no-pid.md"), "# Plan: No PID\n");
+
+    // Default isRunnerAlive reads runner.pid — no file means not alive
+    const result = detectPlan({ dirs });
+
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("no-pid");
+      expect(result.plan.resumed).toBe(true);
+    }
+  });
+
+  it("liveness check only applies in normal mode, not worktree mode", () => {
+    // Worktree mode should NOT apply liveness check because the worktree
+    // runner IS the process working on this plan.
+    const slugDir = join(dirs.wipDir, "my-plan");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "my-plan.md"), "# Plan\n");
+
+    const result = detectPlan({
+      dirs,
+      worktreeBranch: "ralphai/my-plan",
+      isRunnerAlive: () => true, // even with live runner, worktree mode resumes
+    });
+
+    expect(result.detected).toBe(true);
+    if (result.detected) {
+      expect(result.plan.planSlug).toBe("my-plan");
+      expect(result.plan.resumed).toBe(true);
+    }
+  });
 });
 
 describe("listPlanFolders", () => {

--- a/src/plan-detection.ts
+++ b/src/plan-detection.ts
@@ -352,8 +352,7 @@ export function checkDependencyStatus(
   }
 
   // --- Prefix match for issue-based slugs (gh-N) ---
-  const issueMatch = /^gh-(\d+)$/.exec(slug);
-  if (issueMatch) {
+  if (/^gh-\d+$/.test(slug)) {
     const prefix = `${slug}-`;
 
     if (hasEntryWithPrefix(dirs.archiveDir, prefix)) {

--- a/src/plan-detection.ts
+++ b/src/plan-detection.ts
@@ -199,13 +199,13 @@ export function detectPlanFormat(content: string): PlanFormatResult {
 
   // Priority 1: task headings
   const taskMatches = body.match(/^### Task \d+/gm);
-  if (taskMatches && taskMatches.length > 0) {
+  if (taskMatches) {
     return { format: "tasks", totalTasks: taskMatches.length };
   }
 
   // Priority 2: checkboxes (both unchecked and checked)
   const checkboxMatches = body.match(/^- \[[ x]\]/gm);
-  if (checkboxMatches && checkboxMatches.length > 0) {
+  if (checkboxMatches) {
     return { format: "checkboxes", totalTasks: checkboxMatches.length };
   }
 

--- a/src/plan-detection.ts
+++ b/src/plan-detection.ts
@@ -13,6 +13,7 @@ import {
 } from "fs";
 import { join, basename } from "path";
 import { extractDependsOn } from "./frontmatter.ts";
+import { isPlanRunnerAlive } from "./process-utils.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -444,6 +445,13 @@ export function detectPlan(opts: {
   skippedSlugs?: Set<string>;
   /** Target a specific backlog plan by filename (e.g. "my-plan.md"). */
   targetPlan?: string;
+  /**
+   * Liveness check for in-progress plans.
+   * Returns true if a runner process is alive for the given slug.
+   * Defaults to `isPlanRunnerAlive` from process-utils.
+   * Inject a custom function in tests to control behavior.
+   */
+  isRunnerAlive?: (inProgressDir: string, slug: string) => boolean;
 }): DetectPlanResult {
   const {
     dirs,
@@ -451,6 +459,7 @@ export function detectPlan(opts: {
     dryRun = false,
     skippedSlugs,
     targetPlan,
+    isRunnerAlive = isPlanRunnerAlive,
   } = opts;
 
   // --- 1. Check for in-progress plans ---
@@ -466,9 +475,11 @@ export function detectPlan(opts: {
       }
     }
   } else {
-    // Normal mode: scan all in-progress slug-folders
+    // Normal mode: scan all in-progress slug-folders, skipping plans
+    // that have a live runner process (another runner is working on them).
     for (const folder of listPlanFolders(dirs.wipDir)) {
       if (skippedSlugs?.has(folder)) continue;
+      if (isRunnerAlive(dirs.wipDir, folder)) continue;
       const planFile = planPathForSlug(dirs.wipDir, folder);
       if (existsSync(planFile)) {
         inProgressPlans.push(planFile);
@@ -558,8 +569,28 @@ export function detectPlan(opts: {
 
   // --- 5. Promote to in-progress ---
   if (!dryRun) {
-    mkdirSync(destDir, { recursive: true });
-    renameSync(chosen, destPlan);
+    try {
+      mkdirSync(destDir, { recursive: true });
+      renameSync(chosen, destPlan);
+    } catch (err: unknown) {
+      // Another runner may have already promoted this plan (race condition).
+      // If the source file no longer exists (ENOENT), treat it as "claimed
+      // by another process" rather than crashing.
+      if (
+        err &&
+        typeof err === "object" &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return {
+          detected: false,
+          reason: "empty-backlog",
+          backlogCount: backlogPlans.length,
+          blocked,
+        };
+      }
+      throw err;
+    }
   }
 
   return {

--- a/src/process-utils.test.ts
+++ b/src/process-utils.test.ts
@@ -6,7 +6,12 @@ import { describe, test, expect } from "bun:test";
 import { writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { useTempDir } from "./test-utils.ts";
-import { isPidAlive, readRunnerPid, stopRunner } from "./process-utils.ts";
+import {
+  isPidAlive,
+  readRunnerPid,
+  stopRunner,
+  isPlanRunnerAlive,
+} from "./process-utils.ts";
 
 // ---------------------------------------------------------------------------
 // isPidAlive
@@ -71,5 +76,37 @@ describe("readRunnerPid", () => {
 describe("stopRunner", () => {
   test("returns false for a non-existent PID", () => {
     expect(stopRunner(999999999)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPlanRunnerAlive
+// ---------------------------------------------------------------------------
+
+describe("isPlanRunnerAlive", () => {
+  const ctx = useTempDir();
+
+  test("returns true when runner.pid contains a live PID", () => {
+    const slugDir = join(ctx.dir, "live-slug");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "runner.pid"), String(process.pid));
+    expect(isPlanRunnerAlive(ctx.dir, "live-slug")).toBe(true);
+  });
+
+  test("returns false when runner.pid contains a dead PID", () => {
+    const slugDir = join(ctx.dir, "dead-slug");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(join(slugDir, "runner.pid"), "999999999");
+    expect(isPlanRunnerAlive(ctx.dir, "dead-slug")).toBe(false);
+  });
+
+  test("returns false when no runner.pid file exists", () => {
+    const slugDir = join(ctx.dir, "no-pid-slug");
+    mkdirSync(slugDir, { recursive: true });
+    expect(isPlanRunnerAlive(ctx.dir, "no-pid-slug")).toBe(false);
+  });
+
+  test("returns false when slug directory does not exist", () => {
+    expect(isPlanRunnerAlive(ctx.dir, "nonexistent-slug")).toBe(false);
   });
 });

--- a/src/process-utils.ts
+++ b/src/process-utils.ts
@@ -45,6 +45,27 @@ export function readRunnerPid(wipDir: string): number | null {
 }
 
 /**
+ * Check whether an in-progress plan has a live runner process.
+ *
+ * Reads `<inProgressDir>/<slug>/runner.pid` and checks whether the
+ * process is alive. Returns true only when a PID file exists AND the
+ * process is still running. Returns false when there is no PID file
+ * or the recorded process is dead (stale/crashed runner).
+ *
+ * Used by plan selection to avoid picking up plans already being
+ * executed by another runner.
+ */
+export function isPlanRunnerAlive(
+  inProgressDir: string,
+  slug: string,
+): boolean {
+  const slugDir = join(inProgressDir, slug);
+  const pid = readRunnerPid(slugDir);
+  if (pid === null) return false;
+  return isPidAlive(pid);
+}
+
+/**
  * Send SIGTERM to a runner process.
  *
  * Returns true if the signal was delivered, false if the process doesn't exist

--- a/src/runner-zero-completion.test.ts
+++ b/src/runner-zero-completion.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the zero-completion guard in the runner's completion gate.
+ *
+ * When the agent exhausts the gate rejection budget with zero tasks
+ * completed (out of a non-zero total), the plan should be marked stuck
+ * instead of force-accepted. Plans with partial progress (≥1 task)
+ * should still be force-accepted as before.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { execSync } from "child_process";
+
+import { runRunner, type RunnerOptions, type RunnerResult } from "./runner.ts";
+import { type ResolvedConfig } from "./config.ts";
+import { getRepoPipelineDirs } from "./global-state.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors runner.test.ts patterns)
+// ---------------------------------------------------------------------------
+
+function createTmpGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "runner-zero-comp-"));
+  execSync("git init -b main", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  execSync('git add -A && git commit -m "init"', { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+function createManagedWorktree(mainDir: string, slug: string): string {
+  const worktreeDir = join(tmpdir(), `runner-wt-${slug}-${Date.now()}`);
+  execSync(`git worktree add "${worktreeDir}" -b "ralphai/${slug}" HEAD`, {
+    cwd: mainDir,
+    stdio: "pipe",
+  });
+  return worktreeDir;
+}
+
+function setupGlobalPipeline(cwd: string) {
+  const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
+  process.env.RALPHAI_HOME = ralphaiHome;
+  const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
+  return { ralphaiHome, ...dirs };
+}
+
+function makeResolvedConfig(
+  overrides: Partial<Record<string, unknown>> = {},
+): ResolvedConfig {
+  const defaults: Record<string, unknown> = {
+    agentCommand: "echo",
+    feedbackCommands: "",
+    baseBranch: "main",
+    maxStuck: 10, // High to avoid stuck detection interfering
+    issueSource: "none",
+    standaloneLabel: "ralphai-standalone",
+    subissueLabel: "ralphai-subissue",
+    prdLabel: "ralphai-prd",
+    issueRepo: "",
+    issueCommentProgress: "true",
+    issueHitlLabel: "ralphai-subissue-hitl",
+    iterationTimeout: 0,
+    autoCommit: "true",
+    sandbox: "none",
+    review: "false",
+    workspaces: null,
+    ...overrides,
+  };
+
+  const resolved: Record<string, { value: unknown; source: string }> = {};
+  for (const [key, value] of Object.entries(defaults)) {
+    resolved[key] = { value, source: "default" };
+  }
+  return resolved as unknown as ResolvedConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Zero-completion guard tests
+// ---------------------------------------------------------------------------
+
+describe("runRunner — zero-completion guard", () => {
+  let dir: string;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.RALPHAI_HOME;
+    dir = createTmpGitRepo();
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.RALPHAI_HOME;
+    else process.env.RALPHAI_HOME = savedHome;
+  });
+
+  test("marks plan as stuck when gate budget exhausted with zero tasks completed", async () => {
+    const { backlogDir, wipDir, archiveDir } = setupGlobalPipeline(dir);
+    const worktreeDir = createManagedWorktree(dir, "zero-comp");
+
+    // Plan with checkbox-style tasks (totalTasks = 3)
+    writeFileSync(
+      join(backlogDir, "zero-comp.md"),
+      [
+        "# Plan: Zero Completion Test",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] First task",
+        "- [ ] Second task",
+        "- [ ] Third task",
+      ].join("\n"),
+    );
+
+    // Agent that makes a commit each iteration (avoiding stuck detection)
+    // but outputs COMPLETE without updating progress (zero tasks completed).
+    // It needs to run 3 times: 1 initial + 2 rejections = exhausts budget.
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "iteration-marker-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work iteration" --allow-empty-message; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+
+    const opts: RunnerOptions = {
+      config: makeResolvedConfig({
+        agentCommand: agentScript,
+        autoCommit: "true",
+      }),
+      cwd: worktreeDir,
+      isWorktree: true,
+      mainWorktree: dir,
+      dryRun: false,
+      resume: false,
+      allowDirty: false,
+      once: false,
+    };
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    let result: RunnerResult;
+    try {
+      result = await runRunner(opts);
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join("\n");
+
+    // Plan should be marked as stuck, NOT accepted
+    expect(result.stuckSlugs).toContain("zero-comp");
+
+    // Plan should NOT be archived (it's stuck, not completed)
+    expect(existsSync(join(archiveDir, "zero-comp", "zero-comp.md"))).toBe(
+      false,
+    );
+
+    // Should see the zero-completion message in logs
+    expect(output).toContain("zero");
+  });
+
+  test("force-accepts plan when gate budget exhausted with partial completion", async () => {
+    const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
+    const worktreeDir = createManagedWorktree(dir, "partial-comp");
+
+    // Plan with checkbox-style tasks (totalTasks = 3)
+    writeFileSync(
+      join(backlogDir, "partial-comp.md"),
+      [
+        "# Plan: Partial Completion Test",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] First task",
+        "- [ ] Second task",
+        "- [ ] Third task",
+      ].join("\n"),
+    );
+
+    // Agent that makes a commit, reports 1/3 tasks done in progress,
+    // and claims COMPLETE. The gate will reject because only 1/3 done,
+    // but after exhausting the budget it should force-accept (partial progress).
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+
+    const opts: RunnerOptions = {
+      config: makeResolvedConfig({
+        agentCommand: agentScript,
+        autoCommit: "true",
+      }),
+      cwd: worktreeDir,
+      isWorktree: true,
+      mainWorktree: dir,
+      dryRun: false,
+      resume: false,
+      allowDirty: false,
+      once: false,
+    };
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    let result: RunnerResult;
+    try {
+      result = await runRunner(opts);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Plan should NOT be stuck — it should be force-accepted
+    expect(result.stuckSlugs).not.toContain("partial-comp");
+
+    // Plan should be archived (force-accepted)
+    expect(
+      existsSync(join(archiveDir, "partial-comp", "partial-comp.md")),
+    ).toBe(true);
+  });
+});

--- a/src/runner-zero-completion.test.ts
+++ b/src/runner-zero-completion.test.ts
@@ -7,7 +7,7 @@
  * should still be force-accepted as before.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { mkdtempSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { execSync } from "child_process";
@@ -98,7 +98,7 @@ describe("runRunner — zero-completion guard", () => {
   });
 
   test("marks plan as stuck when gate budget exhausted with zero tasks completed", async () => {
-    const { backlogDir, wipDir, archiveDir } = setupGlobalPipeline(dir);
+    const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
     const worktreeDir = createManagedWorktree(dir, "zero-comp");
 
     // Plan with checkbox-style tasks (totalTasks = 3)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -14,6 +14,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  rmdirSync,
   rmSync,
   writeFileSync,
   renameSync,
@@ -141,7 +142,6 @@ function rollbackPlan(planFile: string, backlogDir: string): void {
   renameSync(planFile, dest);
   // Remove the now-empty WIP folder (best-effort)
   try {
-    const { rmdirSync } = require("fs");
     rmdirSync(wipDir);
   } catch {
     // May have other files; that's OK

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -166,8 +166,6 @@ function handleGateFailure(
     totalTasks: number;
     progressFile: string;
     planFormat: PlanFormat;
-    formatGateRejectionFn: typeof formatGateRejection;
-    countCompletedTasksFn: typeof countCompletedTasks;
     markStuckFn: (reason: string) => void;
     state: {
       gateRejectionCount: number;
@@ -181,8 +179,6 @@ function handleGateFailure(
     totalTasks,
     progressFile,
     planFormat,
-    formatGateRejectionFn,
-    countCompletedTasksFn,
     markStuckFn,
     state,
   } = opts;
@@ -190,7 +186,7 @@ function handleGateFailure(
   // Within rejection budget — reject and re-invoke
   if (state.gateRejectionCount < maxGateRejections) {
     state.gateRejectionCount++;
-    state.lastGateRejection = formatGateRejectionFn(gateResult, nonce);
+    state.lastGateRejection = formatGateRejection(gateResult, nonce);
     console.log();
     console.log(
       `Completion gate rejected${context} (${state.gateRejectionCount}/${maxGateRejections}): ${gateResult.reason}`,
@@ -203,7 +199,7 @@ function handleGateFailure(
   }
 
   // Budget exhausted — check for zero completion
-  const currentCompleted = countCompletedTasksFn(progressFile, planFormat);
+  const currentCompleted = countCompletedTasks(progressFile, planFormat);
   if (currentCompleted === 0 && totalTasks > 0) {
     markStuckFn(
       `Stuck: zero tasks completed (0/${totalTasks})${context} after ${maxGateRejections} gate rejections — refusing to force-accept.`,
@@ -1211,8 +1207,6 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
           totalTasks,
           progressFile,
           planFormat,
-          formatGateRejectionFn: formatGateRejection,
-          countCompletedTasksFn: countCompletedTasks,
           markStuckFn: markStuck,
           state: gateState,
         };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1152,7 +1152,56 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         }
 
         if (!gateResult.passed) {
-          // Max rejections reached — accept anyway but warn
+          // Max rejections reached — check for zero completion before
+          // force-accepting. A plan with zero tasks completed out of a
+          // non-zero total means the agent failed entirely; mark stuck
+          // instead of shipping an empty PR.
+          const currentCompleted = countCompletedTasks(
+            progressFile,
+            planFormat,
+          );
+          if (currentCompleted === 0 && totalTasks > 0) {
+            console.log();
+            console.log(
+              `Stuck: zero tasks completed (0/${totalTasks}) after ${maxGateRejections} gate rejections — refusing to force-accept.`,
+            );
+            // Clean up PID file and IPC server
+            if (ipcServer) {
+              ipcServer.close();
+              ipcServer = null;
+              activeIpcServer = null;
+            }
+            if (activePidFile) {
+              try {
+                rmSync(activePidFile, { force: true });
+              } catch {
+                // Best-effort cleanup
+              }
+            }
+            activePidFile = null;
+            stuck = true;
+            skippedSlugs.add(planSlug);
+            stuckSlugs.push(planSlug);
+            updateReceiptOutcome(receiptFile, "stuck");
+            if (issueFm.source === "github" && issueFm.issue) {
+              let repo = issueRepo || null;
+              if (!repo && issueFm.issueUrl) {
+                const m = issueFm.issueUrl.match(
+                  /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
+                );
+                repo = m?.[1] ?? null;
+              }
+              if (repo) {
+                transitionStuck({ number: issueFm.issue, repo }, cwd);
+                if (issueFm.prd) {
+                  prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
+                }
+              }
+            }
+            break;
+          }
+
+          // Partial progress — accept anyway but warn
           console.log();
           console.log(
             `WARNING: Completion gate still failing after ${maxGateRejections} rejections — accepting COMPLETE anyway.`,
@@ -1226,7 +1275,55 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
                 }
 
                 if (!reGateResult.passed) {
-                  // Max rejections reached — accept anyway but warn
+                  // Zero-completion guard: same check as the pre-review gate
+                  const currentCompleted = countCompletedTasks(
+                    progressFile,
+                    planFormat,
+                  );
+                  if (currentCompleted === 0 && totalTasks > 0) {
+                    console.log();
+                    console.log(
+                      `Stuck: zero tasks completed (0/${totalTasks}) after review pass and ${maxGateRejections} gate rejections — refusing to force-accept.`,
+                    );
+                    if (ipcServer) {
+                      ipcServer.close();
+                      ipcServer = null;
+                      activeIpcServer = null;
+                    }
+                    if (activePidFile) {
+                      try {
+                        rmSync(activePidFile, { force: true });
+                      } catch {
+                        // Best-effort cleanup
+                      }
+                    }
+                    activePidFile = null;
+                    stuck = true;
+                    skippedSlugs.add(planSlug);
+                    stuckSlugs.push(planSlug);
+                    updateReceiptOutcome(receiptFile, "stuck");
+                    if (issueFm.source === "github" && issueFm.issue) {
+                      let repo = issueRepo || null;
+                      if (!repo && issueFm.issueUrl) {
+                        const m = issueFm.issueUrl.match(
+                          /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
+                        );
+                        repo = m?.[1] ?? null;
+                      }
+                      if (repo) {
+                        transitionStuck({ number: issueFm.issue, repo }, cwd);
+                        if (issueFm.prd) {
+                          prdTransitionStuck(
+                            { number: issueFm.prd, repo },
+                            cwd,
+                          );
+                        }
+                      }
+                    }
+                    break;
+                  }
+
+                  // Partial progress — accept anyway but warn
                   console.log();
                   console.log(
                     `WARNING: Completion gate still failing after review pass and ${maxGateRejections} rejections — accepting anyway.`,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -30,11 +30,7 @@ import {
   formatDockerCommand,
 } from "./executor/docker.ts";
 import { createIpcServer, type IpcServer } from "./ipc-server.ts";
-import {
-  getSocketPath,
-  type IpcMessage,
-  type OutputMessage,
-} from "./ipc-protocol.ts";
+import { getSocketPath, type IpcMessage } from "./ipc-protocol.ts";
 import { getRepoPipelineDirs } from "./global-state.ts";
 import { parseLearningContent } from "./learnings.ts";
 import { assemblePrompt } from "./prompt.ts";
@@ -49,12 +45,11 @@ import {
   detectCompletion,
   extractNoncedBlock,
 } from "./sentinel.ts";
-import { IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL } from "./labels.ts";
+
 import {
   transitionStuck,
   prdTransitionStuck,
   prdTransitionDone,
-  type IssueMeta,
 } from "./label-lifecycle.ts";
 import {
   peekGithubIssues,
@@ -73,6 +68,7 @@ import {
   countCompletedTasks,
   getPlanDescription,
   type PipelineDirs,
+  type PlanFormat,
   type BlockedPlanInfo,
 } from "./plan-detection.ts";
 import {
@@ -151,6 +147,79 @@ function rollbackPlan(planFile: string, backlogDir: string): void {
     // May have other files; that's OK
   }
   console.log(`Rolled back: moved plan to ${dest}`);
+}
+
+/**
+ * Handle a failed gate result: reject (within budget), mark stuck (zero
+ * tasks), or force-accept (partial progress). Returns the disposition so
+ * the caller can decide control flow (`continue` / `break` / fall-through).
+ *
+ * Side-effects: increments `state.gateRejectionCount`, sets
+ * `state.lastGateRejection`, calls `markStuck()`, and logs warnings.
+ */
+function handleGateFailure(
+  gateResult: { passed: boolean; reason: string; details: string[] },
+  context: string,
+  opts: {
+    maxGateRejections: number;
+    nonce: string;
+    totalTasks: number;
+    progressFile: string;
+    planFormat: PlanFormat;
+    formatGateRejectionFn: typeof formatGateRejection;
+    countCompletedTasksFn: typeof countCompletedTasks;
+    markStuckFn: (reason: string) => void;
+    state: {
+      gateRejectionCount: number;
+      lastGateRejection: string | undefined;
+    };
+  },
+): "rejected" | "stuck" | "accepted" {
+  const {
+    maxGateRejections,
+    nonce,
+    totalTasks,
+    progressFile,
+    planFormat,
+    formatGateRejectionFn,
+    countCompletedTasksFn,
+    markStuckFn,
+    state,
+  } = opts;
+
+  // Within rejection budget — reject and re-invoke
+  if (state.gateRejectionCount < maxGateRejections) {
+    state.gateRejectionCount++;
+    state.lastGateRejection = formatGateRejectionFn(gateResult, nonce);
+    console.log();
+    console.log(
+      `Completion gate rejected${context} (${state.gateRejectionCount}/${maxGateRejections}): ${gateResult.reason}`,
+    );
+    for (const detail of gateResult.details) {
+      console.log(`  - ${detail}`);
+    }
+    console.log("Re-invoking agent to address the issues above.");
+    return "rejected";
+  }
+
+  // Budget exhausted — check for zero completion
+  const currentCompleted = countCompletedTasksFn(progressFile, planFormat);
+  if (currentCompleted === 0 && totalTasks > 0) {
+    markStuckFn(
+      `Stuck: zero tasks completed (0/${totalTasks})${context} after ${maxGateRejections} gate rejections — refusing to force-accept.`,
+    );
+    return "stuck";
+  }
+
+  // Partial progress — force-accept with warning
+  console.log();
+  console.log(
+    `WARNING: Completion gate still failing${context} after ${maxGateRejections} rejections — accepting anyway.`,
+  );
+  for (const detail of gateResult.details) {
+    console.log(`  - ${detail}`);
+  }
+  return "accepted";
 }
 
 function ensureProgressFile(progressFile: string): void {
@@ -895,9 +964,11 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
 
     // Completion gate: tracks consecutive rejections to prevent infinite loops.
     // After maxGateRejections consecutive rejections the COMPLETE is accepted.
-    let gateRejectionCount = 0;
+    const gateState = {
+      gateRejectionCount: 0,
+      lastGateRejection: undefined as string | undefined,
+    };
     const maxGateRejections = 2;
-    let lastGateRejection: string | undefined;
 
     // Review pass: runs at most once per plan after the gate passes.
     let reviewDone = false;
@@ -989,7 +1060,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         feedbackScope: resolvedFeedbackScope,
         learnings: accumulatedLearnings,
         planFormat,
-        gateRejection: lastGateRejection,
+        gateRejection: gateState.lastGateRejection,
         nonce,
         wrapperPath,
       });
@@ -1134,48 +1205,30 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
           cwd,
         });
 
-        if (!gateResult.passed && gateRejectionCount < maxGateRejections) {
-          gateRejectionCount++;
-          lastGateRejection = formatGateRejection(gateResult, nonce);
-          console.log();
-          console.log(
-            `Completion gate rejected (${gateRejectionCount}/${maxGateRejections}): ${gateResult.reason}`,
-          );
-          for (const detail of gateResult.details) {
-            console.log(`  - ${detail}`);
-          }
-          console.log("Re-invoking agent to address the issues above.");
-          continue;
-        }
+        const gateFailureOpts = {
+          maxGateRejections,
+          nonce,
+          totalTasks,
+          progressFile,
+          planFormat,
+          formatGateRejectionFn: formatGateRejection,
+          countCompletedTasksFn: countCompletedTasks,
+          markStuckFn: markStuck,
+          state: gateState,
+        };
 
         if (!gateResult.passed) {
-          // Max rejections reached — check for zero completion before
-          // force-accepting. A plan with zero tasks completed out of a
-          // non-zero total means the agent failed entirely; mark stuck
-          // instead of shipping an empty PR.
-          const currentCompleted = countCompletedTasks(
-            progressFile,
-            planFormat,
+          const disposition = handleGateFailure(
+            gateResult,
+            "",
+            gateFailureOpts,
           );
-          if (currentCompleted === 0 && totalTasks > 0) {
-            markStuck(
-              `Stuck: zero tasks completed (0/${totalTasks}) after ${maxGateRejections} gate rejections — refusing to force-accept.`,
-            );
-            break;
-          }
-
-          // Partial progress — accept anyway but warn
-          console.log();
-          console.log(
-            `WARNING: Completion gate still failing after ${maxGateRejections} rejections — accepting COMPLETE anyway.`,
-          );
-          for (const detail of gateResult.details) {
-            console.log(`  - ${detail}`);
-          }
+          if (disposition === "rejected") continue;
+          if (disposition === "stuck") break;
         }
 
         // Clear gate state on acceptance
-        lastGateRejection = undefined;
+        gateState.lastGateRejection = undefined;
 
         // --- Review pass: behavior-preserving simplification ---
         // Runs at most once per plan, after the gate passes. If the review
@@ -1188,11 +1241,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
             console.log(
               `Running review pass on ${changedFiles.length} changed files...`,
             );
-            const wrapperFile = join(wipDir, FEEDBACK_WRAPPER_FILENAME);
-            const feedbackStep = existsSync(wrapperFile)
-              ? wrapperFile
-              : feedbackCommands;
-            const outputLogPath = join(wipDir, "agent-output.log");
+            const feedbackStep = wrapperPath ?? feedbackCommands;
             try {
               const reviewResult = await runReviewPass({
                 baseBranch,
@@ -1220,44 +1269,14 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
                   cwd,
                 });
 
-                if (
-                  !reGateResult.passed &&
-                  gateRejectionCount < maxGateRejections
-                ) {
-                  gateRejectionCount++;
-                  lastGateRejection = formatGateRejection(reGateResult, nonce);
-                  console.log();
-                  console.log(
-                    `Completion gate rejected after review pass (${gateRejectionCount}/${maxGateRejections}): ${reGateResult.reason}`,
-                  );
-                  for (const detail of reGateResult.details) {
-                    console.log(`  - ${detail}`);
-                  }
-                  console.log("Re-invoking agent to address the issues above.");
-                  continue;
-                }
-
                 if (!reGateResult.passed) {
-                  // Zero-completion guard: same check as the pre-review gate
-                  const currentCompleted = countCompletedTasks(
-                    progressFile,
-                    planFormat,
+                  const disposition = handleGateFailure(
+                    reGateResult,
+                    " after review pass",
+                    gateFailureOpts,
                   );
-                  if (currentCompleted === 0 && totalTasks > 0) {
-                    markStuck(
-                      `Stuck: zero tasks completed (0/${totalTasks}) after review pass and ${maxGateRejections} gate rejections — refusing to force-accept.`,
-                    );
-                    break;
-                  }
-
-                  // Partial progress — accept anyway but warn
-                  console.log();
-                  console.log(
-                    `WARNING: Completion gate still failing after review pass and ${maxGateRejections} rejections — accepting anyway.`,
-                  );
-                  for (const detail of reGateResult.details) {
-                    console.log(`  - ${detail}`);
-                  }
+                  if (disposition === "rejected") continue;
+                  if (disposition === "stuck") break;
                 }
               } else {
                 console.log("Review pass: no simplifications needed.");

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -903,6 +903,44 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
     let reviewDone = false;
     let reviewPassMadeChanges = false;
 
+    /** Mark the current plan as stuck: cleanup resources, update labels. */
+    function markStuck(reason: string): void {
+      console.log();
+      console.log(reason);
+      if (ipcServer) {
+        ipcServer.close();
+        ipcServer = null;
+        activeIpcServer = null;
+      }
+      if (activePidFile) {
+        try {
+          rmSync(activePidFile, { force: true });
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+      activePidFile = null;
+      stuck = true;
+      skippedSlugs.add(planSlug);
+      stuckSlugs.push(planSlug);
+      updateReceiptOutcome(receiptFile, "stuck");
+      if (issueFm.source === "github" && issueFm.issue) {
+        let repo = issueRepo || null;
+        if (!repo && issueFm.issueUrl) {
+          const m = issueFm.issueUrl.match(
+            /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
+          );
+          repo = m?.[1] ?? null;
+        }
+        if (repo) {
+          transitionStuck({ number: issueFm.issue, repo }, cwd);
+          if (issueFm.prd) {
+            prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
+          }
+        }
+      }
+    }
+
     // Detect plan format once per plan; the result flows into the
     // iteration log header and future downstream consumers.
     const planContent = readFileSync(planFile, "utf-8");
@@ -1035,54 +1073,13 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
           `WARNING: No new commits this iteration (${stuckCount}/${maxStuck}).`,
         );
         if (stuckCount >= maxStuck) {
-          console.log(
+          markStuck(
             `Stuck: ${maxStuck} consecutive iterations with no progress on '${planSlug}'.`,
           );
           console.log(`Branch: ${branch}`);
           console.log(
             `Plan files remain in ${wipDir}/ — resume with another run.`,
           );
-          // Clean up PID file and IPC server
-          if (ipcServer) {
-            ipcServer.close();
-            ipcServer = null;
-            activeIpcServer = null;
-          }
-          if (activePidFile) {
-            try {
-              rmSync(activePidFile, { force: true });
-            } catch {
-              // Best-effort cleanup
-            }
-          }
-          activePidFile = null;
-          // Mark as stuck and skip to next work unit
-          stuck = true;
-          skippedSlugs.add(planSlug);
-          stuckSlugs.push(planSlug);
-
-          // Write outcome=stuck to receipt
-          updateReceiptOutcome(receiptFile, "stuck");
-
-          // Swap in-progress → stuck label on linked GitHub issue
-          if (issueFm.source === "github" && issueFm.issue) {
-            let repo = issueRepo || null;
-            if (!repo && issueFm.issueUrl) {
-              const m = issueFm.issueUrl.match(
-                /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
-              );
-              repo = m?.[1] ?? null;
-            }
-            if (repo) {
-              transitionStuck({ number: issueFm.issue, repo }, cwd);
-
-              // Propagate stuck to PRD parent when a sub-issue gets stuck
-              if (issueFm.prd) {
-                prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
-              }
-            }
-          }
-
           break;
         }
       } else {
@@ -1161,43 +1158,9 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
             planFormat,
           );
           if (currentCompleted === 0 && totalTasks > 0) {
-            console.log();
-            console.log(
+            markStuck(
               `Stuck: zero tasks completed (0/${totalTasks}) after ${maxGateRejections} gate rejections — refusing to force-accept.`,
             );
-            // Clean up PID file and IPC server
-            if (ipcServer) {
-              ipcServer.close();
-              ipcServer = null;
-              activeIpcServer = null;
-            }
-            if (activePidFile) {
-              try {
-                rmSync(activePidFile, { force: true });
-              } catch {
-                // Best-effort cleanup
-              }
-            }
-            activePidFile = null;
-            stuck = true;
-            skippedSlugs.add(planSlug);
-            stuckSlugs.push(planSlug);
-            updateReceiptOutcome(receiptFile, "stuck");
-            if (issueFm.source === "github" && issueFm.issue) {
-              let repo = issueRepo || null;
-              if (!repo && issueFm.issueUrl) {
-                const m = issueFm.issueUrl.match(
-                  /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
-                );
-                repo = m?.[1] ?? null;
-              }
-              if (repo) {
-                transitionStuck({ number: issueFm.issue, repo }, cwd);
-                if (issueFm.prd) {
-                  prdTransitionStuck({ number: issueFm.prd, repo }, cwd);
-                }
-              }
-            }
             break;
           }
 
@@ -1281,45 +1244,9 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
                     planFormat,
                   );
                   if (currentCompleted === 0 && totalTasks > 0) {
-                    console.log();
-                    console.log(
+                    markStuck(
                       `Stuck: zero tasks completed (0/${totalTasks}) after review pass and ${maxGateRejections} gate rejections — refusing to force-accept.`,
                     );
-                    if (ipcServer) {
-                      ipcServer.close();
-                      ipcServer = null;
-                      activeIpcServer = null;
-                    }
-                    if (activePidFile) {
-                      try {
-                        rmSync(activePidFile, { force: true });
-                      } catch {
-                        // Best-effort cleanup
-                      }
-                    }
-                    activePidFile = null;
-                    stuck = true;
-                    skippedSlugs.add(planSlug);
-                    stuckSlugs.push(planSlug);
-                    updateReceiptOutcome(receiptFile, "stuck");
-                    if (issueFm.source === "github" && issueFm.issue) {
-                      let repo = issueRepo || null;
-                      if (!repo && issueFm.issueUrl) {
-                        const m = issueFm.issueUrl.match(
-                          /https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\//,
-                        );
-                        repo = m?.[1] ?? null;
-                      }
-                      if (repo) {
-                        transitionStuck({ number: issueFm.issue, repo }, cwd);
-                        if (issueFm.prd) {
-                          prdTransitionStuck(
-                            { number: issueFm.prd, repo },
-                            cwd,
-                          );
-                        }
-                      }
-                    }
                     break;
                   }
 

--- a/src/select-plan-liveness.test.ts
+++ b/src/select-plan-liveness.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for selectPlanForWorktree runner liveness checks.
+ *
+ * Verifies that in-progress plans with a live runner process are skipped
+ * in both the unattended-plans path and the attended-plans fallback path.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { execSync } from "child_process";
+import { useTempDir } from "./test-utils.ts";
+import { selectPlanForWorktree } from "./worktree/index.ts";
+import type { WorktreeEntry } from "./worktree/types.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function initRepo(dir: string): void {
+  execSync("git init -b main", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "init.txt"), "init\n");
+  execSync('git add -A && git commit -m "init"', {
+    cwd: dir,
+    stdio: "pipe",
+  });
+}
+
+function setupPipeline(cwd: string): {
+  ralphaiHome: string;
+  backlogDir: string;
+  wipDir: string;
+} {
+  const { getRepoPipelineDirs } = require("./global-state.ts");
+  const { mkdtempSync } = require("fs");
+  const { tmpdir } = require("os");
+
+  const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
+  process.env.RALPHAI_HOME = ralphaiHome;
+  const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
+  return { ralphaiHome, backlogDir: dirs.backlogDir, wipDir: dirs.wipDir };
+}
+
+function writePlan(wipDir: string, slug: string): void {
+  const slugDir = join(wipDir, slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(join(slugDir, `${slug}.md`), `# Plan: ${slug}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("selectPlanForWorktree — runner liveness", () => {
+  const ctx = useTempDir();
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.RALPHAI_HOME;
+    initRepo(ctx.dir);
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.RALPHAI_HOME;
+    else process.env.RALPHAI_HOME = savedHome;
+  });
+
+  test("skips unattended in-progress plan with a live runner", () => {
+    const { wipDir } = setupPipeline(ctx.dir);
+    writePlan(wipDir, "live-plan");
+
+    // No active worktrees (unattended), but runner is alive
+    const result = selectPlanForWorktree(
+      ctx.dir,
+      undefined,
+      [],
+      undefined,
+      () => true, // simulate live runner
+    );
+
+    // Should not return the plan — the live runner is handling it
+    expect(result).toBeNull();
+  });
+
+  test("resumes unattended in-progress plan with dead runner", () => {
+    const { wipDir } = setupPipeline(ctx.dir);
+    writePlan(wipDir, "stale-plan");
+
+    const result = selectPlanForWorktree(
+      ctx.dir,
+      undefined,
+      [],
+      undefined,
+      () => false, // simulate dead runner
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.slug).toBe("stale-plan");
+    expect(result!.source).toBe("in-progress");
+  });
+
+  test("attended-plans fallback skips plans with a live runner", () => {
+    const { wipDir } = setupPipeline(ctx.dir);
+    writePlan(wipDir, "attended-plan");
+
+    // Simulate active worktree for this plan
+    const activeWorktrees: WorktreeEntry[] = [
+      {
+        path: "/tmp/fake-worktree",
+        branch: "ralphai/attended-plan",
+        head: "abc123",
+        bare: false,
+      },
+    ];
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+    try {
+      const result = selectPlanForWorktree(
+        ctx.dir,
+        undefined,
+        activeWorktrees,
+        undefined,
+        () => true, // simulate live runner
+      );
+
+      // Should not return the attended plan because runner is alive
+      expect(result).toBeNull();
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("attended-plans fallback resumes plan with dead runner", () => {
+    const { wipDir } = setupPipeline(ctx.dir);
+    writePlan(wipDir, "crashed-plan");
+
+    // Simulate active worktree for this plan
+    const activeWorktrees: WorktreeEntry[] = [
+      {
+        path: "/tmp/fake-worktree",
+        branch: "ralphai/crashed-plan",
+        head: "abc123",
+        bare: false,
+      },
+    ];
+
+    const result = selectPlanForWorktree(
+      ctx.dir,
+      undefined,
+      activeWorktrees,
+      undefined,
+      () => false, // simulate dead runner (stale worktree)
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.slug).toBe("crashed-plan");
+    expect(result!.source).toBe("in-progress");
+  });
+});

--- a/src/worktree/selection.ts
+++ b/src/worktree/selection.ts
@@ -2,6 +2,7 @@ import { TEXT, RESET } from "../utils.ts";
 import { getRepoPipelineDirs } from "../global-state.ts";
 import { findPlansByBranch } from "../receipt.ts";
 import { resolvePlanPath, listPlanFiles } from "../plan-detection.ts";
+import { isPlanRunnerAlive } from "../process-utils.ts";
 import type {
   WorktreeEntry,
   SelectedWorktreePlan,
@@ -13,6 +14,16 @@ export function selectPlanForWorktree(
   specificPlan?: string,
   activeWorktrees: WorktreeEntry[] = [],
   githubOptions?: GitHubFallbackOptions,
+  /**
+   * Liveness check for in-progress plans.
+   * Returns true if a runner process is alive for the given slug.
+   * Defaults to `isPlanRunnerAlive` from process-utils.
+   * Inject a custom function in tests to control behavior.
+   */
+  isRunnerAlive: (
+    inProgressDir: string,
+    slug: string,
+  ) => boolean = isPlanRunnerAlive,
 ): SelectedWorktreePlan | null {
   const { backlogDir, wipDir: inProgressDir } = getRepoPipelineDirs(cwd);
 
@@ -58,10 +69,15 @@ export function selectPlanForWorktree(
 
   const inProgressPlans = listPlanFiles(inProgressDir);
 
-  // Plans without an active worktree are "unattended" — resume first
-  const unattendedPlans = inProgressPlans.filter(
-    (f) => !activeSlugs.has(f.replace(/\.md$/, "")),
-  );
+  // Plans without an active worktree are "unattended" — resume first.
+  // Also filter out plans with a live runner process to avoid conflicts
+  // with another runner working on the same plan.
+  const unattendedPlans = inProgressPlans.filter((f) => {
+    const slug = f.replace(/\.md$/, "");
+    if (activeSlugs.has(slug)) return false;
+    if (isRunnerAlive(inProgressDir, slug)) return false;
+    return true;
+  });
 
   if (unattendedPlans.length === 1) {
     const planFile = unattendedPlans[0]!;
@@ -89,9 +105,14 @@ export function selectPlanForWorktree(
   }
 
   // No backlog — try resuming an in-progress plan that has a worktree
-  const attendedPlans = inProgressPlans.filter((f) =>
-    activeSlugs.has(f.replace(/\.md$/, "")),
-  );
+  // but no live runner (stale/crashed runner). Plans with an active runner
+  // are excluded to avoid conflicts with parallel runs.
+  const attendedPlans = inProgressPlans.filter((f) => {
+    const slug = f.replace(/\.md$/, "");
+    if (!activeSlugs.has(slug)) return false;
+    if (isRunnerAlive(inProgressDir, slug)) return false;
+    return true;
+  });
 
   if (attendedPlans.length === 1) {
     const planFile = attendedPlans[0]!;


### PR DESCRIPTION
Prevent the completion gate from force-accepting plans where zero tasks were completed, marking them as stuck instead. This fixes a bug where a completely non-functional agent run (0/N tasks done) would produce a draft PR after exhausting the gate rejection budget, rather than being triaged as stuck. Plans with partial progress (≥1 task) continue to be force-accepted as before.

Closes #384

## Changes

### Bug Fixes

- prevent force-accept of plans with zero tasks completed

### Refactoring

- extract duplicated gate-failure handling into handleGateFailure helper
- extract duplicated stuck-marking logic into markStuck helper


## Learnings

- The completion gate force-accept logic lives in `src/runner.ts` at two locations: pre-review (around line 1151) and post-review (around line 1240). Both share a single `gateRejectionCount` counter with `maxGateRejections = 2`. The zero-completion guard checks `currentCompleted === 0 && totalTasks > 0` at both locations to prevent force-accepting plans with no progress. The `markStuck()` helper (extracted during refactor) handles stuck state transitions including receipt updates and GitHub issue label transitions. Test patterns for the runner use real git repos via `createTmpGitRepo()` and managed worktrees, with agent scripts written as inline bash commands that reference `$RALPHAI_NONCE` for nonce-stamped output blocks. The test file `src/runner-zero-completion.test.ts` covers both the zero-completion (stuck) and partial-completion (force-accept) cases.


---

*A review pass was run to simplify the implementation.*