### PR TITLE
docs: improve feedback command hints during init and document Docker model config

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -141,6 +141,16 @@ Or in `config.json`:
 
 Mounts use standard Docker bind-mount syntax (`host:container[:options]`). Env vars use `-e VAR` format — Docker reads the value from the host environment, so values are not exposed in process listings. Vars that are unset or empty on the host are silently skipped.
 
+**Specifying a model:** Inside a Docker container, some agents may not auto-detect which model to use (e.g. when credentials come from a host-side proxy or environment). Pass the model as part of the agent command in your repo config file (`~/.ralphai/repos/<reponame>/config.json`):
+
+```json
+{
+  "agentCommand": "opencode run --agent build --model github-copilot/claude-opus-4.6"
+}
+```
+
+The exact flag depends on which agent you use — check your agent's CLI reference for the correct option.
+
 For details on the Docker execution flow and credential forwarding, see [How Ralphai Works](how-ralphai-works.md#docker-execution-flow).
 
 ## Test a plan without changing anything

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -200,12 +200,15 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
   const project = detectProject(cwd);
   const detectedFeedback = project ? project.feedbackCommands.join(",") : "";
   const feedbackPlaceholder = project
-    ? project.feedbackCommands.join(", ") || "<build command>, <test command>"
-    : "<build command>, <test command>";
+    ? project.feedbackCommands.join(", ") || "e.g. npm run build, npm test"
+    : "e.g. npm run build, npm test";
+  clack.log.info(
+    "Feedback commands run after every agent iteration to guide corrections. Keep them fast — slow tests belong in PR feedback commands.",
+  );
   const feedbackCommands = await clack.text({
     message: detectedFeedback
       ? `Feedback commands (auto-detected for ${project!.label}):`
-      : "Feedback commands (comma-separated, or leave empty):",
+      : "Fast feedback commands (comma-separated, or leave empty):",
     initialValue: detectedFeedback || undefined,
     placeholder: detectedFeedback ? undefined : feedbackPlaceholder,
     defaultValue: detectedFeedback || "",
@@ -222,7 +225,7 @@ async function runWizard(cwd: string): Promise<WizardAnswers | null> {
     : "";
   const prFeedbackCommands = await clack.text({
     message:
-      "Slow commands to run only before creating a PR (e.g. E2E or integration tests):",
+      "Slow commands to run only before creating a PR, comma-separated (e.g. E2E or integration tests):",
     initialValue: detectedPrFeedback || undefined,
     placeholder: detectedPrFeedback
       ? undefined
@@ -1487,6 +1490,9 @@ async function runRalphaiInit(
       `  ${DIM}Branch:${RESET}    ${TEXT}${answers.baseBranch}${RESET}`,
     );
     console.log(`  ${DIM}Feedback:${RESET}  ${TEXT}${feedbackDisplay}${RESET}`);
+    console.log(
+      `  ${DIM}           (runs after every iteration — keep these fast)${RESET}`,
+    );
     console.log(
       `  ${DIM}PR feedback:${RESET} ${TEXT}${prFeedbackDisplay}${RESET}`,
     );


### PR DESCRIPTION
## Summary

- **Better inline docs for feedback commands during `ralphai init`:** Added a `clack.log.info()` hint in the interactive wizard explaining that feedback commands run after every agent iteration and should be fast. Updated the non-auto-detected prompt label to "Fast feedback commands" and replaced the generic `<build command>, <test command>` placeholder with concrete examples (`e.g. npm run build, npm test`). Added "(comma-separated)" to the PR feedback commands prompt for consistency. In `--yes` mode, added a dim hint line under the `Feedback:` summary reinforcing the "runs after every iteration" guidance.

- **Docker model configuration docs:** Added a "Specifying a model" block to the Docker sandboxing section of `docs/workflows.md`, explaining how to pass a model flag via `agentCommand` in the repo config file (`~/.ralphai/repos/<reponame>/config.json`) with a sample config entry.