### PR TITLE
fix: done transitions remove all other status labels

### DIFF
--- a/src/hitl.test.ts
+++ b/src/hitl.test.ts
@@ -429,6 +429,10 @@ describe("runHitl", () => {
     expect(labelCall).toBeDefined();
     expect(labelCall![0]).toContain("ralphai-subissue-hitl");
     expect(labelCall![0]).toContain("done");
+
+    // Verify other status labels are also removed
+    expect(labelCall![0]).toContain('--remove-label "in-progress"');
+    expect(labelCall![0]).toContain('--remove-label "stuck"');
   });
 
   // --- Label updates on abnormal exit ---

--- a/src/hitl.ts
+++ b/src/hitl.ts
@@ -34,7 +34,7 @@ import {
   commitTypeFromTitle,
 } from "./issues.ts";
 import { execQuiet } from "./exec.ts";
-import { DONE_LABEL } from "./labels.ts";
+import { DONE_LABEL, IN_PROGRESS_LABEL, STUCK_LABEL } from "./labels.ts";
 import { prepareWorktree, type SetupSandboxConfig } from "./worktree/index.ts";
 import { isGitWorktree, ensureRepoHasCommit } from "./worktree/management.ts";
 import { detectBaseBranch } from "./git-helpers.ts";
@@ -280,7 +280,7 @@ export async function runHitl(options: HitlOptions): Promise<HitlResult> {
   if (exitCode === 0) {
     // Clean exit: remove HITL label, add done
     execQuiet(
-      `gh issue edit ${issueNumber} --repo "${repo}" --remove-label "${hitlLabel}" --add-label "${DONE_LABEL}"`,
+      `gh issue edit ${issueNumber} --repo "${repo}" --remove-label "${hitlLabel}" --remove-label "${IN_PROGRESS_LABEL}" --remove-label "${STUCK_LABEL}" --add-label "${DONE_LABEL}"`,
       cwd,
     );
     const message = `Sub-issue #${issueNumber} completed. Removed "${hitlLabel}" label, added "${DONE_LABEL}".`;

--- a/src/label-lifecycle.test.ts
+++ b/src/label-lifecycle.test.ts
@@ -233,3 +233,31 @@ describe("dry-run safety — label lifecycle", () => {
     expect(logs[0]).toContain("stuck");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Done transitions remove all other state labels
+// ---------------------------------------------------------------------------
+
+describe("done transitions remove all other state labels", () => {
+  it("transitionDone removes both in-progress and stuck", () => {
+    mockExecSync.mockReturnValue(Buffer.from(""));
+    transitionDone(ISSUE, "/tmp");
+
+    const calls = ghEditCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('--add-label "done"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
+    expect(calls[0]).toContain('--remove-label "stuck"');
+  });
+
+  it("prdTransitionDone removes both in-progress and stuck", () => {
+    mockExecSync.mockReturnValue(Buffer.from(""));
+    prdTransitionDone({ number: 100, repo: "acme/widgets" }, "/tmp");
+
+    const calls = ghEditCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('--add-label "done"');
+    expect(calls[0]).toContain('--remove-label "in-progress"');
+    expect(calls[0]).toContain('--remove-label "stuck"');
+  });
+});

--- a/src/label-lifecycle.ts
+++ b/src/label-lifecycle.ts
@@ -8,13 +8,13 @@
  *
  * Every label transition in the system flows through this module:
  *   pull:  add in-progress  (family label stays)
- *   done:  remove in-progress, add done
+ *   done:  remove in-progress + stuck, add done
  *   stuck: remove in-progress, add stuck
  *   reset: remove in-progress + stuck  (family label stays)
  *
  * PRD parent propagation helpers:
  *   prdInProgress: add in-progress label to PRD parent
- *   prdDone:       add done label (remove in-progress) on PRD parent
+ *   prdDone:       add done label (remove in-progress + stuck) on PRD parent
  *   prdStuck:      add stuck label on PRD parent
  *
  * All functions are best-effort: failures are logged but never thrown.
@@ -100,6 +100,7 @@ export function transitionPull(
  * Done transition: in-progress → done.
  *
  * Used when work completes successfully and the plan is archived.
+ * Removes both in-progress and stuck labels to ensure a clean state.
  */
 export function transitionDone(
   issue: IssueMeta,
@@ -113,7 +114,7 @@ export function transitionDone(
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${DONE_LABEL}" --remove-label "${IN_PROGRESS_LABEL}"`,
+      `--add-label "${DONE_LABEL}" --remove-label "${IN_PROGRESS_LABEL}" --remove-label "${STUCK_LABEL}"`,
     cwd,
   );
   if (result === null) {
@@ -231,7 +232,7 @@ export function prdTransitionInProgress(
  * PRD parent → done.
  *
  * Called when all sub-issues under a PRD are completed.
- * Adds the done label and removes the in-progress label.
+ * Adds the done label and removes both in-progress and stuck labels.
  */
 export function prdTransitionDone(
   issue: IssueMeta,
@@ -245,7 +246,7 @@ export function prdTransitionDone(
   }
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
-      `--add-label "${DONE_LABEL}" --remove-label "${IN_PROGRESS_LABEL}"`,
+      `--add-label "${DONE_LABEL}" --remove-label "${IN_PROGRESS_LABEL}" --remove-label "${STUCK_LABEL}"`,
     cwd,
   );
   if (result === null) {


### PR DESCRIPTION
## Summary

- `transitionDone()` and `prdTransitionDone()` now remove **both** `in-progress` and `stuck` labels when adding `done` (previously only removed `in-progress`).
- The HITL done path now removes `in-progress` and `stuck` labels alongside the HITL label when marking an issue done (previously removed neither).
- Added regression tests verifying `gh issue edit` commands include `--remove-label` for all other state labels during done transitions.

## Problem

When an issue was labeled `done`, stale status labels could linger:

| Path | Removed `in-progress` | Removed `stuck` |
|---|---|---|
| `transitionDone` | yes | **no** |
| `prdTransitionDone` | yes | **no** |
| HITL done | **no** | **no** |

This meant e.g. an issue manually labeled `stuck` that later completed would carry both `stuck` and `done`.

## Fix

All three done transitions now remove every other state label. This is safe because `gh issue edit --remove-label` is a no-op when the label isn't present.