### PR TITLE
feat: Reset: remove GH-issue plans from pipeline instead of moving to backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ ralphai stop             # stop the running plan runner (auto-selects if only on
 ralphai stop my-plan     # stop a specific plan runner by slug
 ralphai stop --all       # stop all running plan runners
 ralphai doctor           # validate your setup (agent, feedback commands, config)
-ralphai reset            # move in-progress plans back to backlog
+ralphai reset            # reset in-progress plans (local -> backlog, GH -> removed)
 ralphai clean            # remove archived plans and orphaned worktrees
 ralphai clean --archive  # clean only archived plans
 ralphai clean --worktrees # clean only orphaned worktrees

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,7 +13,7 @@ ralphai <command> [options]
 | `hitl`         | Open interactive agent session for a HITL sub-issue                    |
 | `status`       | Show pipeline and worktree status                                      |
 | `stop`         | Stop running plan runners by sending SIGTERM                           |
-| `reset`        | Move in-progress plans back to backlog and clean up                    |
+| `reset`        | Reset in-progress plans and clean up                                   |
 | `clean`        | Remove archived plans and orphaned worktrees                           |
 | `repos`        | List all known repos with pipeline summaries                           |
 | `doctor`       | Check your Ralphai setup for problems                                  |
@@ -304,12 +304,13 @@ The runner handles SIGTERM gracefully: it finishes the current iteration, preser
 
 Resets pipeline state so you can start fresh:
 
-- **Plans** -> moves plan files from `in-progress/<slug>/` back to `backlog/` as flat `.md` files
+- **Local plans** -> moves plan files from `in-progress/<slug>/` back to `backlog/` as flat `.md` files
+- **GitHub-sourced plans** -> removes plan files from `in-progress/<slug>/` entirely (they are re-pulled from GitHub on the next `ralphai run`, picking up any edits made to the issue since the last pull)
 - **Artifacts** -> deletes `progress.md` and `receipt.txt` for each in-progress plan
 - **Worktrees** -> removes Ralphai-managed worktrees and force-deletes their branches
 - **GitHub labels** -> for plans sourced from GitHub issues, restores the intake label and removes the in-progress label (best-effort)
 
-Use `reset` when a run is stuck and you want to re-queue the plan, or when you want to abandon in-progress work and start over.
+Use `reset` when a run is stuck and you want to re-queue the plan, or when you want to abandon in-progress work and start over. For GitHub-sourced plans, this is particularly useful because the re-pull on the next run captures any edits you made to the issue body after the original pull.
 
 ## Doctor
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -213,6 +213,8 @@ ralphai reset --repo=~/work/api --yes   # reset a stuck plan remotely
 
 Use `ralphai repos` to list every initialized repo with plan counts. The `--repo` flag works with read-only commands like `status`, `doctor`, `reset`, `uninstall`, and `config`.
 
