### PR TITLE
refactor: deepen Worktree Management with exec.ts routing and curated interface

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,33 +81,33 @@ Worktree logic is split into focused sub-modules, re-exported through a barrel (
 
 ## Supporting modules
 
-| File                       | Role                                                                                     |
-| -------------------------- | ---------------------------------------------------------------------------------------- |
-| `src/config.ts`            | Config file resolution, CLI arg merging, validation.                                     |
-| `src/show-config.ts`       | `--show-config` output formatting.                                                       |
-| `src/issues.ts`            | GitHub issue pulling, slug generation, label fetching, parent discovery, HITL filtering. |
-| `src/issue-dispatch.ts`    | Label-driven dispatch classification and validation for issue targets.                   |
-| `src/labels.ts`            | Shared state label constants (`in-progress`, `done`, `stuck`).                           |
-| `src/label-lifecycle.ts`   | Centralized label transitions (pull, done, stuck, reset, PRD).                           |
-| `src/prd-discovery.ts`     | PRD issue discovery and sub-issue routing.                                               |
-| `src/pr-lifecycle.ts`      | PR lifecycle: creation, updates, archiving, and body generation (summary, learnings).    |
-| `src/receipt.ts`           | Completion receipt parsing and source checking.                                          |
-| `src/frontmatter.ts`       | YAML frontmatter extraction (`scope`, `depends-on`, etc.).                               |
-| `src/pipeline-state.ts`    | Gathers backlog/in-progress/completed counts for status display.                         |
-| `src/project-detection.ts` | Auto-detects project type, feedback commands, workspaces.                                |
-| `src/target-detection.ts`  | Resolves run targets from CLI args (plan slug, issue number, PRD).                       |
-| `src/global-state.ts`      | Pipeline directory resolution and repo registry.                                         |
-| `src/git-ops.ts`           | Higher-level git operations: commit hashing, branch checks.                              |
-| `src/learnings.ts`         | Learnings formatting for prompts and PR bodies (pure functions).                         |
-| `src/completion-gate.ts`   | Verifies agent COMPLETE claims before accepting plan completion.                         |
-| `src/review-pass.ts`       | Post-completion review pass: changed file detection and simplification prompt assembly.  |
-| `src/feedback-wrapper.ts`  | Generates `_ralphai_feedback.sh` wrapper script (written to WIP dir, not worktree).      |
-| `src/process-utils.ts`     | Child process helpers.                                                                   |
-| `src/shell-split.ts`       | Minimal shell-like argument splitting (handles quotes and escapes).                      |
-| `src/utils.ts`             | Terminal color constants and shared formatting utilities.                                |
-| `src/ipc-server.ts`        | IPC server for agent communication.                                                      |
-| `src/ipc-protocol.ts`      | IPC message types and socket path resolution.                                            |
-| `src/self-update.ts`       | `ralphai update` self-update logic.                                                      |
+| File                       | Role                                                                                           |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/config.ts`            | Config file resolution, CLI arg merging, validation.                                           |
+| `src/show-config.ts`       | `--show-config` output formatting.                                                             |
+| `src/issues.ts`            | GitHub issue pulling, slug generation, label fetching, parent discovery, HITL filtering.       |
+| `src/issue-dispatch.ts`    | Label-driven dispatch classification and validation for issue targets.                         |
+| `src/labels.ts`            | Shared state label constants (`in-progress`, `done`, `stuck`).                                 |
+| `src/label-lifecycle.ts`   | Centralized label transitions (pull, done, stuck, reset, PRD).                                 |
+| `src/prd-discovery.ts`     | PRD issue discovery and sub-issue routing.                                                     |
+| `src/pr-lifecycle.ts`      | PR lifecycle: creation, updates, archiving, and body generation (summary, learnings).          |
+| `src/receipt.ts`           | Completion receipt parsing and source checking.                                                |
+| `src/frontmatter.ts`       | YAML frontmatter extraction (`scope`, `depends-on`, etc.).                                     |
+| `src/pipeline-state.ts`    | Gathers backlog/in-progress/completed counts for status display.                               |
+| `src/project-detection.ts` | Auto-detects project type, feedback commands, workspaces.                                      |
+| `src/target-detection.ts`  | Resolves run targets from CLI args (plan slug, issue number, PRD).                             |
+| `src/global-state.ts`      | Pipeline directory resolution and repo registry.                                               |
+| `src/git-ops.ts`           | Higher-level git operations: commit hashing, branch checks.                                    |
+| `src/learnings.ts`         | Learnings formatting for prompts and PR bodies (pure functions).                               |
+| `src/completion-gate.ts`   | Verifies agent COMPLETE claims before accepting plan completion.                               |
+| `src/review-pass.ts`       | Post-completion review pass: changed file detection and simplification prompt assembly.        |
+| `src/feedback-wrapper.ts`  | Generates and writes `_ralphai_feedback.sh` wrapper script (written to WIP dir, not worktree). |
+| `src/process-utils.ts`     | Child process helpers.                                                                         |
+| `src/shell-split.ts`       | Minimal shell-like argument splitting (handles quotes and escapes).                            |
+| `src/utils.ts`             | Terminal color constants and shared formatting utilities.                                      |
+| `src/ipc-server.ts`        | IPC server for agent communication.                                                            |
+| `src/ipc-protocol.ts`      | IPC message types and socket path resolution.                                                  |
+| `src/self-update.ts`       | `ralphai update` self-update logic.                                                            |
 
 ## Dependency direction
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,7 +70,16 @@ Pure data helpers and the `@clack/prompts`-based config wizard, shared between t
 
 ## Worktree subsystem (`src/worktree/`)
 
-Worktree logic is split into focused sub-modules, re-exported through a barrel (`index.ts`).
+Worktree logic is split into focused sub-modules, re-exported through a curated barrel (`index.ts`). External callers must import from the barrel — never from internal files like `management.ts` or `parsing.ts` directly.
+
+**Public API** (exported from `worktree/index.ts`):
+
+- Types: `WorktreeEntry`, `GitHubFallbackOptions`, `SetupSandboxConfig`
+- Parsing: `listRalphaiWorktrees`
+- Selection: `selectPlanForWorktree`
+- Management: `isGitWorktree`, `resolveWorktreeInfo`, `resolveMainGitDir`, `resolveMainRepo`, `executeSetupCommand`, `ensureRepoHasCommit`, `prepareWorktree`
+
+Internal-only symbols (e.g. `parseWorktreeList`, `isRalphaiManagedBranch`, `SelectedWorktreePlan`) are not re-exported and should only be used within the worktree module or its own tests.
 
 | File                         | Role                                                                                                  |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------- |

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -40,7 +40,6 @@ const ISOLATED = [
   "src/interactive/run-wizard.test.ts",
   "src/runner-github-drain.test.ts",
   "src/hitl.test.ts",
-  "src/setup-command-routing.test.ts",
   "src/plan-detection-race.test.ts",
 ];
 

--- a/src/docker-executor.test.ts
+++ b/src/docker-executor.test.ts
@@ -22,7 +22,7 @@ import {
   CONTAINER_HOME,
   getUserFlag,
 } from "./executor/docker.ts";
-import { resolveMainGitDir } from "./worktree/management.ts";
+import { resolveMainGitDir } from "./worktree/index.ts";
 import { createExecutor } from "./executor/index.ts";
 import { LocalExecutor } from "./executor/local.ts";
 import {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -129,6 +129,27 @@ export function execWithStdin(
   }
 }
 
+/**
+ * Run a command with inherited stdio (output streams to the terminal).
+ * Returns an `ExecRunResult` with the exit code. `stdout` and `stderr`
+ * are always empty strings because the streams are inherited, not captured.
+ *
+ * Use this for commands whose output should be visible to the user in
+ * real time (e.g. setup commands, cleanup operations).
+ */
+export function execInherit(cmd: string, cwd: string): ExecRunResult {
+  try {
+    _execSync(cmd, { cwd, stdio: "inherit" });
+    return { exitCode: 0, stdout: "", stderr: "" };
+  } catch (err: unknown) {
+    const exitCode =
+      err && typeof err === "object" && "status" in err
+        ? ((err as { status: number }).status ?? 1)
+        : 1;
+    return { exitCode, stdout: "", stderr: "" };
+  }
+}
+
 /** Run a command, returning true if it exits 0. */
 export function execOk(cmd: string, cwd: string): boolean {
   try {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -32,6 +32,13 @@ export function setExecImpl(impl: ExecSyncFn): () => void {
   };
 }
 
+/** Extract exit code from an execSync error, defaulting to 1. */
+function exitCodeFrom(err: unknown): number {
+  return err && typeof err === "object" && "status" in err
+    ? ((err as { status: number }).status ?? 1)
+    : 1;
+}
+
 /** Options for exec utilities that support timeout. */
 export interface ExecOptions {
   /**
@@ -72,10 +79,6 @@ export function execRun(
     });
     return { exitCode: 0, stdout: String(stdout).trim(), stderr: "" };
   } catch (err: unknown) {
-    const exitCode =
-      err && typeof err === "object" && "status" in err
-        ? ((err as { status: number }).status ?? 1)
-        : 1;
     const stderr =
       err && typeof err === "object" && "stderr" in err
         ? String((err as { stderr: unknown }).stderr).trim()
@@ -84,7 +87,7 @@ export function execRun(
       err && typeof err === "object" && "stdout" in err
         ? String((err as { stdout: unknown }).stdout).trim()
         : "";
-    return { exitCode, stdout, stderr };
+    return { exitCode: exitCodeFrom(err), stdout, stderr };
   }
 }
 
@@ -142,11 +145,7 @@ export function execInherit(cmd: string, cwd: string): ExecRunResult {
     _execSync(cmd, { cwd, stdio: "inherit" });
     return { exitCode: 0, stdout: "", stderr: "" };
   } catch (err: unknown) {
-    const exitCode =
-      err && typeof err === "object" && "status" in err
-        ? ((err as { status: number }).status ?? 1)
-        : 1;
-    return { exitCode, stdout: "", stderr: "" };
+    return { exitCode: exitCodeFrom(err), stdout: "", stderr: "" };
   }
 }
 

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -170,21 +170,12 @@ export function execOk(cmd: string, cwd: string): boolean {
 export function checkGhAvailable(options?: ExecOptions): boolean {
   const timeoutOpt =
     options?.timeout != null ? { timeout: options.timeout } : {};
-  try {
-    _execSync("gh --version", {
-      stdio: ["pipe", "pipe", "pipe"],
-      ...timeoutOpt,
-    });
-  } catch {
-    return false;
-  }
-  try {
-    _execSync("gh auth status", {
-      stdio: ["pipe", "pipe", "pipe"],
-      ...timeoutOpt,
-    });
-  } catch {
-    return false;
+  for (const cmd of ["gh --version", "gh auth status"]) {
+    try {
+      _execSync(cmd, { stdio: ["pipe", "pipe", "pipe"], ...timeoutOpt });
+    } catch {
+      return false;
+    }
   }
   return true;
 }

--- a/src/executor/docker.ts
+++ b/src/executor/docker.ts
@@ -26,7 +26,7 @@ import type {
 
 import { shellSplit } from "../shell-split.ts";
 import { detectAgentType } from "../show-config.ts";
-import { resolveMainGitDir } from "../worktree/management.ts";
+import { resolveMainGitDir } from "../worktree/index.ts";
 
 // ---------------------------------------------------------------------------
 // Container user and home directory

--- a/src/feedback-wrapper.test.ts
+++ b/src/feedback-wrapper.test.ts
@@ -19,8 +19,8 @@ import {
   parseFeedbackCommands,
   FEEDBACK_WRAPPER_FILENAME,
   DEFAULT_TIMEOUT_SECONDS,
+  writeFeedbackWrapper,
 } from "./feedback-wrapper.ts";
-import { writeFeedbackWrapper } from "./worktree/management.ts";
 
 // ---------------------------------------------------------------------------
 // parseFeedbackCommands — pure logic

--- a/src/feedback-wrapper.ts
+++ b/src/feedback-wrapper.ts
@@ -1,3 +1,6 @@
+import { writeFileSync } from "fs";
+import { join } from "path";
+
 /**
  * Feedback wrapper script generator.
  *
@@ -12,8 +15,8 @@
  * wrapper out of the user's worktree so it doesn't appear as an
  * untracked file in `git status`.
  *
- * This module exports a pure function — no I/O. The caller
- * (`writeFeedbackWrapper` in worktree/management.ts) handles writing.
+ * `writeFeedbackWrapper` handles writing the generated script to disk.
+ * `generateFeedbackWrapper` is a pure function — no I/O.
  */
 
 /** Filename of the generated wrapper script. */
@@ -152,4 +155,27 @@ function generateCommandBlock(
  */
 function escapeForShell(cmd: string): string {
   return `'${cmd.replace(/'/g, "'\\''")}'`;
