### PR TITLE
fix: worktree creation respects --base-branch config

### DIFF
--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -26,7 +26,8 @@ Run `ralphai run` from the **main repository**, not from inside a worktree.
 ## How it works
 
 1. `ralphai run` creates a git worktree with a conventional-commit-style branch
-   (e.g. `feat/add-dark-mode`, `fix/broken-login`).
+   (e.g. `feat/add-dark-mode`, `fix/broken-login`), branching from the
+   configured `baseBranch` (default: `main`).
    It reuses existing worktrees for in-progress plans.
 2. If a `setupCommand` is configured, it runs in the worktree directory
    immediately after creation (e.g. `bun install`). This ensures
@@ -121,3 +122,36 @@ file is a pointer back to the main repo's `.git/worktrees/<name>` directory
 
 The mount is read-write so agents can create commits. No manual
 `dockerMounts` configuration is needed for worktree git operations.
+
+## Base branch
+
+By default, worktrees branch from `main` (or whatever `baseBranch` is set
+to in your config). You can override this per-run:
+
+```bash
+ralphai run --base-branch=develop
+```
+
+Resolution order (highest priority first):
+
+1. `--base-branch=<branch>` CLI flag
+2. `RALPHAI_BASE_BRANCH` env var
+3. `baseBranch` in config file (`~/.ralphai/repos/<id>/config.json`)
+4. Default: `main` (auto-detected during `ralphai init`)
+
+### Stacking work across PRDs
+
+If you have an in-progress PRD on a feature branch and want a second PRD
+to build on top of it, set `--base-branch` to the first PRD's branch:
+
+```bash
+# First PRD is in progress on feat/user-auth
+ralphai run 200 --base-branch=feat/user-auth
+```
+
+This creates the new worktree forked from `feat/user-auth` instead of
+`main`, so all the first PRD's commits are included. The resulting PR
+will target `feat/user-auth` as its base.
+
+When the first PRD merges to `main`, you can rebase or merge `main` into
+the second PRD's branch to update its base.

--- a/src/hitl.test.ts
+++ b/src/hitl.test.ts
@@ -521,6 +521,31 @@ describe("runHitl", () => {
     // baseBranch
     expect(call[3]).toBe("main");
   });
+
+  test("uses config baseBranch for worktree creation, not detectBaseBranch()", async () => {
+    // Config says "develop", but detectBaseBranch returns "main"
+    mockResolveConfig.mockReturnValue({
+      config: makeResolvedConfig({ baseBranch: "develop" }),
+    });
+    mockDetectBaseBranch.mockReturnValue("main");
+
+    const hitlPromise = runHitl({
+      issueNumber: 42,
+      cwd: tmpDir,
+      dryRun: false,
+      runArgs: [],
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    mockChildProcess!.emit("close", 0);
+    await hitlPromise;
+
+    expect(mockPrepareWorktree).toHaveBeenCalledTimes(1);
+    const call = mockPrepareWorktree.mock.calls[0]!;
+    // baseBranch should come from config, not detectBaseBranch
+    expect(call[3]).toBe("develop");
+    expect(mockDetectBaseBranch).not.toHaveBeenCalled();
+  });
 });
 
 describe("spawnInteractiveAgent", () => {

--- a/src/hitl.ts
+++ b/src/hitl.ts
@@ -37,7 +37,6 @@ import { execQuiet } from "./exec.ts";
 import { DONE_LABEL, IN_PROGRESS_LABEL, STUCK_LABEL } from "./labels.ts";
 import { prepareWorktree, type SetupSandboxConfig } from "./worktree/index.ts";
 import { isGitWorktree, ensureRepoHasCommit } from "./worktree/management.ts";
-import { detectBaseBranch } from "./git-helpers.ts";
 import { shellSplit } from "./runner.ts";
 import { formatFileRef } from "./prompt.ts";
 
@@ -196,7 +195,7 @@ export async function runHitl(options: HitlOptions): Promise<HitlResult> {
 
   // --- Prepare worktree ---
   ensureRepoHasCommit(cwd);
-  const baseBranch = detectBaseBranch(cwd);
+  const baseBranch = config.baseBranch.value;
   const setupCommand = config.setupCommand?.value ?? "";
   const feedbackCommands = config.feedbackCommands.value
     ? config.feedbackCommands.value.split(",").map((s: string) => s.trim())

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1786,6 +1786,7 @@ async function runIssueTarget(
     standaloneLabel: string;
     subissueLabel: string;
     prdLabel: string;
+    baseBranch: string;
     setupSandboxConfig?: SetupSandboxConfig;
   },
 ): Promise<void> {
@@ -1798,6 +1799,7 @@ async function runIssueTarget(
     standaloneLabel,
     subissueLabel,
     prdLabel,
+    baseBranch: resolvedBaseBranch,
     setupSandboxConfig,
   } = flags;
 
@@ -1934,6 +1936,7 @@ async function runIssueTarget(
       hasShowConfig,
       setupCommand,
       feedbackCommands,
+      baseBranch: resolvedBaseBranch,
       setupSandboxConfig,
     });
   }
@@ -1983,6 +1986,7 @@ async function runIssueTarget(
       hasShowConfig,
       setupCommand,
       feedbackCommands,
+      baseBranch: resolvedBaseBranch,
       setupSandboxConfig,
     });
   }