+> **Note:** `reset` moves local plans back to backlog but removes GitHub-sourced plans from the pipeline entirely. Removed GH plans are re-pulled from GitHub on the next `ralphai run`, so any edits to the issue body are picked up automatically.
+
 To clean up stale entries (from deleted temp dirs or old projects):
 
 ```bash

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -919,15 +919,14 @@ export function resetPlanBySlug(cwd: string, slug: string): void {
   const dest = join(backlogDir, `${slug}.md`);
   mkdirSync(backlogDir, { recursive: true });
 
-  // Determine if this is a GH-sourced plan before any file operations.
+  // Determine if this is a GH-sourced plan and restore issue labels
+  // before any file operations (both need frontmatter from the plan file).
   let isGhPlan = false;
   if (existsSync(planFile)) {
     const fm = extractIssueFrontmatter(planFile);
     isGhPlan = fm.source === "github" && !!fm.issue;
-  }
 
-  // Restore GitHub issue labels before moving the file (needs frontmatter).
-  if (existsSync(planFile)) {
+    // Restore GitHub issue labels (best-effort).
     try {
       const cfgResult = resolveConfig({
         cwd,
@@ -2321,14 +2320,6 @@ async function runPrdIssueTarget(
         },
         { skipPrCreation: true },
       );
-      // Collect learnings from this sub-issue run (deduplicated)
-      if (result.accumulatedLearnings) {
-        for (const learning of result.accumulatedLearnings) {
-          if (!prdLearnings.includes(learning)) {
-            prdLearnings.push(learning);
-          }
-        }
-      }
       if (result.stuckSlugs.length > 0) {
         // Runner returned normally but the sub-issue got stuck
         stuckSubIssues.push(subIssueNumber);

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -17,21 +17,15 @@ import {
   listPlanFolders,
   listPlanFiles,
   resolvePlanPath,
-  planExistsForSlug,
   getPlanDescription,
 } from "./plan-detection.ts";
-import {
-  parseReceipt,
-  checkReceiptSource,
-  findPlansByBranch,
-} from "./receipt.ts";
+import { checkReceiptSource } from "./receipt.ts";
 import {
   getRepoPipelineDirs,
   resolveRepoByNameOrPath,
   removeStaleRepos,
 } from "./global-state.ts";
 import {
-  detectFeedbackCommands,
   detectWorkspaces,
   detectProject,
   detectSetupCommand,
@@ -94,11 +88,7 @@ import {
 } from "./issue-dispatch.ts";
 import { restoreIssueLabels } from "./reset-labels.ts";
 import { createPrdPr } from "./pr-lifecycle.ts";
-import {
-  isInsideGitRepo,
-  extractExecStderr,
-  detectBaseBranch,
-} from "./git-helpers.ts";
+import { isInsideGitRepo, detectBaseBranch } from "./git-helpers.ts";
 import { parseRalphaiOptions } from "./parse-options.ts";
 import type {
   RalphaiSubcommand,
@@ -114,7 +104,6 @@ import {
 import {
   isGitWorktree,
   resolveWorktreeInfo,
-  executeSetupCommand,
   ensureRepoHasCommit,
   prepareWorktree,
   listRalphaiWorktrees,
@@ -122,7 +111,6 @@ import {
 } from "./worktree/index.ts";
 import type {
   WorktreeEntry,
-  SelectedWorktreePlan,
   GitHubFallbackOptions,
   SetupSandboxConfig,
 } from "./worktree/index.ts";
@@ -683,7 +671,6 @@ async function runRalphaiReset(
   }
 
   const planSlugs = listPlanFolders(wipDir);
-  const planFiles = planSlugs.map((slug) => `${slug}.md`);
 
   // Check for worktrees to clean
   let worktrees: WorktreeEntry[] = [];
@@ -693,7 +680,7 @@ async function runRalphaiReset(
     // Not in a git repo or git not available
   }
 
-  if (planFiles.length === 0 && worktrees.length === 0) {
+  if (planSlugs.length === 0 && worktrees.length === 0) {
     console.log("Nothing to reset — pipeline is already clean.");
     return;
   }
@@ -720,7 +707,7 @@ async function runRalphaiReset(
   console.log();
   console.log(`${TEXT}The following will be reset:${RESET}`);
   console.log();
-  if (planFiles.length > 0) {
+  if (planSlugs.length > 0) {
     if (localPlanFiles.length > 0) {
       console.log(
         `  ${TEXT}Plans${RESET}       ${DIM}${localPlanFiles.length} plan${localPlanFiles.length !== 1 ? "s" : ""} moved back to backlog${RESET}`,
@@ -857,7 +844,7 @@ async function runRalphaiReset(
   console.log(`${TEXT}Pipeline reset.${RESET}`);
   console.log();
   console.log(`${DIM}Actions:${RESET}`);
-  if (planFiles.length > 0) {
+  if (planSlugs.length > 0) {
     if (localPlanFiles.length > 0) {
       console.log(
         `  ${localPlanFiles.length} plan${localPlanFiles.length !== 1 ? "s" : ""} moved to backlog`,
@@ -869,7 +856,7 @@ async function runRalphaiReset(
       );
     }
     console.log(
-      `  Deleted progress.md and receipt.txt in ${planFiles.length} plan${planFiles.length !== 1 ? "s" : ""}`,
+      `  Deleted progress.md and receipt.txt in ${planSlugs.length} plan${planSlugs.length !== 1 ? "s" : ""}`,
     );
   }
   if (worktrees.length > 0) {

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -698,16 +698,44 @@ async function runRalphaiReset(
     return;
   }
 
+  // Classify plans as GH-sourced or local for preview and action logic.
+  const ghPlanFiles: string[] = [];
+  const localPlanFiles: string[] = [];
+  for (const slug of planSlugs) {
+    const planFile = join(wipDir, slug, `${slug}.md`);
+    if (existsSync(planFile)) {
+      const fm = extractIssueFrontmatter(planFile);
+      if (fm.source === "github" && !!fm.issue) {
+        ghPlanFiles.push(`${slug}.md`);
+      } else {
+        localPlanFiles.push(`${slug}.md`);
+      }
+    } else {
+      // Missing plan file — treat as local (will be moved to backlog if it exists)
+      localPlanFiles.push(`${slug}.md`);
+    }
+  }
+
   // Show what will be reset
   console.log();
   console.log(`${TEXT}The following will be reset:${RESET}`);
   console.log();
   if (planFiles.length > 0) {
-    console.log(
-      `  ${TEXT}Plans${RESET}       ${DIM}${planFiles.length} plan${planFiles.length !== 1 ? "s" : ""} moved back to backlog${RESET}`,
-    );
-    for (const f of planFiles) {
-      console.log(`    ${DIM}${f}${RESET}`);
+    if (localPlanFiles.length > 0) {
+      console.log(
+        `  ${TEXT}Plans${RESET}       ${DIM}${localPlanFiles.length} plan${localPlanFiles.length !== 1 ? "s" : ""} moved back to backlog${RESET}`,
+      );
+      for (const f of localPlanFiles) {
+        console.log(`    ${DIM}${f}${RESET}`);
+      }
+    }
+    if (ghPlanFiles.length > 0) {
+      console.log(
+        `  ${TEXT}Plans${RESET}       ${DIM}${ghPlanFiles.length} plan${ghPlanFiles.length !== 1 ? "s" : ""} removed (re-pull from GitHub)${RESET}`,
+      );
+      for (const f of ghPlanFiles) {
+        console.log(`    ${DIM}${f}${RESET}`);
+      }
     }
     console.log(
       `  ${TEXT}Artifacts${RESET}   ${DIM}progress.md + receipt.txt removed per plan${RESET}`,
@@ -753,7 +781,9 @@ async function runRalphaiReset(
     // Config resolution failure is not critical — skip label restoration.
   }
 
-  // 1. Extract plan files from in-progress slug-folders back to backlog as flat files
+  // 1. Extract plan files from in-progress slug-folders back to backlog as flat files.
+  //    GH-sourced plans are deleted (they will be re-pulled from GitHub).
+  //    Local plans are moved back to backlog.
   for (const slug of planSlugs) {
     const src = join(wipDir, slug);
     const planFile = join(src, `${slug}.md`);
@@ -772,11 +802,16 @@ async function runRalphaiReset(
       }
     }
 
+    // Determine if this is a GH-sourced plan.
+    const isGhPlan = ghPlanFiles.includes(`${slug}.md`);
+
     rmSync(join(src, "progress.md"), { force: true });
     rmSync(join(src, "receipt.txt"), { force: true });
-    if (existsSync(planFile)) {
+    if (!isGhPlan && existsSync(planFile)) {
+      // Local plan: move back to backlog
       renameSync(planFile, dest);
     }
+    // GH plans: plan file is deleted along with the slug-folder below.
     rmSync(src, { recursive: true, force: true });
     actions++;
   }
@@ -823,9 +858,16 @@ async function runRalphaiReset(
   console.log();
   console.log(`${DIM}Actions:${RESET}`);
   if (planFiles.length > 0) {
-    console.log(
-      `  ${planFiles.length} plan${planFiles.length !== 1 ? "s" : ""} moved to backlog`,
-    );
+    if (localPlanFiles.length > 0) {
+      console.log(
+        `  ${localPlanFiles.length} plan${localPlanFiles.length !== 1 ? "s" : ""} moved to backlog`,
+      );
+    }
+    if (ghPlanFiles.length > 0) {
+      console.log(
+        `  ${ghPlanFiles.length} plan${ghPlanFiles.length !== 1 ? "s" : ""} removed (re-pull from GitHub)`,
+      );
+    }
     console.log(
       `  Deleted progress.md and receipt.txt in ${planFiles.length} plan${planFiles.length !== 1 ? "s" : ""}`,
     );
@@ -843,11 +885,23 @@ async function runRalphaiReset(
 // ---------------------------------------------------------------------------
 
 /**
- * Reset a single in-progress plan back to the backlog.
+ * Reset a single in-progress plan back to the backlog (local plans) or
+ * remove it from the pipeline entirely (GitHub-sourced plans).
  *
- * Moves the plan file from the in-progress slug-folder to the backlog
- * directory, deletes progress.md and receipt.txt, removes the slug
- * folder, and cleans up any associated worktree.
+ * For **local plans**: moves the plan file from the in-progress
+ * slug-folder to the backlog directory, deletes progress.md and
+ * receipt.txt, removes the slug folder, and cleans up any associated
+ * worktree.
+ *
+ * For **GitHub-sourced plans** (`source: "github"` with a truthy
+ * `issue` number in frontmatter): the plan file is NOT moved to
+ * backlog. Instead, it is deleted along with the slug-folder.
+ * The plan can be re-pulled from GitHub on the next `ralphai pull`.
+ * If frontmatter cannot be parsed, the plan is treated as local
+ * to prevent accidental data loss.
+ *
+ * In both cases, GitHub issue labels are restored (best-effort)
+ * before the plan is moved or deleted.
  *
  * Skips confirmation — callers are expected to confirm before calling.
  */
@@ -864,6 +918,13 @@ export function resetPlanBySlug(cwd: string, slug: string): void {
   const planFile = join(slugDir, `${slug}.md`);
   const dest = join(backlogDir, `${slug}.md`);
   mkdirSync(backlogDir, { recursive: true });
+
+  // Determine if this is a GH-sourced plan before any file operations.
+  let isGhPlan = false;
+  if (existsSync(planFile)) {
+    const fm = extractIssueFrontmatter(planFile);
+    isGhPlan = fm.source === "github" && !!fm.issue;
+  }
 
   // Restore GitHub issue labels before moving the file (needs frontmatter).
   if (existsSync(planFile)) {
@@ -890,9 +951,11 @@ export function resetPlanBySlug(cwd: string, slug: string): void {
   rmSync(join(slugDir, "progress.md"), { force: true });
   rmSync(join(slugDir, "receipt.txt"), { force: true });
   rmSync(join(slugDir, "runner.pid"), { force: true });
-  if (existsSync(planFile)) {
+  if (!isGhPlan && existsSync(planFile)) {
+    // Local plan: move back to backlog
     renameSync(planFile, dest);
   }
+  // GH plans: plan file is deleted along with the slug-folder below.
   rmSync(slugDir, { recursive: true, force: true });
 
   // Clean associated worktree
@@ -924,7 +987,11 @@ export function resetPlanBySlug(cwd: string, slug: string): void {
     }
   }
 
-  console.log(`Reset '${slug}' — plan moved back to backlog.`);
+  if (isGhPlan) {
+    console.log(`Reset '${slug}' — removed (will re-pull from GitHub).`);
+  } else {
+    console.log(`Reset '${slug}' — plan moved back to backlog.`);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/reset-gh-plans.test.ts
+++ b/src/reset-gh-plans.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { existsSync, writeFileSync, mkdirSync, readdirSync } from "fs";
+import { existsSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import {
   runCliOutputInProcess,
@@ -157,6 +157,22 @@ describe("reset: GH-sourced plan handling", () => {
   // Single-plan reset (resetPlanBySlug)
   // -----------------------------------------------------------------------
 
+  /** Run resetPlanBySlug with RALPHAI_HOME set and console.log captured. */
+  function captureResetBySlug(slug: string): string[] {
+    const logs: string[] = [];
+    const origLog = console.log;
+    const origHome = process.env.RALPHAI_HOME;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+    process.env.RALPHAI_HOME = testEnv().RALPHAI_HOME;
+    try {
+      resetPlanBySlug(ctx.dir, slug);
+    } finally {
+      console.log = origLog;
+      process.env.RALPHAI_HOME = origHome;
+    }
+    return logs;
+  }
+
   it("resetPlanBySlug removes GH plan and logs re-pull message", async () => {
     await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
 
@@ -166,17 +182,7 @@ describe("reset: GH-sourced plan handling", () => {
     writeFileSync(join(planDir, "gh-55-search.md"), GH_FRONTMATTER);
     writeFileSync(join(planDir, "progress.md"), "## Progress");
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    const origHome = process.env.RALPHAI_HOME;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-    process.env.RALPHAI_HOME = testEnv().RALPHAI_HOME;
-    try {
-      resetPlanBySlug(ctx.dir, "gh-55-search");
-    } finally {
-      console.log = origLog;
-      process.env.RALPHAI_HOME = origHome;
-    }
+    const logs = captureResetBySlug("gh-55-search");
 
     // Plan should NOT be in backlog
     expect(existsSync(join(backlogDir, "gh-55-search.md"))).toBe(false);
@@ -194,17 +200,7 @@ describe("reset: GH-sourced plan handling", () => {
     mkdirSync(planDir, { recursive: true });
     writeFileSync(join(planDir, "prd-charts.md"), LOCAL_CONTENT);
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    const origHome = process.env.RALPHAI_HOME;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-    process.env.RALPHAI_HOME = testEnv().RALPHAI_HOME;
-    try {
-      resetPlanBySlug(ctx.dir, "prd-charts");
-    } finally {
-      console.log = origLog;
-      process.env.RALPHAI_HOME = origHome;
-    }
+    const logs = captureResetBySlug("prd-charts");
 
     // Local plan should be in backlog
     expect(existsSync(join(backlogDir, "prd-charts.md"))).toBe(true);
@@ -221,17 +217,7 @@ describe("reset: GH-sourced plan handling", () => {
     mkdirSync(planDir, { recursive: true });
     writeFileSync(join(planDir, "gh-88-malformed.md"), MALFORMED_FRONTMATTER);
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    const origHome = process.env.RALPHAI_HOME;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-    process.env.RALPHAI_HOME = testEnv().RALPHAI_HOME;
-    try {
-      resetPlanBySlug(ctx.dir, "gh-88-malformed");
-    } finally {
-      console.log = origLog;
-      process.env.RALPHAI_HOME = origHome;
-    }
+    const logs = captureResetBySlug("gh-88-malformed");
 
     // Malformed frontmatter should fall through to backlog
     expect(existsSync(join(backlogDir, "gh-88-malformed.md"))).toBe(true);

--- a/src/reset-gh-plans.test.ts
+++ b/src/reset-gh-plans.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "bun:test";
+import { existsSync, writeFileSync, mkdirSync, readdirSync } from "fs";
+import { join } from "path";
+import {
+  runCliOutputInProcess,
+  stripLogo,
+  useTempGitDir,
+} from "./test-utils.ts";
+import { getRepoPipelineDirs } from "./global-state.ts";
+import { resetPlanBySlug } from "./ralphai.ts";
+
+const GH_FRONTMATTER = `---
+source: github
+issue: 42
+issue-url: https://github.com/acme/widgets/issues/42
+---
+
+# GH Feature
+`;
+
+const LOCAL_CONTENT = "# Local Feature";
+
+const MALFORMED_FRONTMATTER = `---
+source: github
+issue: not-a-number
+---
+
+# Malformed Feature
+`;
+
+describe("reset: GH-sourced plan handling", () => {
+  const ctx = useTempGitDir();
+
+  function testEnv() {
+    return { RALPHAI_HOME: join(ctx.dir, ".ralphai-home") };
+  }
+
+  // -----------------------------------------------------------------------
+  // Bulk reset (runRalphaiReset via CLI)
+  // -----------------------------------------------------------------------
+
+  it("reset --yes removes GH plan instead of moving to backlog", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir, backlogDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+    const planDir = join(wipDir, "gh-42-my-feature");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "gh-42-my-feature.md"), GH_FRONTMATTER);
+
+    const output = stripLogo(
+      await runCliOutputInProcess(["reset", "--yes"], ctx.dir, testEnv()),
+    );
+
+    // GH plan should NOT appear in backlog
+    expect(existsSync(join(backlogDir, "gh-42-my-feature.md"))).toBe(false);
+    // Slug-folder should be deleted from in-progress
+    expect(existsSync(join(wipDir, "gh-42-my-feature"))).toBe(false);
+    // Summary should mention removal
+    expect(output).toContain("removed (re-pull from GitHub)");
+  });
+
+  it("reset --yes moves local plan to backlog (existing behavior)", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir, backlogDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+    const planDir = join(wipDir, "prd-local-feature");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "prd-local-feature.md"), LOCAL_CONTENT);
+
+    const output = stripLogo(
+      await runCliOutputInProcess(["reset", "--yes"], ctx.dir, testEnv()),
+    );
+
+    // Local plan should be moved to backlog
+    expect(existsSync(join(backlogDir, "prd-local-feature.md"))).toBe(true);
+    expect(existsSync(join(wipDir, "prd-local-feature"))).toBe(false);
+    expect(output).toContain("moved to backlog");
+  });
+
+  it("reset --yes with mixed plans: GH removed, local moved, summary reflects both", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir, backlogDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+
+    // Create a GH plan
+    const ghDir = join(wipDir, "gh-99-api-fix");
+    mkdirSync(ghDir, { recursive: true });
+    writeFileSync(
+      join(ghDir, "gh-99-api-fix.md"),
+      `---\nsource: github\nissue: 99\nissue-url: https://github.com/acme/widgets/issues/99\n---\n\n# API Fix\n`,
+    );
+
+    // Create a local plan
+    const localDir = join(wipDir, "prd-dashboard");
+    mkdirSync(localDir, { recursive: true });
+    writeFileSync(join(localDir, "prd-dashboard.md"), LOCAL_CONTENT);
+
+    const output = stripLogo(
+      await runCliOutputInProcess(["reset", "--yes"], ctx.dir, testEnv()),
+    );
+
+    // GH plan should NOT be in backlog
+    expect(existsSync(join(backlogDir, "gh-99-api-fix.md"))).toBe(false);
+    // Local plan should be in backlog
+    expect(existsSync(join(backlogDir, "prd-dashboard.md"))).toBe(true);
+    // Both slug-folders should be gone
+    expect(existsSync(join(wipDir, "gh-99-api-fix"))).toBe(false);
+    expect(existsSync(join(wipDir, "prd-dashboard"))).toBe(false);
+    // Summary should report separate counts
+    expect(output).toContain("1 plan moved to backlog");
+    expect(output).toContain("1 plan removed (re-pull from GitHub)");
+  });
+
+  it("reset --yes treats malformed frontmatter as local plan (moved to backlog)", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir, backlogDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+    const planDir = join(wipDir, "gh-77-broken");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "gh-77-broken.md"), MALFORMED_FRONTMATTER);
+
+    await runCliOutputInProcess(["reset", "--yes"], ctx.dir, testEnv());
+
+    // Malformed frontmatter should fall through to backlog (not deleted)
+    expect(existsSync(join(backlogDir, "gh-77-broken.md"))).toBe(true);
+    expect(existsSync(join(wipDir, "gh-77-broken"))).toBe(false);
+  });
+
+  it("reset --yes preview differentiates GH and local plans", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+
+    // Create a GH plan
+    const ghDir = join(wipDir, "gh-10-feat");
+    mkdirSync(ghDir, { recursive: true });
+    writeFileSync(
+      join(ghDir, "gh-10-feat.md"),
+      `---\nsource: github\nissue: 10\n---\n\n# Feat\n`,
+    );
+
+    // Create a local plan
+    const localDir = join(wipDir, "prd-widget");
+    mkdirSync(localDir, { recursive: true });
+    writeFileSync(join(localDir, "prd-widget.md"), LOCAL_CONTENT);
+
+    const output = stripLogo(
+      await runCliOutputInProcess(["reset", "--yes"], ctx.dir, testEnv()),
+    );
+
+    // Preview should mention both categories
+    expect(output).toContain("moved back to backlog");
+    expect(output).toContain("removed (re-pull from GitHub)");
+  });
+
+  // -----------------------------------------------------------------------
+  // Single-plan reset (resetPlanBySlug)
+  // -----------------------------------------------------------------------
+
+  it("resetPlanBySlug removes GH plan and logs re-pull message", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir, backlogDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+    const planDir = join(wipDir, "gh-55-search");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "gh-55-search.md"), GH_FRONTMATTER);
+    writeFileSync(join(planDir, "progress.md"), "## Progress");
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    const origHome = process.env.RALPHAI_HOME;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+    process.env.RALPHAI_HOME = testEnv().RALPHAI_HOME;
+    try {
+      resetPlanBySlug(ctx.dir, "gh-55-search");
+    } finally {
+      console.log = origLog;
+      process.env.RALPHAI_HOME = origHome;
+    }
+
+    // Plan should NOT be in backlog
+    expect(existsSync(join(backlogDir, "gh-55-search.md"))).toBe(false);
+    // Slug-folder should be gone
+    expect(existsSync(join(wipDir, "gh-55-search"))).toBe(false);
+    // Log message should say "re-pull from GitHub"
+    expect(logs.some((l) => l.includes("re-pull from GitHub"))).toBe(true);
+  });
+
+  it("resetPlanBySlug moves local plan to backlog", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir, backlogDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+    const planDir = join(wipDir, "prd-charts");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "prd-charts.md"), LOCAL_CONTENT);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    const origHome = process.env.RALPHAI_HOME;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+    process.env.RALPHAI_HOME = testEnv().RALPHAI_HOME;
+    try {
+      resetPlanBySlug(ctx.dir, "prd-charts");
+    } finally {
+      console.log = origLog;
+      process.env.RALPHAI_HOME = origHome;
+    }
+
+    // Local plan should be in backlog
+    expect(existsSync(join(backlogDir, "prd-charts.md"))).toBe(true);
+    expect(existsSync(join(wipDir, "prd-charts"))).toBe(false);
+    // Log should say "moved back to backlog"
+    expect(logs.some((l) => l.includes("moved back to backlog"))).toBe(true);
+  });
+
+  it("resetPlanBySlug treats malformed frontmatter as local plan", async () => {
+    await runCliOutputInProcess(["init", "--yes"], ctx.dir, testEnv());
+
+    const { wipDir, backlogDir } = getRepoPipelineDirs(ctx.dir, testEnv());
+    const planDir = join(wipDir, "gh-88-malformed");
+    mkdirSync(planDir, { recursive: true });
+    writeFileSync(join(planDir, "gh-88-malformed.md"), MALFORMED_FRONTMATTER);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    const origHome = process.env.RALPHAI_HOME;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+    process.env.RALPHAI_HOME = testEnv().RALPHAI_HOME;
+    try {
+      resetPlanBySlug(ctx.dir, "gh-88-malformed");
+    } finally {
+      console.log = origLog;
+      process.env.RALPHAI_HOME = origHome;
+    }
+
+    // Malformed frontmatter should fall through to backlog
+    expect(existsSync(join(backlogDir, "gh-88-malformed.md"))).toBe(true);
+    expect(existsSync(join(wipDir, "gh-88-malformed"))).toBe(false);
+    expect(logs.some((l) => l.includes("moved back to backlog"))).toBe(true);
+  });
+});