+}
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * Write the feedback wrapper script to the given directory.
+ * Typically called with the WIP slug directory so the script stays
+ * out of the user's worktree (no untracked-file noise in git status).
+ * Skipped on Windows (process.platform === "win32") and when no
+ * feedback commands are configured.
+ */
+export function writeFeedbackWrapper(
+  targetDir: string,
+  feedbackCommands?: string[],
+): void {
+  if (process.platform === "win32") return;
+  if (!feedbackCommands || feedbackCommands.length === 0) return;
+
+  const script = generateFeedbackWrapper(feedbackCommands);
+  const wrapperPath = join(targetDir, FEEDBACK_WRAPPER_FILENAME);
+  writeFileSync(wrapperPath, script, { mode: 0o755 });
 }

--- a/src/feedback-wrapper.ts
+++ b/src/feedback-wrapper.ts
@@ -56,9 +56,9 @@ export function generateFeedbackWrapper(
     return generateEmptyWrapper();
   }
 
-  const escapedCommands = commands.map((cmd) => escapeForShell(cmd));
-  const commandBlocks = escapedCommands
-    .map((cmd, i) => generateCommandBlock(cmd, i + 1, commands.length))
+  const total = commands.length;
+  const commandBlocks = commands
+    .map((cmd, i) => `run_command ${escapeForShell(cmd)} ${i + 1} ${total}`)
     .join("\n");
 
   return `#!/usr/bin/env bash
@@ -135,17 +135,6 @@ function generateEmptyWrapper(): string {
 echo "No feedback commands configured."
 exit 0
 `;
