### PR TITLE
feat: allow ralphai run/hitl from inside a worktree

### DIFF
--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -21,7 +21,7 @@ ralphai clean --worktrees                 # remove completed worktrees
 
 The lifecycle: `ralphai run` creates or reuses a worktree → runs the plan there → pushes a branch → opens or updates a draft PR → `ralphai clean --worktrees` removes completed worktrees.
 
-Run `ralphai run` from the **main repository**, not from inside a worktree.
+Run `ralphai run` from anywhere — if you're inside a worktree, Ralphai automatically resolves to the main repository.
 
 ## How it works
 

--- a/src/hitl.test.ts
+++ b/src/hitl.test.ts
@@ -69,6 +69,7 @@ const mockPrepareWorktree =
 
 mock.module("./worktree/management.ts", () => ({
   isGitWorktree: mockIsGitWorktree,
+  resolveMainRepo: (dir: string) => dir,
   ensureRepoHasCommit: mockEnsureRepoHasCommit,
   resolveMainGitDir: () => undefined,
 }));
@@ -82,6 +83,7 @@ mock.module("./worktree/index.ts", () => ({
   selectPlanForWorktree: () => null,
   isGitWorktree: mockIsGitWorktree,
   resolveWorktreeInfo: () => ({ isWorktree: false, mainWorktree: "" }),
+  resolveMainRepo: (dir: string) => dir,
   resolveMainGitDir: () => undefined,
   ensureRepoHasCommit: mockEnsureRepoHasCommit,
   executeSetupCommand: () => {},

--- a/src/hitl.ts
+++ b/src/hitl.ts
@@ -31,7 +31,7 @@ import {
 import { execQuiet } from "./exec.ts";
 import { DONE_LABEL, IN_PROGRESS_LABEL, STUCK_LABEL } from "./labels.ts";
 import { prepareWorktree, type SetupSandboxConfig } from "./worktree/index.ts";
-import { isGitWorktree, ensureRepoHasCommit } from "./worktree/management.ts";
+import { resolveMainRepo, ensureRepoHasCommit } from "./worktree/management.ts";
 import { shellSplit } from "./runner.ts";
 import { formatFileRef } from "./prompt.ts";
 
@@ -63,16 +63,11 @@ export interface HitlResult {
  * the HITL label and adds `done`. On abnormal exit, leaves labels unchanged.
  */
 export async function runHitl(options: HitlOptions): Promise<HitlResult> {
-  const { issueNumber, cwd, dryRun, runArgs } = options;
+  const { issueNumber, dryRun, runArgs } = options;
+  let { cwd } = options;
 
   // --- Validate git context ---
-  if (isGitWorktree(cwd)) {
-    console.error("'ralphai hitl' must be run from the main repository.");
-    console.error(
-      "You are inside a worktree. Run this command from the main repo.",
-    );
-    process.exit(1);
-  }
+  cwd = resolveMainRepo(cwd);
 
   if (!existsSync(getConfigFilePath(cwd))) {
     console.error(

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -105,6 +105,7 @@ import {
 import {
   isGitWorktree,
   resolveWorktreeInfo,
+  resolveMainRepo,
   ensureRepoHasCommit,
   prepareWorktree,
   listRalphaiWorktrees,
@@ -1822,13 +1823,7 @@ async function runIssueTarget(
   // Validate run args (reject unrecognised flags)
   validateRunArgs(runArgs);
 
-  if (isGitWorktree(cwd)) {
-    console.error("'ralphai run' must be run from the main repository.");
-    console.error(
-      "You are inside a worktree. Run this command from the main repo.",
-    );
-    process.exit(1);
-  }
+  cwd = resolveMainRepo(cwd);
 
   if (!existsSync(getConfigFilePath(cwd))) {
     console.error(
@@ -2656,13 +2651,7 @@ async function runRalphaiInManagedWorktree(
       // Validate early (before worktree creation) — both dry-run and real runs
       validateRunArgs(runArgs);
 
-      if (isGitWorktree(cwd)) {
-        console.error(`'ralphai run' must be run from the main repository.`);
-        console.error(
-          "You are inside a worktree. Run this command from the main repo.",
-        );
-        process.exit(1);
-      }
+      cwd = resolveMainRepo(cwd);
 
       if (!existsSync(getConfigFilePath(cwd))) {
         console.error(
@@ -2776,13 +2765,7 @@ async function runRalphaiInManagedWorktree(
 
   validateRunArgs(runArgs);
 
-  if (isGitWorktree(cwd)) {
-    console.error(`'ralphai run' must be run from the main repository.`);
-    console.error(
-      "You are inside a worktree. Run this command from the main repo.",
-    );
-    process.exit(1);
-  }
+  cwd = resolveMainRepo(cwd);
 
   if (!existsSync(getConfigFilePath(cwd))) {
     console.error(

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -116,10 +116,12 @@ describe("worktree", () => {
       expect(result.stdout).toContain("worktree");
     });
 
-    it("run rejects execution from inside a worktree when not initialized", async () => {
+    it("run resolves to the main repo when invoked from a worktree (not initialized)", async () => {
       const result = await runCliInProcess(["run"], worktreeDir, env());
       expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).toContain("must be run from the main repository");
+      // Should resolve to the main repo and then fail because ralphai is not set up
+      expect(result.stderr).toContain("Detected worktree");
+      expect(result.stderr).toContain("not set up");
     });
   });
 });

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -16,6 +16,7 @@ export {
   isGitWorktree,
   resolveWorktreeInfo,
   resolveMainGitDir,
+  resolveMainRepo,
   executeSetupCommand,
   ensureRepoHasCommit,
   prepareWorktree,

--- a/src/worktree/management.ts
+++ b/src/worktree/management.ts
@@ -1,7 +1,7 @@
 import { execSync, spawnSync } from "child_process";
 import { existsSync, mkdirSync, rmSync, renameSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
-import { TEXT, RESET } from "../utils.ts";
+import { DIM, TEXT, RESET } from "../utils.ts";
 import { getRepoPipelineDirs } from "../global-state.ts";
 import { planExistsForSlug } from "../plan-detection.ts";
 import { findPlansByBranch } from "../receipt.ts";
@@ -38,6 +38,21 @@ export interface SetupSandboxConfig {
 
 export function isGitWorktree(dir: string): boolean {
   return resolveWorktreeInfo(dir).isWorktree;
+}
+
+/**
+ * If `dir` is inside a git worktree, resolve to the main repository root
+ * and print a dim info line. Otherwise return `dir` unchanged.
+ */
+export function resolveMainRepo(dir: string): string {
+  const info = resolveWorktreeInfo(dir);
+  if (info.isWorktree) {
+    console.error(
+      `${DIM}Detected worktree — using main repo at ${info.mainWorktree}${RESET}`,
+    );
+    return info.mainWorktree;
+  }
+  return dir;
 }
 
 export function resolveWorktreeInfo(dir: string): {


### PR DESCRIPTION
## Summary

- Instead of rejecting `ralphai run` and `ralphai hitl` when invoked from inside a git worktree, auto-resolve to the main repository root and continue normally
- Prints a dim info line (`Detected worktree — using main repo at /path`) so the user knows the redirect happened
- `ralphai init` still blocks inside worktrees — config writes should target the main repo explicitly

## Changes

- **`src/worktree/management.ts`** — new `resolveMainRepo()` helper that wraps `resolveWorktreeInfo()` with a user-facing message
- **`src/ralphai.ts`** — replaced 3 error-and-exit blocks with `cwd = resolveMainRepo(cwd)` (issue target, `--prd` path, default plan path)
- **`src/hitl.ts`** — replaced 1 error-and-exit block, removed unused `isGitWorktree` import
- **`src/worktree/index.ts`** — re-exports `resolveMainRepo`
- **`src/worktree.test.ts`** — updated test to expect "Detected worktree" + "not set up" instead of "must be run from the main repository"
- **`src/hitl.test.ts`** — added `resolveMainRepo` to mock modules
- **`docs/worktrees.md`** — updated guidance to reflect the new behavior