### PR DESCRIPTION
PRD #391: Reset: remove GH-issue plans from pipeline instead of moving to backlog

## Summary

- **#392:** When resetting the pipeline, GitHub-sourced plans are now removed instead of being moved back to the backlog, since they can be re-pulled from GitHub on the next `ralphai pull`. Local plans continue to be moved to the backlog as before. The UI messaging in both bulk and single-plan reset paths now differentiates between the two behaviors with separate counts and descriptive labels.
- **#393:** Update documentation across cli-reference, workflows, and README to reflect the new `ralphai reset` behavior where GitHub-sourced plans are removed from the pipeline entirely (and re-pulled from GitHub on the next run) instead of being moved back to backlog like local plans.

Closes #391
Closes #392
Closes #393

## Completed Sub-Issues

- [x] #392
- [x] #393

## Changes

### Features

- remove GH-sourced plans from pipeline instead of moving to backlog

### Refactoring

- remove unused imports and redundant planFiles variable in reset
- remove redundant code in reset and PRD target flows

### Documentation

- update reset documentation for GH-sourced plan removal behavior


## Learnings

- <entry>status: none</entry>
- The implementation was already complete from a previous iteration (commit aeffa71) — both the code changes in `src/ralphai.ts` and the test file `src/reset-gh-plans.test.ts` were already committed and passing. The completion gate rejection was due to the progress file not having tasks checked off, not because work was actually incomplete. When re-invoked after a completion gate rejection, verify the actual state of the codebase (git log, git status, feedback script) before assuming work needs to be redone. Key files: `src/ralphai.ts` (lines 667-995 for reset logic), `src/reset-gh-plans.test.ts` (new test file), `src/frontmatter.ts` (`extractIssueFrontmatter`), `src/reset-labels.ts` (`restoreIssueLabels`). The `resetPlanBySlug` function is exported from `ralphai.ts` and tested directly (not through CLI) by capturing `console.log` output.