-}
-
-/**
- * Generate the shell block for a single command invocation.
- */
-function generateCommandBlock(
-  escapedCmd: string,
-  index: number,
-  total: number,
-): string {
-  return `run_command ${escapedCmd} ${index} ${total}`;
 }
 
 /**

--- a/src/hitl.test.ts
+++ b/src/hitl.test.ts
@@ -92,8 +92,6 @@ mock.module("./worktree/index.ts", () => ({
   resolveMainGitDir: () => undefined,
   ensureRepoHasCommit: mockEnsureRepoHasCommit,
   executeSetupCommand: () => {},
-  listWorktrees: () => [],
-  cleanWorktrees: () => {},
 }));
 
 // Mock git-helpers

--- a/src/hitl.test.ts
+++ b/src/hitl.test.ts
@@ -81,8 +81,6 @@ mock.module("./worktree/management.ts", () => ({
 
 mock.module("./worktree/index.ts", () => ({
   prepareWorktree: mockPrepareWorktree,
-  parseWorktreeList: () => [],
-  isRalphaiManagedBranch: () => false,
   listRalphaiWorktrees: () => [],
   selectPlanForWorktree: () => null,
   isGitWorktree: mockIsGitWorktree,

--- a/src/hitl.test.ts
+++ b/src/hitl.test.ts
@@ -81,7 +81,6 @@ mock.module("./worktree/management.ts", () => ({
 
 mock.module("./worktree/index.ts", () => ({
   prepareWorktree: mockPrepareWorktree,
-  writeFeedbackWrapper: () => {},
   parseWorktreeList: () => [],
   isRalphaiManagedBranch: () => false,
   listRalphaiWorktrees: () => [],

--- a/src/hitl.test.ts
+++ b/src/hitl.test.ts
@@ -137,8 +137,7 @@ const { makeTestResolvedConfig } = await import("./test-utils.ts");
 // ---------------------------------------------------------------------------
 
 function createTmpDir(): string {
-  const dir = mkdtempSync(join(tmpdir(), "ralphai-hitl-test-"));
-  return dir;
+  return mkdtempSync(join(tmpdir(), "ralphai-hitl-test-"));
 }
 
 function setupDefaultMocks(tmpDir: string) {

--- a/src/hitl.ts
+++ b/src/hitl.ts
@@ -30,8 +30,12 @@ import {
 } from "./issues.ts";
 import { execQuiet } from "./exec.ts";
 import { DONE_LABEL, IN_PROGRESS_LABEL, STUCK_LABEL } from "./labels.ts";
-import { prepareWorktree, type SetupSandboxConfig } from "./worktree/index.ts";
-import { resolveMainRepo, ensureRepoHasCommit } from "./worktree/management.ts";
+import {
+  prepareWorktree,
+  resolveMainRepo,
+  ensureRepoHasCommit,
+  type SetupSandboxConfig,
+} from "./worktree/index.ts";
 import { shellSplit } from "./shell-split.ts";
 import { formatFileRef } from "./prompt.ts";
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -41,8 +41,8 @@ import { assemblePrompt } from "./prompt.ts";
 import {
   FEEDBACK_WRAPPER_FILENAME,
   parseFeedbackCommands,
+  writeFeedbackWrapper,
 } from "./feedback-wrapper.ts";
-import { writeFeedbackWrapper } from "./worktree/index.ts";
 import { stripAnsi } from "./utils.ts";
 
 import {

--- a/src/select-plan-liveness.test.ts
+++ b/src/select-plan-liveness.test.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 import { execSync } from "child_process";
 import { useTempDir } from "./test-utils.ts";
 import { selectPlanForWorktree } from "./worktree/index.ts";
-import type { WorktreeEntry } from "./worktree/types.ts";
+import type { WorktreeEntry } from "./worktree/index.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/setup-command-routing.test.ts
+++ b/src/setup-command-routing.test.ts
@@ -13,7 +13,7 @@ import { setExecImpl } from "./exec.ts";
 import {
   executeSetupCommand,
   type SetupSandboxConfig,
-} from "./worktree/management.ts";
+} from "./worktree/index.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/setup-command-routing.test.ts
+++ b/src/setup-command-routing.test.ts
@@ -3,52 +3,13 @@
  *
  * Verifies that executeSetupCommand() routes through Docker when given
  * a sandbox config with sandbox="docker", and falls through to host
- * execSync when sandbox="none" or no config is provided.
+ * exec when sandbox="none" or no config is provided.
  *
- * Uses mock.module() to intercept child_process calls — no real Docker
+ * Uses setExecImpl() to intercept all subprocess calls — no real Docker
  * or shell commands are executed.
  */
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
-
-// ---------------------------------------------------------------------------
-// Mock child_process to capture spawnSync and execSync calls
-// ---------------------------------------------------------------------------
-
-let spawnSyncCalls: Array<{
-  command: string;
-  args: string[];
-  options: Record<string, unknown>;
-}> = [];
-let execSyncCalls: Array<{
-  command: string;
-  options: Record<string, unknown>;
-}> = [];
-
-let mockSpawnSyncResult: {
-  status: number | null;
-  error?: Error;
-} = { status: 0 };
-let mockExecSyncThrow: Error | null = null;
-
-mock.module("child_process", () => ({
-  execSync: (command: string, options: Record<string, unknown> = {}) => {
-    execSyncCalls.push({ command, options });
-    if (mockExecSyncThrow) throw mockExecSyncThrow;
-    return "";
-  },
-  spawnSync: (
-    command: string,
-    args: string[],
-    options: Record<string, unknown> = {},
-  ) => {
-    spawnSyncCalls.push({ command, args, options });
-    return mockSpawnSyncResult;
-  },
-  // Re-export spawn for other modules that might need it
-  spawn: () => {},
-}));
-
-// Import after mocking
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { setExecImpl } from "./exec.ts";
 import {
   executeSetupCommand,
   type SetupSandboxConfig,
@@ -58,17 +19,47 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-// Capture process.exit calls instead of actually exiting
+let execCalls: Array<{
+  command: string;
+  options: Record<string, unknown>;
+}> = [];
+
+let restore: () => void;
 let exitCode: number | null = null;
 const originalExit = process.exit;
 const originalConsoleError = console.error;
 const originalConsoleLog = console.log;
 
+/** Default mock that succeeds and records calls. */
+function mockExecSuccess() {
+  return setExecImpl(((command: string, options: Record<string, unknown>) => {
+    execCalls.push({ command, options });
+    return "";
+  }) as any);
+}
+
+/** Mock that throws for specific commands (simulating failure). */
+function mockExecFail(failCmd?: string | RegExp) {
+  return setExecImpl(((command: string, options: Record<string, unknown>) => {
+    execCalls.push({ command, options });
+    if (!failCmd) {
+      const err = new Error("Command failed");
+      (err as any).status = 1;
+      throw err;
+    }
+    const matches =
+      failCmd instanceof RegExp ? failCmd.test(command) : command === failCmd;
+    if (matches) {
+      const err = new Error("Command failed");
+      (err as any).status = 1;
+      throw err;
+    }
+    return "";
+  }) as any);
+}
+
 beforeEach(() => {
-  spawnSyncCalls = [];
-  execSyncCalls = [];
-  mockSpawnSyncResult = { status: 0 };
-  mockExecSyncThrow = null;
+  execCalls = [];
   exitCode = null;
   process.exit = ((code: number) => {
     exitCode = code;
@@ -80,6 +71,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  if (restore) restore();
   process.exit = originalExit;
   console.error = originalConsoleError;
   console.log = originalConsoleLog;
@@ -90,55 +82,69 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("executeSetupCommand — routing", () => {
-  it("runs via execSync on host when no sandboxConfig is provided", () => {
+  it("runs setup command on host when no sandboxConfig is provided", () => {
+    restore = mockExecSuccess();
     executeSetupCommand("bun install", "/work/my-project");
-    expect(execSyncCalls).toHaveLength(1);
-    expect(execSyncCalls[0]!.command).toBe("bun install");
-    expect(execSyncCalls[0]!.options.cwd).toBe("/work/my-project");
-    expect(spawnSyncCalls).toHaveLength(0);
+
+    // Should have exactly one call: the setup command itself
+    const setupCalls = execCalls.filter((c) =>
+      c.command.includes("bun install"),
+    );
+    expect(setupCalls).toHaveLength(1);
+    expect(setupCalls[0]!.options.cwd).toBe("/work/my-project");
+    // Should NOT route through docker
+    const dockerCalls = execCalls.filter((c) => c.command.startsWith("docker"));
+    expect(dockerCalls).toHaveLength(0);
   });
 
-  it("runs via execSync on host when sandbox is 'none'", () => {
+  it("runs setup command on host when sandbox is 'none'", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "none",
       agentCommand: "claude -p",
     };
     executeSetupCommand("bun install", "/work/my-project", config);
-    expect(execSyncCalls).toHaveLength(1);
-    expect(execSyncCalls[0]!.command).toBe("bun install");
-    expect(spawnSyncCalls).toHaveLength(0);
+
+    const setupCalls = execCalls.filter((c) =>
+      c.command.includes("bun install"),
+    );
+    expect(setupCalls).toHaveLength(1);
+    const dockerCalls = execCalls.filter((c) => c.command.startsWith("docker"));
+    expect(dockerCalls).toHaveLength(0);
   });
 
-  it("runs via Docker spawnSync when sandbox is 'docker'", () => {
+  it("routes through Docker when sandbox is 'docker'", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
     };
     executeSetupCommand("bun install", "/work/my-project", config);
-    expect(spawnSyncCalls).toHaveLength(1);
-    expect(spawnSyncCalls[0]!.command).toBe("docker");
-    // resolveMainGitDir may call execSync for git rev-parse, but no
-    // host setup command (like "bun install") should run via execSync
-    const hostSetupCalls = execSyncCalls.filter(
+
+    // Should include a docker command
+    const dockerCalls = execCalls.filter((c) => c.command.startsWith("docker"));
+    expect(dockerCalls).toHaveLength(1);
+    // Should NOT have a direct host "bun install" call
+    const directSetupCalls = execCalls.filter(
       (c) => c.command === "bun install",
     );
-    expect(hostSetupCalls).toHaveLength(0);
+    expect(directSetupCalls).toHaveLength(0);
   });
 
   it("no-ops when setupCommand is empty (sandbox=none)", () => {
+    restore = mockExecSuccess();
     executeSetupCommand("", "/work/my-project");
-    expect(execSyncCalls).toHaveLength(0);
-    expect(spawnSyncCalls).toHaveLength(0);
+    expect(execCalls).toHaveLength(0);
   });
 
   it("no-ops when setupCommand is empty (sandbox=docker)", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
     };
     executeSetupCommand("", "/work/my-project", config);
-    expect(execSyncCalls).toHaveLength(0);
-    expect(spawnSyncCalls).toHaveLength(0);
+    expect(execCalls).toHaveLength(0);
   });
 });
 
@@ -148,43 +154,46 @@ describe("executeSetupCommand — routing", () => {
 
 describe("executeSetupCommand — Docker command construction", () => {
   it("includes worktree bind mount at host path", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
     };
     executeSetupCommand("npm install", "/work/my-project", config);
 
-    const args = spawnSyncCalls[0]!.args;
-    const vIdx = args.indexOf("-v");
-    expect(vIdx).toBeGreaterThan(-1);
-    expect(args[vIdx + 1]).toBe("/work/my-project:/work/my-project");
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall).toBeDefined();
+    expect(dockerCall!.command).toContain("/work/my-project:/work/my-project");
   });
 
   it("sets working directory to worktree path", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
     };
     executeSetupCommand("npm install", "/work/my-project", config);
 
-    const args = spawnSyncCalls[0]!.args;
-    const wIdx = args.indexOf("-w");
-    expect(wIdx).toBeGreaterThan(-1);
-    expect(args[wIdx + 1]).toBe("/work/my-project");
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall!.command).toContain("-w /work/my-project");
   });
 
   it("resolves image from agent command", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
     };
     executeSetupCommand("npm install", "/work", config);
 
-    const args = spawnSyncCalls[0]!.args;
-    expect(args).toContain("ghcr.io/mfaux/ralphai-sandbox:claude");
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall!.command).toContain(
+      "ghcr.io/mfaux/ralphai-sandbox:claude",
+    );
   });
 
   it("uses dockerImage override from config", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
@@ -194,36 +203,29 @@ describe("executeSetupCommand — Docker command construction", () => {
     };
     executeSetupCommand("npm install", "/work", config);
 
-    const args = spawnSyncCalls[0]!.args;
-    expect(args).toContain("my-custom-image:v2");
-    expect(args).not.toContain("ghcr.io/mfaux/ralphai-sandbox:claude");
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall!.command).toContain("my-custom-image:v2");
+    expect(dockerCall!.command).not.toContain(
+      "ghcr.io/mfaux/ralphai-sandbox:claude",
+    );
   });
 
   it("wraps setup command with sh -c", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
     };
     executeSetupCommand("bun install && bun run build", "/work", config);
 