@@ -2006,12 +2010,11 @@ async function runIssueTarget(
   // Ensure repo has at least one commit
   ensureRepoHasCommit(cwd);
 
-  const baseBranch = detectBaseBranch(cwd);
   const resolvedWorktreeDir = prepareWorktree(
     cwd,
     issueSlug,
     branch,
-    baseBranch,
+    resolvedBaseBranch,
     setupCommand,
     setupSandboxConfig,
   ); // Pull the issue into a plan file in the worktree's pipeline
@@ -2094,11 +2097,17 @@ async function runPrdIssueTarget(
     hasShowConfig: boolean;
     setupCommand: string;
     feedbackCommands: string[];
+    baseBranch: string;
     setupSandboxConfig?: SetupSandboxConfig;
   },
 ): Promise<void> {
-  const { isDryRun, setupCommand, feedbackCommands, setupSandboxConfig } =
-    flags;
+  const {
+    isDryRun,
+    setupCommand,
+    feedbackCommands,
+    baseBranch: resolvedBaseBranch,
+    setupSandboxConfig,
+  } = flags;
   const { prd, subIssues, allCompleted } = discovery;
   const prdSlug = slugify(commitTypeFromTitle(prd.title).description);
   const branch = issueBranchName(prd.title);
@@ -2147,12 +2156,11 @@ async function runPrdIssueTarget(
   // Ensure repo has at least one commit
   ensureRepoHasCommit(cwd);
 
-  const baseBranch = detectBaseBranch(cwd);
   const resolvedWorktreeDir = prepareWorktree(
     cwd,
     prdSlug,
     branch,
-    baseBranch,
+    resolvedBaseBranch,
     setupCommand,
     setupSandboxConfig,
   );
@@ -2370,7 +2378,7 @@ async function runPrdIssueTarget(
     const issueRepo = worktreeConfig.issueRepo.value || repo;
     const prResult = createPrdPr({
       branch,
-      baseBranch,
+      baseBranch: resolvedBaseBranch,
       prd,
       completedSubIssues,
       stuckSubIssues,
@@ -2601,6 +2609,10 @@ async function runRalphaiInManagedWorktree(
   // --- Handle explicit positional target: `ralphai run 42` or `ralphai run my-feature.md` ---
   const target = options.runTarget;
 
+  // Use the resolved config baseBranch (respects --base-branch, env, config file),
+  // falling back to auto-detection only if config resolution failed.
+  const baseBranch = resolvedConfig?.baseBranch.value ?? detectBaseBranch(cwd);
+
   if (target?.type === "issue") {
     return runIssueTarget(target.number, options, runArgs, cwd, {
       isDryRun,
@@ -2611,6 +2623,7 @@ async function runRalphaiInManagedWorktree(
       standaloneLabel: resolvedIssueLabel,
       subissueLabel: resolvedSubissueLabel,
       prdLabel: resolvedIssuePrdLabel,
+      baseBranch,
       setupSandboxConfig,
     });
   }
@@ -2711,7 +2724,6 @@ async function runRalphaiInManagedWorktree(
 
       // --- Real PRD run: create worktree with PRD-derived branch ---
       ensureRepoHasCommit(cwd);
-      const baseBranch = detectBaseBranch(cwd);
       const activeWorktrees = listRalphaiWorktrees(cwd);
       const activeWorktree = activeWorktrees.find((wt) => wt.branch === branch);
       const resolvedWorktreeDir = prepareWorktree(
@@ -2782,7 +2794,6 @@ async function runRalphaiInManagedWorktree(
   ensureRepoHasCommit(cwd);
 
   const hasOnce = runArgs.includes("--once");
-  const baseBranch = detectBaseBranch(cwd);
 
   // Build GitHub fallback options so selectPlanForWorktree can pull an issue
   // when the local backlog is empty and issueSource is "github".
@@ -2881,6 +2892,7 @@ async function runRalphaiInManagedWorktree(
             hasShowConfig: false,
             setupCommand,
             feedbackCommands: feedbackCommandsList,
+            baseBranch,
             setupSandboxConfig,
           });
           // runPrdIssueTarget handles all sub-issues and PR creation — we're done


### PR DESCRIPTION
## Summary

- **Worktree creation now uses the resolved `baseBranch` config value** (respecting `--base-branch` CLI flag, `RALPHAI_BASE_BRANCH` env var, and config file) instead of always auto-detecting via `detectBaseBranch()`.
- **Enables stacked PRD workflows** — you can now fork a new PRD's worktree from an existing in-progress PRD branch with `ralphai run --base-branch=feat/first-prd`.
- **Init flows unchanged** — `ralphai init` still uses auto-detection since no config exists yet.

## Problem

There were two separate code paths for resolving the base branch:

1. **Worktree creation** (in `ralphai.ts` and `hitl.ts`) always called `detectBaseBranch()` which auto-detects from `origin/HEAD` / `main` / `master`, ignoring the `--base-branch` config.
2. **Runner operations** (PR creation, diffs, review pass) correctly used `config.baseBranch.value`.

This meant `--base-branch` had no effect on which branch worktrees forked from — only on PR targets and diffs, creating a confusing mismatch.

## Changes

- `src/ralphai.ts`: Consolidated baseBranch resolution in `runRalphaiInManagedWorktree()` to use `resolvedConfig.baseBranch.value` (with `detectBaseBranch()` fallback if config resolution failed). Threaded the value through to `runIssueTarget()` and `runPrdIssueTarget()` via their `flags` parameter.
- `src/hitl.ts`: Replaced `detectBaseBranch(cwd)` with `config.baseBranch.value` (resolved config is already available in scope).
- `src/hitl.test.ts`: Added test proving config baseBranch is used over `detectBaseBranch()`.