### PR TITLE
docs: streamline AGENTS.md by removing redundant sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,6 @@ Ralphai is a CLI tool that takes plans (markdown files) from a backlog and drive
 - **Use the `gh` CLI** to create issues and pull requests. Link PRs to related issues when applicable.
 - **Squash-merge PRs.** The merge commit message should follow conventional commit format.
 
-## Module Focus
-
-- **Single responsibility.** Each source file should have one clear reason to change. When a file accumulates unrelated concerns — even if it's only a few hundred lines — extract the distinct responsibilities into their own modules.
-- **New test files per feature.** When adding tests for a new feature, create a new `<feature>.test.ts` file rather than appending to an existing one. If an existing test file covers multiple unrelated features, split it by domain before adding more tests.
-- **Check before appending.** Before adding substantial new code to a file, review whether it still has a single focus. If your changes would introduce a second responsibility, extract first.
-
 ## Completeness
 
 Don't treat a task as done until you've traced how your changes affect the rest of the codebase. A change that works in isolation but breaks adjacent code is not complete — and neither is a fix applied to one module when analogous modules have the same problem.
@@ -42,6 +36,7 @@ Don't treat a task as done until you've traced how your changes affect the rest 
 - **Verify the build.** Run the build and tests before declaring a task done. A green diff is not the same as a green build.
 - **Check for stale references.** Renaming or removing something? Search for string references (config keys, CLI flags, error messages, docs) that still point to the old name.
 - **Check analogous modules.** When applying a fix or pattern to one module, look for other modules that would benefit from the same treatment and include them unless the task was explicitly scoped to a single module.
+- **Single responsibility.** Each source file should have one clear reason to change. Before adding substantial new code to a file, check whether it still has a single focus. If your changes would introduce a second responsibility, extract first.
 
 ## Dry-Run Safety
 
@@ -51,20 +46,13 @@ The `--dry-run` / `-n` flag must never cause side effects. When adding code that
 
 CI runs on both Ubuntu and Windows. Don't hardcode Unix paths or assume Linux-specific behavior in tests. Use `path.join()` for path assertions and `describe.skipIf(process.platform === "win32")` for inherently platform-specific tests.
 
-## GitHub Issue Dependencies
-
-When pulling GitHub issues into plan files, native GitHub blocking relationships are queried via `Issue.blockedBy` GraphQL API (`gh api graphql`). The returned blocker issue numbers are written to `depends-on` frontmatter using issue-based slugs like `gh-42`. The GraphQL query is fail-open: if it fails, the plan proceeds with no `depends-on` entries. The dependency checker in `plan-detection.ts` supports these slugs via prefix matching: `gh-42` matches any file/directory starting with `gh-42-` in the pipeline directories.
-
 ## Testing
 
 - **Speed tiers.** Tests fall into two tiers: fast (default) and slow. `bun run test` runs everything; `bun run test:fast` skips files in the `SLOW` array in `scripts/test.ts`. CI runs the full suite; use `test:fast` locally to keep the feedback loop under ~60s.
 - **What makes a test slow.** A test is slow if it creates real sockets (`net.connect`), runs full E2E runner loops, or heavily spawns child processes. Add these files to the `SLOW` array in `scripts/test.ts`.
 - **Prefer fast patterns.** Use `runCliInProcess` (from `src/test-utils.ts`) instead of `runCli` — it avoids ~300ms subprocess overhead per call. Use `useTempDir` over `useTempGitDir` when git isn't needed. Keep pure-logic tests (no I/O) separate from integration tests that touch the filesystem.
 - **Isolated tests.** Files that call `mock.module()` on built-in or third-party modules must be listed in the `ISOLATED` array in `scripts/test.ts` to prevent mock leaks across files. This is a bun limitation — remove the workaround if bun adds per-file mock isolation.
-
-## Package Manager
-
-This project uses **bun**.
+- **New test files per feature.** When adding tests for a new feature, create a new `<feature>.test.ts` file rather than appending to an existing one. If an existing test file covers multiple unrelated features, split it by domain before adding more tests.
 
 ## Docker Sandbox
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,6 +130,10 @@ cli.ts
 
 Modules import from leaf utilities and supporting modules. `ralphai.ts` is the root dispatcher; `types.ts`, `git-helpers.ts`, and `utils.ts` are leaves with no intra-project imports. The `src/tui/` subsystem depends on `src/interactive/` for pure data helpers (menu item builders, plan filters) but not for any interactive prompts.
 
+## GitHub issue dependencies
+
+When pulling GitHub issues into plan files, native GitHub blocking relationships are queried via `Issue.blockedBy` GraphQL API (`gh api graphql`). The returned blocker issue numbers are written to `depends-on` frontmatter using issue-based slugs like `gh-42`. The GraphQL query is fail-open: if it fails, the plan proceeds with no `depends-on` entries. The dependency checker in `plan-lifecycle.ts` supports these slugs via prefix matching: `gh-42` matches any file/directory starting with `gh-42-` in the pipeline directories.
+
 ## Where to add new code
 
 - **New CLI subcommand:** Add a case to the dispatcher switch in `ralphai.ts`, implement the command in a new module, and re-export the entry function.


### PR DESCRIPTION
## Summary

- **Remove "Package Manager" section** -- redundant; obvious from `bun.lock` and every build/test command in the repo.
- **Move "GitHub Issue Dependencies" to ARCHITECTURE.md** -- documents GraphQL query internals and `plan-lifecycle.ts` slug matching, which is architecture documentation rather than contributor guidance.
- **Dissolve "Module Focus" section** -- merge the SRP bullet into Completeness and the "new test files per feature" bullet into Testing. No content lost, just better homes.

Net result: 74 lines / 10 sections → 62 lines / 8 sections.