### PR TITLE
fix: inject --once for standalone issue targets to prevent drain

### DIFF
--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -2042,17 +2042,21 @@ async function runIssueTarget(
   console.log(pullResult.message);
   console.log("Running ralphai in worktree...");
 
-  // Build runner options: single-target, no drain
+  // Build runner options: single-target, no drain.
+  // --once ensures the runner exits after completing this single issue
+  // instead of draining the backlog or pulling more GitHub issues.
   const activeWorktrees = listRalphaiWorktrees(cwd);
   const activeWorktree = activeWorktrees.find((wt) => wt.branch === branch);
   const shouldResume = activeWorktree !== undefined;
   const hasResumeFlag = runArgs.includes("--resume") || runArgs.includes("-r");
+  const hasOnceFlag = runArgs.includes("--once");
   const worktreeRunOptions: RalphaiOptions = {
     ...options,
     subcommand: "run",
     runTarget: undefined, // already handled
     runArgs: [
       ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
+      ...(!hasOnceFlag ? ["--once"] : []),
       ...runArgs,
     ],
   };


### PR DESCRIPTION
## Summary

- `ralphai run <issue>` for standalone (non-PRD) issues now stops after completing the targeted issue instead of continuing to drain the backlog or pull more GitHub issues.
- Injects `--once` into the runner args for standalone issues, matching the pattern already used by the PRD sub-issue path (`src/ralphai.ts:2286`).

## Problem

When running `ralphai run 42` for a standalone issue, the runner was started without `--once` (drain mode). After completing issue #42 it could:
1. Pull and run additional labeled GitHub issues
2. Process unrelated local plans in the backlog

This is confusing — a user targeting a specific issue expects exactly that issue to be processed.

## Change

Added `--once` injection in `runIssueTarget`'s standalone path (`src/ralphai.ts:2052-2059`), using the same guard pattern as the PRD path:

```ts
const hasOnceFlag = runArgs.includes("--once");
// ...
...(!hasOnceFlag ? ["--once"] : []),
```