-    const args = spawnSyncCalls[0]!.args;
-    const len = args.length;
-    expect(args[len - 3]).toBe("sh");
-    expect(args[len - 2]).toBe("-c");
-    expect(args[len - 1]).toBe("bun install && bun run build");
-  });
-
-  it("uses stdio: inherit for interactive output", () => {
-    const config: SetupSandboxConfig = {
-      sandbox: "docker",
-      agentCommand: "claude -p",
-    };
-    executeSetupCommand("npm install", "/work", config);
-
-    expect(spawnSyncCalls[0]!.options.stdio).toBe("inherit");
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    // sh -c is in the command string; the setup command may be quoted
+    expect(dockerCall!.command).toContain("sh -c");
+    expect(dockerCall!.command).toContain("bun install && bun run build");
   });
 
   it("passes extra docker mounts from config", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
@@ -233,11 +235,12 @@ describe("executeSetupCommand — Docker command construction", () => {
     };
     executeSetupCommand("npm install", "/work", config);
 
-    const args = spawnSyncCalls[0]!.args;
-    expect(args).toContain("/host/cache:/container/cache:ro");
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall!.command).toContain("/host/cache:/container/cache:ro");
   });
 
   it("passes extra docker env vars from config", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
@@ -247,13 +250,13 @@ describe("executeSetupCommand — Docker command construction", () => {
     };
     executeSetupCommand("npm install", "/work", config);
 
-    // Verify docker args were built (env var forwarding is tested in
-    // buildEnvFlags tests — here we verify it was passed through)
-    expect(spawnSyncCalls).toHaveLength(1);
-    expect(spawnSyncCalls[0]!.command).toBe("docker");
+    // Verify docker command was built
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall).toBeDefined();
   });
 
   it("mounts main git dir when mainGitDir is provided", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
@@ -265,32 +268,30 @@ describe("executeSetupCommand — Docker command construction", () => {
       config,
     );
 
-    const args = spawnSyncCalls[0]!.args;
-    const mountArgs = args.filter(
-      (a: string, i: number) => i > 0 && args[i - 1] === "-v",
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall!.command).toContain(
+      "/work/main-repo/.git:/work/main-repo/.git",
     );
-    const gitMount = mountArgs.find((m: string) =>
-      m.includes("/work/main-repo/.git"),
-    );
-    expect(gitMount).toBe("/work/main-repo/.git:/work/main-repo/.git");
   });
 
   it("does NOT add main git dir mount when mainGitDir is absent", () => {
+    restore = mockExecSuccess();
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
     };
     executeSetupCommand("bun install", "/work/my-project", config);
 
-    const args = spawnSyncCalls[0]!.args;
-    const mountArgs = args.filter(
-      (a: string, i: number) => i > 0 && args[i - 1] === "-v",
-    );
-    // Only the worktree mount should be present (no credential mounts since
-    // host env is mocked and no files exist)
-    const bindMounts = mountArgs.filter((m: string) => !m.includes(":ro"));
-    expect(bindMounts).toHaveLength(1);
-    expect(bindMounts[0]).toBe("/work/my-project:/work/my-project");
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    // The docker command should have the worktree mount but not a .git mount.
+    // resolveMainGitDir calls execQuiet which returns "" (not a worktree),
+    // so no main git dir mount is added.
+    expect(dockerCall!.command).toContain("/work/my-project:/work/my-project");
+    // Count -v mounts: should only have the worktree mount (no git dir mount)
+    const vMatches = dockerCall!.command.match(/-v /g);
+    // There's always at least one -v for the worktree bind mount; there may
+    // be credential mounts too. The key assertion is no .git mount.
+    expect(dockerCall!.command).not.toContain("/.git:");
   });
 });
 
@@ -300,7 +301,7 @@ describe("executeSetupCommand — Docker command construction", () => {
 
 describe("executeSetupCommand — error handling", () => {
   it("exits with code 1 when Docker setup command fails", () => {
-    mockSpawnSyncResult = { status: 1 };
+    restore = mockExecFail(/^docker/);
     const config: SetupSandboxConfig = {
       sandbox: "docker",
       agentCommand: "claude -p",
@@ -313,21 +314,8 @@ describe("executeSetupCommand — error handling", () => {
   });
 
   it("exits with code 1 when host setup command fails", () => {
-    mockExecSyncThrow = new Error("Command failed");
+    restore = mockExecFail();
     expect(() => executeSetupCommand("npm install", "/work")).toThrow(
-      "process.exit(1)",
-    );
-    expect(exitCode).toBe(1);
-  });
-
-  it("exits with code 1 when Docker spawn error occurs", () => {
-    mockSpawnSyncResult = { status: 1, error: new Error("ENOENT") };
-    const config: SetupSandboxConfig = {
-      sandbox: "docker",
-      agentCommand: "claude -p",
-    };
-
-    expect(() => executeSetupCommand("npm install", "/work", config)).toThrow(
       "process.exit(1)",
     );
     expect(exitCode).toBe(1);

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -1,14 +1,6 @@
-export type {
-  WorktreeEntry,
-  SelectedWorktreePlan,
-  GitHubFallbackOptions,
-} from "./types.ts";
+export type { WorktreeEntry, GitHubFallbackOptions } from "./types.ts";
 
-export {
-  parseWorktreeList,
-  isRalphaiManagedBranch,
-  listRalphaiWorktrees,
-} from "./parsing.ts";
+export { listRalphaiWorktrees } from "./parsing.ts";
 
 export { selectPlanForWorktree } from "./selection.ts";
 

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -21,7 +21,5 @@ export {
   ensureRepoHasCommit,
   prepareWorktree,
   writeFeedbackWrapper,
-  listWorktrees,
-  cleanWorktrees,
   type SetupSandboxConfig,
 } from "./management.ts";

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -20,6 +20,5 @@ export {
   executeSetupCommand,
   ensureRepoHasCommit,
   prepareWorktree,
-  writeFeedbackWrapper,
   type SetupSandboxConfig,
 } from "./management.ts";

--- a/src/worktree/management.test.ts
+++ b/src/worktree/management.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Boundary tests for worktree management and parsing functions.
+ *
+ * Uses `setExecImpl` to mock subprocess calls, verifying that all I/O
+ * routes through the `exec.ts` abstraction.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { setExecImpl } from "../exec.ts";
+import { listRalphaiWorktrees } from "./parsing.ts";
+import { resolveWorktreeInfo } from "./management.ts";
+
+// ---------------------------------------------------------------------------
+// listRalphaiWorktrees via setExecImpl
+// ---------------------------------------------------------------------------
+
+describe("listRalphaiWorktrees (mocked exec)", () => {
+  let restore: () => void;
+
+  afterEach(() => {
+    if (restore) restore();
+  });
+
+  it("returns ralphai-managed worktrees from mocked porcelain output", () => {
+    const porcelain = [
+      "worktree /home/user/project",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /home/user/.ralphai-worktrees/fix-login",
+      "HEAD def456",
+      "branch refs/heads/ralphai/fix-login",
+      "",
+      "worktree /home/user/.ralphai-worktrees/feat-dark-mode",
+      "HEAD 789abc",
+      "branch refs/heads/feat/dark-mode",
+      "",
+    ].join("\n");
+
+    restore = setExecImpl((() => porcelain) as any);
+
+    const result = listRalphaiWorktrees("/fake/cwd");
+    expect(result).toHaveLength(2);
+    expect(result[0]!.branch).toBe("ralphai/fix-login");
+    expect(result[1]!.branch).toBe("feat/dark-mode");
+  });
+
+  it("returns empty array when git command fails", () => {
+    restore = setExecImpl((() => {
+      throw new Error("not a git repo");
+    }) as any);
+
+    const result = listRalphaiWorktrees("/fake/cwd");
+    expect(result).toEqual([]);
+  });
+
+  it("filters out non-managed branches", () => {
+    const porcelain = [
+      "worktree /home/user/project",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /home/user/.ralphai-worktrees/some-feature",
+      "HEAD def456",
+      "branch refs/heads/feature/something",
+      "",
+    ].join("\n");
+
+    restore = setExecImpl((() => porcelain) as any);
+
+    const result = listRalphaiWorktrees("/fake/cwd");
+    expect(result).toHaveLength(0);
+  });
+
+  it("passes timeout option through to exec", () => {
+    let receivedOpts: any;
+    restore = setExecImpl(((_cmd: string, opts: any) => {
+      receivedOpts = opts;
+      return "";
+    }) as any);
+
+    listRalphaiWorktrees("/fake/cwd", { timeout: 3000 });
+    expect(receivedOpts?.timeout).toBe(3000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWorktreeInfo via setExecImpl
+// ---------------------------------------------------------------------------
+
+describe("resolveWorktreeInfo (mocked exec)", () => {
+  let restore: () => void;
+
+  afterEach(() => {
+    if (restore) restore();
+  });
+
+  it("detects worktree when git-common-dir differs from git-dir", () => {
+    const responses: Record<string, string> = {
+      "git rev-parse --git-common-dir": "/home/user/main-repo/.git",
+      "git rev-parse --git-dir":
+        "/home/user/main-repo/.git/worktrees/my-worktree",
+    };
+
+    restore = setExecImpl(((cmd: string) => {
+      const key = cmd.trim();
+      if (key in responses) return responses[key]!;
+      throw new Error(`unexpected command: ${cmd}`);
+    }) as any);
+
+    const info = resolveWorktreeInfo("/home/user/.ralphai-worktrees/my-slug");
+    expect(info.isWorktree).toBe(true);
+    expect(info.mainWorktree).toContain("main-repo");
+  });
+
+  it("returns isWorktree=false when dirs are equal", () => {
+    restore = setExecImpl((() => ".git") as any);
+
+    const info = resolveWorktreeInfo("/some/repo");
+    expect(info.isWorktree).toBe(false);
+    expect(info.mainWorktree).toBe("");
+  });
+
+  it("returns isWorktree=false when git command fails", () => {
+    restore = setExecImpl((() => {
+      throw new Error("not a git repo");
+    }) as any);
+
+    const info = resolveWorktreeInfo("/not/a/repo");
+    expect(info.isWorktree).toBe(false);
+    expect(info.mainWorktree).toBe("");
+  });
+});

--- a/src/worktree/management.test.ts
+++ b/src/worktree/management.test.ts
@@ -4,10 +4,15 @@
  * Uses `setExecImpl` to mock subprocess calls, verifying that all I/O
  * routes through the `exec.ts` abstraction.
  */
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { setExecImpl } from "../exec.ts";
 import { listRalphaiWorktrees } from "./parsing.ts";
-import { resolveWorktreeInfo } from "./management.ts";
+import {
+  resolveWorktreeInfo,
+  isGitWorktree,
+  resolveMainGitDir,
+  ensureRepoHasCommit,
+} from "./management.ts";
 
 // ---------------------------------------------------------------------------
 // listRalphaiWorktrees via setExecImpl
@@ -128,5 +133,121 @@ describe("resolveWorktreeInfo (mocked exec)", () => {
     const info = resolveWorktreeInfo("/not/a/repo");
     expect(info.isWorktree).toBe(false);
     expect(info.mainWorktree).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isGitWorktree via setExecImpl
+// ---------------------------------------------------------------------------
+
+describe("isGitWorktree (mocked exec)", () => {
+  let restore: () => void;
+
+  afterEach(() => {
+    if (restore) restore();
+  });
+
+  it("returns true when inside a worktree", () => {
+    const responses: Record<string, string> = {
+      "git rev-parse --git-common-dir": "/home/user/main-repo/.git",
+      "git rev-parse --git-dir":
+        "/home/user/main-repo/.git/worktrees/my-worktree",
+    };
+
+    restore = setExecImpl(((cmd: string) => {
+      const key = cmd.trim();
+      if (key in responses) return responses[key]!;
+      throw new Error(`unexpected command: ${cmd}`);
+    }) as any);
+
+    expect(isGitWorktree("/home/user/.ralphai-worktrees/my-slug")).toBe(true);
+  });
+
+  it("returns false for main repo", () => {
+    restore = setExecImpl((() => ".git") as any);
+    expect(isGitWorktree("/some/repo")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveMainGitDir via setExecImpl
+// ---------------------------------------------------------------------------
+
+describe("resolveMainGitDir (mocked exec)", () => {
+  let restore: () => void;
+
+  afterEach(() => {
+    if (restore) restore();
+  });
+
+  it("returns main .git path for worktrees", () => {
+    const responses: Record<string, string> = {
+      "git rev-parse --git-common-dir": "/home/user/main-repo/.git",
+      "git rev-parse --git-dir":
+        "/home/user/main-repo/.git/worktrees/my-worktree",
+    };
+
+    restore = setExecImpl(((cmd: string) => {
+      const key = cmd.trim();
+      if (key in responses) return responses[key]!;
+      throw new Error(`unexpected command: ${cmd}`);
+    }) as any);
+
+    const gitDir = resolveMainGitDir("/home/user/.ralphai-worktrees/my-slug");
+    expect(gitDir).toContain("main-repo");
+    expect(gitDir).toEndWith(".git");
+  });
+
+  it("returns undefined for non-worktree dirs", () => {
+    restore = setExecImpl((() => ".git") as any);
+    expect(resolveMainGitDir("/some/repo")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureRepoHasCommit via setExecImpl
+// ---------------------------------------------------------------------------
+
+describe("ensureRepoHasCommit (mocked exec)", () => {
+  let restore: () => void;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as any);
+  });
+
+  afterEach(() => {
+    if (restore) restore();
+    exitSpy?.mockRestore();
+  });
+
+  it("does not exit when repo has commits", () => {
+    restore = setExecImpl((() => "abc123") as any);
+    ensureRepoHasCommit("/fake/repo");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls process.exit(1) when repo has no commits", () => {
+    restore = setExecImpl((() => {
+      throw new Error("HEAD not found");
+    }) as any);
+
+    expect(() => ensureRepoHasCommit("/fake/repo")).toThrow(
+      "process.exit called",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("routes git rev-parse HEAD through exec abstraction", () => {
+    const commands: string[] = [];
+    restore = setExecImpl(((cmd: string) => {
+      commands.push(cmd);
+      return "abc123";
+    }) as any);
+
+    ensureRepoHasCommit("/fake/repo");
+    expect(commands).toContain("git rev-parse HEAD");
   });
 });

--- a/src/worktree/management.ts
+++ b/src/worktree/management.ts
@@ -1,10 +1,7 @@
-import { existsSync, mkdirSync, rmSync, renameSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
 import { execQuiet, execOk, execRun, execInherit } from "../exec.ts";
 import { DIM, TEXT, RESET } from "../utils.ts";
-import { getRepoPipelineDirs } from "../global-state.ts";
-import { planExistsForSlug } from "../plan-detection.ts";
-import { findPlansByBranch } from "../receipt.ts";
 import {
   generateFeedbackWrapper,
   FEEDBACK_WRAPPER_FILENAME,
@@ -61,16 +58,12 @@ export function resolveWorktreeInfo(dir: string): {
   isWorktree: boolean;
   mainWorktree: string;
 } {
-  try {
-    const commonDir = execQuiet("git rev-parse --git-common-dir", dir);
-    const gitDir = execQuiet("git rev-parse --git-dir", dir);
-    if (commonDir != null && gitDir != null && commonDir !== gitDir) {
-      // In a worktree: --git-common-dir points to the main .git
-      const mainRoot = resolve(dir, commonDir, "..");
-      return { isWorktree: true, mainWorktree: mainRoot };
-    }
-  } catch {
-    // Not in a git repo or git not available
+  const commonDir = execQuiet("git rev-parse --git-common-dir", dir);
+  const gitDir = execQuiet("git rev-parse --git-dir", dir);
+  if (commonDir != null && gitDir != null && commonDir !== gitDir) {
+    // In a worktree: --git-common-dir points to the main .git
+    const mainRoot = resolve(dir, commonDir, "..");
+    return { isWorktree: true, mainWorktree: mainRoot };
   }
   return { isWorktree: false, mainWorktree: "" };
 }
@@ -285,95 +278,4 @@ export function writeFeedbackWrapper(
   const script = generateFeedbackWrapper(feedbackCommands);
   const wrapperPath = join(targetDir, FEEDBACK_WRAPPER_FILENAME);
   writeFileSync(wrapperPath, script, { mode: 0o755 });
-}
-
-export function listWorktrees(cwd: string): void {
-  const worktrees = listRalphaiWorktrees(cwd);
-
-  if (worktrees.length === 0) {
-    console.log("No active ralphai worktrees.");
-    return;
-  }
-
-  console.log("Active ralphai worktrees:\n");
-  const { wipDir: inProgressDir } = getRepoPipelineDirs(cwd);
-  for (const wt of worktrees) {
-    let hasActivePlan: boolean;
-    if (wt.branch.startsWith("ralphai/")) {
-      const slug = wt.branch.replace("ralphai/", "");
-      hasActivePlan = planExistsForSlug(inProgressDir, slug);
-    } else {
-      // feat/ or other managed branches: use receipt-based lookup
-      hasActivePlan = findPlansByBranch(inProgressDir, wt.branch).length > 0;
-    }
-    const status = hasActivePlan ? "in-progress" : "idle";
-    console.log(`  ${wt.branch}  ${wt.path}  [${status}]`);
-  }
-}
-
-export function cleanWorktrees(cwd: string): void {
-  // Prune stale worktree entries first
-  execInherit("git worktree prune", cwd);
-
-  const worktrees = listRalphaiWorktrees(cwd);
-
-  if (worktrees.length === 0) {
-    console.log("No ralphai worktrees to clean.");
-    return;
-  }
-
-  const { wipDir: inProgressDir, archiveDir } = getRepoPipelineDirs(cwd);
-  let cleaned = 0;
-
-  for (const wt of worktrees) {
-    let hasActivePlan: boolean;
-    let matchedSlugs: string[];
-
-    if (wt.branch.startsWith("ralphai/")) {
-      const slug = wt.branch.replace("ralphai/", "");
-      hasActivePlan = planExistsForSlug(inProgressDir, slug);
-      matchedSlugs = [slug];
-    } else {
-      // feat/ or other managed branches: use receipt-based lookup
-      matchedSlugs = findPlansByBranch(inProgressDir, wt.branch);
-      hasActivePlan = matchedSlugs.length > 0;
-    }
-
-    if (!hasActivePlan) {
-      console.log(`Removing: ${wt.path} (${wt.branch})`);
-      try {
-        // Use --force because the worktree may have uncommitted changes
-        // from interrupted agent work.
-        execInherit(`git worktree remove --force "${wt.path}"`, cwd);
-        // Force-delete branch (-D) because ralphai/* branches are typically
-        // not merged to main yet. Non-force -d would silently fail, leaving
-        // stale branches that cause dirty-state errors on the next run.
-        execOk(`git branch -D "${wt.branch}"`, cwd);
-
-        // Archive receipts for matched slugs (ralphai/ has one slug,
-        // feat/ may have multiple from receipt scan)
-        for (const slug of matchedSlugs) {
-          const planDir = join(inProgressDir, slug);
-          const receiptFile = join(planDir, "receipt.txt");
-          if (existsSync(receiptFile)) {
-            const destDir = join(archiveDir, slug);
-            mkdirSync(destDir, { recursive: true });
-            const dest = join(destDir, "receipt.txt");
-            renameSync(receiptFile, dest);
-            console.log(`  Archived receipt: ${slug}/receipt.txt`);
-          }
-        }
-
-        cleaned++;
-      } catch {
-        console.log(`  Warning: Could not remove ${wt.path}. Remove manually.`);
-      }
-    } else {
-      console.log(
-        `Keeping: ${wt.path} (${wt.branch}) — plan still in progress`,
-      );
-    }
-  }
-
-  console.log(`\nCleaned ${cleaned} worktree(s).`);
 }

--- a/src/worktree/management.ts
+++ b/src/worktree/management.ts
@@ -1,11 +1,7 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync } from "fs";
 import { join, resolve } from "path";
 import { execQuiet, execOk, execRun, execInherit } from "../exec.ts";
 import { DIM, TEXT, RESET } from "../utils.ts";
-import {
-  generateFeedbackWrapper,
-  FEEDBACK_WRAPPER_FILENAME,
-} from "../feedback-wrapper.ts";
 import {
   buildSetupDockerArgs,
   formatDockerCommand,
@@ -259,23 +255,4 @@ export function prepareWorktree(
   }
 
   return resolvedWorktreeDir;
-}
-
-/**
- * Write the feedback wrapper script to the given directory.
- * Typically called with the WIP slug directory so the script stays
- * out of the user's worktree (no untracked-file noise in git status).
- * Skipped on Windows (process.platform === "win32") and when no
- * feedback commands are configured.
- */
-export function writeFeedbackWrapper(
-  targetDir: string,
-  feedbackCommands?: string[],
-): void {
-  if (process.platform === "win32") return;
-  if (!feedbackCommands || feedbackCommands.length === 0) return;
-
-  const script = generateFeedbackWrapper(feedbackCommands);
-  const wrapperPath = join(targetDir, FEEDBACK_WRAPPER_FILENAME);
-  writeFileSync(wrapperPath, script, { mode: 0o755 });
 }

--- a/src/worktree/management.ts
+++ b/src/worktree/management.ts
@@ -1,16 +1,18 @@
-import { execSync, spawnSync } from "child_process";
 import { existsSync, mkdirSync, rmSync, renameSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
+import { execQuiet, execOk, execRun, execInherit } from "../exec.ts";
 import { DIM, TEXT, RESET } from "../utils.ts";
 import { getRepoPipelineDirs } from "../global-state.ts";
 import { planExistsForSlug } from "../plan-detection.ts";
 import { findPlansByBranch } from "../receipt.ts";
-import { extractExecStderr } from "../git-helpers.ts";
 import {
   generateFeedbackWrapper,
   FEEDBACK_WRAPPER_FILENAME,
 } from "../feedback-wrapper.ts";
-import { buildSetupDockerArgs } from "../executor/docker.ts";
+import {
+  buildSetupDockerArgs,
+  formatDockerCommand,
+} from "../executor/docker.ts";
 import type { DockerExecutorConfig } from "../executor/docker.ts";
 import { listRalphaiWorktrees } from "./parsing.ts";
 
@@ -60,17 +62,9 @@ export function resolveWorktreeInfo(dir: string): {
   mainWorktree: string;
 } {
   try {
-    const commonDir = execSync("git rev-parse --git-common-dir", {
-      cwd: dir,
-      stdio: "pipe",
-      encoding: "utf-8",
-    }).trim();
-    const gitDir = execSync("git rev-parse --git-dir", {
-      cwd: dir,
-      stdio: "pipe",
-      encoding: "utf-8",
-    }).trim();
-    if (commonDir !== gitDir) {
+    const commonDir = execQuiet("git rev-parse --git-common-dir", dir);
+    const gitDir = execQuiet("git rev-parse --git-dir", dir);
+    if (commonDir != null && gitDir != null && commonDir !== gitDir) {
       // In a worktree: --git-common-dir points to the main .git
       const mainRoot = resolve(dir, commonDir, "..");
       return { isWorktree: true, mainWorktree: mainRoot };
@@ -110,7 +104,7 @@ export function resolveMainGitDir(dir: string): string | undefined {
  * container's OS/arch.
  *
  * When `sandboxConfig` is omitted or `sandbox` is `"none"`, the command
- * runs on the host via `execSync` (unchanged behavior).
+ * runs on the host via `exec.ts` (unchanged behavior).
  *
  * On failure the process exits with code 1.
  */
@@ -134,16 +128,12 @@ export function executeSetupCommand(
       dockerMounts: sandboxConfig.dockerConfig?.dockerMounts,
       mainGitDir,
     });
-    const result = spawnSync("docker", dockerArgs, {
-      stdio: "inherit",
-    });
-    if (result.status !== 0) {
+    const dockerCmd = formatDockerCommand(dockerArgs);
+    const result = execInherit(dockerCmd, worktreeDir);
+    if (result.exitCode !== 0) {
       console.error(
         `${TEXT}Error:${RESET} Setup command failed in Docker container: ${setupCommand}`,
       );
-      if (result.error) {
-        console.error(`  ${result.error.message}`);
-      }
       console.error(
         `\nThe sandbox image may be missing tools your project needs.`,
       );
@@ -159,17 +149,11 @@ export function executeSetupCommand(
   }
 
   console.log(`Running setup command: ${setupCommand}`);
-  try {
-    execSync(setupCommand, {
-      cwd: worktreeDir,
-      stdio: "inherit",
-    });
-  } catch (err: unknown) {
-    const stderr = extractExecStderr(err);
+  const result = execInherit(setupCommand, worktreeDir);
+  if (result.exitCode !== 0) {
     console.error(
       `${TEXT}Error:${RESET} Setup command failed: ${setupCommand}`,
     );
-    if (stderr) console.error(`  ${stderr}`);
     console.error(
       `\nFix the issue and re-run, or set ${TEXT}setupCommand${RESET} to "" in config to disable.`,
     );
@@ -179,9 +163,7 @@ export function executeSetupCommand(
 
 /** Ensure the repo has at least one commit (required for worktrees). */
 export function ensureRepoHasCommit(cwd: string): void {
-  try {
-    execSync("git rev-parse HEAD", { cwd, stdio: "ignore" });
-  } catch {
+  if (!execOk("git rev-parse HEAD", cwd)) {
     console.error(
       "This repository has no commits yet. Git worktrees require at least one commit.",
     );
@@ -231,16 +213,14 @@ export function prepareWorktree(
       console.log(
         `Cleaning up orphaned worktree directory: ${resolvedWorktreeDir}`,
       );
-      execSync("git worktree prune", { cwd, stdio: "ignore" });
+      execOk("git worktree prune", cwd);
       try {
         rmSync(resolvedWorktreeDir, { recursive: true, force: true });
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "EACCES") {
           // Retry after fixing permissions (common with node_modules/.bin)
           try {
-            execSync(`chmod -R u+rwx "${resolvedWorktreeDir}"`, {
-              stdio: "ignore",
-            });
+            execOk(`chmod -R u+rwx "${resolvedWorktreeDir}"`, cwd);
             rmSync(resolvedWorktreeDir, { recursive: true, force: true });
           } catch {
             throw new Error(
@@ -255,37 +235,27 @@ export function prepareWorktree(
       }
     }
 
-    let branchExists = false;
-    try {
-      execSync(`git show-ref --verify --quiet refs/heads/${branch}`, {
-        cwd,
-        stdio: "ignore",
-      });
-      branchExists = true;
-    } catch {
-      branchExists = false;
+    const branchExists = execOk(
+      `git show-ref --verify --quiet refs/heads/${branch}`,
+      cwd,
+    );
+
+    const worktreeCmd = branchExists
+      ? `git worktree add "${resolvedWorktreeDir}" "${branch}"`
+      : `git worktree add "${resolvedWorktreeDir}" -b "${branch}" "${baseBranch}"`;
+
+    if (branchExists) {
+      console.log(`Recreating worktree: ${resolvedWorktreeDir}`);
+      console.log(`Branch: ${branch}`);
+    } else {
+      console.log(`Creating worktree: ${resolvedWorktreeDir}`);
+      console.log(`Branch: ${branch} (from ${baseBranch})`);
     }
 
-    try {
-      if (branchExists) {
-        console.log(`Recreating worktree: ${resolvedWorktreeDir}`);
-        console.log(`Branch: ${branch}`);
-        execSync(`git worktree add "${resolvedWorktreeDir}" "${branch}"`, {
-          cwd,
-          stdio: ["inherit", "pipe", "pipe"],
-        });
-      } else {
-        console.log(`Creating worktree: ${resolvedWorktreeDir}`);
-        console.log(`Branch: ${branch} (from ${baseBranch})`);
-        execSync(
-          `git worktree add "${resolvedWorktreeDir}" -b "${branch}" "${baseBranch}"`,
-          { cwd, stdio: ["inherit", "pipe", "pipe"] },
-        );
-      }
-    } catch (err: unknown) {
-      const stderr = extractExecStderr(err);
+    const addResult = execRun(worktreeCmd, cwd);
+    if (addResult.exitCode !== 0) {
       console.error(`${TEXT}Error:${RESET} Failed to prepare worktree.`);
-      if (stderr) console.error(`  git: ${stderr}`);
+      if (addResult.stderr) console.error(`  git: ${addResult.stderr}`);
       process.exit(1);
     }
   }
@@ -343,7 +313,7 @@ export function listWorktrees(cwd: string): void {
 
 export function cleanWorktrees(cwd: string): void {
   // Prune stale worktree entries first
-  execSync("git worktree prune", { cwd, stdio: "inherit" });
+  execInherit("git worktree prune", cwd);
 
   const worktrees = listRalphaiWorktrees(cwd);
 
@@ -374,21 +344,11 @@ export function cleanWorktrees(cwd: string): void {
       try {
         // Use --force because the worktree may have uncommitted changes
         // from interrupted agent work.
-        execSync(`git worktree remove --force "${wt.path}"`, {
-          cwd,
-          stdio: "inherit",
-        });
+        execInherit(`git worktree remove --force "${wt.path}"`, cwd);
         // Force-delete branch (-D) because ralphai/* branches are typically
         // not merged to main yet. Non-force -d would silently fail, leaving
         // stale branches that cause dirty-state errors on the next run.
-        try {
-          execSync(`git branch -D "${wt.branch}"`, {
-            cwd,
-            stdio: "pipe",
-          });
-        } catch {
-          // Branch deletion failure is not critical
-        }
+        execOk(`git branch -D "${wt.branch}"`, cwd);
 
         // Archive receipts for matched slugs (ralphai/ has one slug,
         // feat/ may have multiple from receipt scan)

--- a/src/worktree/parsing.ts
+++ b/src/worktree/parsing.ts
@@ -1,4 +1,5 @@
-import { execSync } from "child_process";
+import { execQuiet } from "../exec.ts";
+import type { ExecOptions } from "../exec.ts";
 import type { WorktreeEntry } from "./types.ts";
 
 export function parseWorktreeList(output: string): WorktreeEntry[] {
@@ -79,12 +80,11 @@ export function listRalphaiWorktrees(
   cwd: string,
   options?: ListWorktreesOptions,
 ): WorktreeEntry[] {
-  const output = execSync("git worktree list --porcelain", {
-    cwd,
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    ...(options?.timeout != null ? { timeout: options.timeout } : {}),
-  });
+  const execOpts: ExecOptions | undefined =
+    options?.timeout != null ? { timeout: options.timeout } : undefined;
+  const output = execQuiet("git worktree list --porcelain", cwd, execOpts);
+
+  if (output == null) return [];
 
   return parseWorktreeList(output).filter((wt) =>
     isRalphaiManagedBranch(wt.branch),

--- a/src/worktree/parsing.ts
+++ b/src/worktree/parsing.ts
@@ -67,22 +67,11 @@ export function isRalphaiManagedBranch(branch: string): boolean {
   );
 }
 
-export interface ListWorktreesOptions {
-  /**
-   * Subprocess timeout in milliseconds. When set, `git worktree list`
-   * is killed after this many milliseconds. Useful for TUI contexts
-   * where a hung git process must not block the event loop.
-   */
-  timeout?: number;
-}
-
 export function listRalphaiWorktrees(
   cwd: string,
-  options?: ListWorktreesOptions,
+  options?: ExecOptions,
 ): WorktreeEntry[] {
-  const execOpts: ExecOptions | undefined =
-    options?.timeout != null ? { timeout: options.timeout } : undefined;
-  const output = execQuiet("git worktree list --porcelain", cwd, execOpts);
+  const output = execQuiet("git worktree list --porcelain", cwd, options);
 
   if (output == null) return [];
 


### PR DESCRIPTION
PRD #404: refactor: deepen Worktree Management with exec.ts routing and curated interface

## Summary

- **#421:** Routes all subprocess calls in `src/worktree/management.ts` and `src/worktree/parsing.ts` through the `exec.ts` abstraction (no direct `Bun.spawn`/`Bun.spawnSync`), and adds comprehensive `setExecImpl`-based boundary tests for `isGitWorktree`, `resolveMainGitDir`, `ensureRepoHasCommit`, `resolveWorktreeInfo`, and `listRalphaiWorktrees`.
- **#422:** Remove the unused `listWorktrees` and `cleanWorktrees` functions from the worktree module. These were exported but had no callers outside their own mock stubs, reducing maintenance surface area. Cleaned up now-unused imports (`getRepoPipelineDirs`, `planExistsForSlug`, `findPlansByBranch`, `renameSync`) from `management.ts`.
- **#423:** Move `writeFeedbackWrapper` from `src/worktree/management.ts` to `src/feedback-wrapper.ts`, colocating it with the script generation logic it depends on. This clarifies module boundaries — the worktree subsystem no longer owns feedback-related file I/O — and updates all importers, tests, and ARCHITECTURE.md accordingly.
- **#424:** Curate the worktree barrel (`worktree/index.ts`) to export only the symbols that external callers actually need, removing three internal-only exports. Fix five call sites that bypassed the barrel by importing directly from `management.ts` or `types.ts`, and document the curated public API in ARCHITECTURE.md.

Closes #404
Closes #421
Closes #422
Closes #423
Closes #424

## Completed Sub-Issues

- [x] #421
- [x] #422
- [x] #423
- [x] #424

## Changes

### Refactoring

- simplify checkGhAvailable with loop and remove unnecessary variable
- curate barrel exports and fix direct-import callers
- inline trivial generateCommandBlock helper in feedback-wrapper
- move writeFeedbackWrapper to feedback-wrapper.ts
- remove duplicate exit-code extraction and redundant ListWorktreesOptions
- remove dead code listWorktrees and cleanWorktrees
- route management and parsing through exec.ts

### Tests

- add boundary tests for isGitWorktree, resolveMainGitDir, ensureRepoHasCommit


## Learnings

- <entry>status: none</entry>
- The worktree management and parsing modules were already routed through `exec.ts` before this iteration — the prior commit `25fc42c` had already completed the refactor. The remaining work was adding boundary tests for functions that lacked `setExecImpl`-based coverage: `isGitWorktree`, `resolveMainGitDir`, and `ensureRepoHasCommit`. When testing functions that call `process.exit`, use `spyOn(process, "exit").mockImplementation(() => { throw new Error(...) })` to prevent actual exit while still asserting the call. Import `spyOn` directly from `bun:test` rather than using dynamic import.
- The worktree module has naming collisions worth being aware of: `listWorktrees` exists as both a (now-removed) exported function from `management.ts` and as an unrelated option property in `src/tui/hooks/use-pipeline-state.ts` (different signature: `(cwd: string) => WorktreeEntry[]`). Similarly, `cleanWorktrees` appears as a local boolean in `src/clean.ts`. When grepping for dead code references, always verify that same-named identifiers in other files are actually the same function via import chains, not just coincidental naming.

The `src/exec.ts` file on this branch had a pre-existing refactor (extracting `exitCodeFrom` helper) that was uncommitted — important to scope commits to only the files changed by the current task.
- `src/hitl.test.ts` uses `mock.module()` to mock entire barrel modules like `./worktree/index.ts`, including exports the test's subject (`hitl.ts`) doesn't actually import. When removing an export from the barrel, the mock must be updated too, but it's safe to just drop it — no assertions depend on these stubs. The `hitl.test.ts` file is in the ISOLATED array in `scripts/test.ts` due to `mock.module()` leak behavior in bun.
- The worktree barrel at `src/worktree/index.ts` now has a curated public API. The externally-needed exports are: types (`WorktreeEntry`, `GitHubFallbackOptions`, `SetupSandboxConfig`), parsing (`listRalphaiWorktrees`), selection (`selectPlanForWorktree`), and management (`isGitWorktree`, `resolveWorktreeInfo`, `resolveMainGitDir`, `resolveMainRepo`, `executeSetupCommand`, `ensureRepoHasCommit`, `prepareWorktree`). Internal-only symbols like `parseWorktreeList`, `isRalphaiManagedBranch`, and `SelectedWorktreePlan` are not re-exported. When auditing barrel exports, `hitl.test.ts` uses `mock.module()` to replace both `./worktree/index.ts` and `./worktree/management.ts` — the management.ts mock is needed because bun's mock system intercepts by module path, so transitive imports through the barrel still resolve to the original internal file unless that file is also mocked. The barrel mock should match the curated exports but the management.ts mock can remain broader since it's a test-only interception.