### PR TITLE
fix: pullGithubIssues re-pulls standalone issues that already have in-progress label

### DIFF
--- a/src/issue-lifecycle.ts
+++ b/src/issue-lifecycle.ts
@@ -1122,6 +1122,40 @@ function fetchAndWriteIssuePlan(opts: FetchAndWriteOptions): PullIssueResult {
 }
 
 // ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Iterate an ordered list of candidate issue numbers, fetch the labels for
+ * each via `gh issue view`, and return the first one whose labels do not
+ * include any of the `skipLabels`. Returns `undefined` when all candidates
+ * should be skipped.
+ *
+ * Used by both `pullGithubIssues()` (standalone) and `pullPrdSubIssue()`
+ * (PRD sub-issues) to avoid re-pulling issues that are already in-progress,
+ * done, stuck, or awaiting human review.
+ */
+function findFirstEligibleIssue(
+  candidates: Array<{ number: number }>,
+  skipLabels: string[],
+  repo: string,
+  cwd: string,
+): number | undefined {
+  for (const candidate of candidates) {
+    const labelsRaw = execQuiet(
+      `gh issue view ${candidate.number} --repo "${repo}" --json labels --jq '[.labels[].name] | join(",")'`,
+      cwd,
+    );
+    const labels = labelsRaw ? labelsRaw.split(",") : [];
+    if (skipLabels.some((skip) => labels.includes(skip))) {
+      continue;
+    }
+    return candidate.number;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
 // Public pull functions
 // ---------------------------------------------------------------------------
 
@@ -1161,24 +1195,53 @@ export function pullGithubIssues(options: PullIssueOptions): PullIssueResult {
     };
   }
 
-  // Get the oldest open issue with the configured label.
-  // gh issue list returns newest first; use jq 'last' to pick the oldest.
-  const number = execQuiet(
+  // Get all open issues with the configured label (newest first from gh).
+  const raw = execQuiet(
     `gh issue list --repo "${repo}" --label "${issueLabel}" --state open ` +
-      `--limit 100 --json number --jq 'if length == 0 then empty else last.number end'`,
+      `--limit 100 --json number`,
     cwd,
   );
 
-  if (!number) {
+  if (!raw) {
     return {
       pulled: false,
       message: `No open issues found with label '${issueLabel}' in ${repo}`,
     };
   }
 
+  let candidates: Array<{ number: number }>;
+  try {
+    candidates = JSON.parse(raw);
+  } catch {
+    return {
+      pulled: false,
+      message: `No open issues found with label '${issueLabel}' in ${repo}`,
+    };
+  }
+
+  if (candidates.length === 0) {
+    return {
+      pulled: false,
+      message: `No open issues found with label '${issueLabel}' in ${repo}`,
+    };
+  }
+
+  // Iterate oldest-first (gh returns newest first, so reverse).
+  // Skip any candidate that already has a state label.
+  const skipLabels = [IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL];
+  const reversed = [...candidates].reverse();
+  const issueNumber = findFirstEligibleIssue(reversed, skipLabels, repo, cwd);
+
+  if (issueNumber === undefined) {
+    return {
+      pulled: false,
+      message: `All open '${issueLabel}' issues in ${repo} already in-progress, done, or stuck`,
+    };
+  }
+
   return fetchAndWriteIssuePlan({
     repo,
-    issueNumber: number,
+    issueNumber: String(issueNumber),
     backlogDir,
     cwd,
     issueCommentProgress,
@@ -1295,19 +1358,12 @@ export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
   // already processed by a prior drain iteration).
   const hitlLabel = options.issueHitlLabel ?? DEFAULTS.issueHitlLabel;
   const skipLabels = [IN_PROGRESS_LABEL, DONE_LABEL, STUCK_LABEL, hitlLabel];
-  let subIssueNumber: number | undefined;
-  for (const candidate of openSubIssues) {
-    const labelsRaw = execQuiet(
-      `gh issue view ${candidate.number} --repo "${repo}" --json labels --jq '[.labels[].name] | join(",")'`,
-      cwd,
-    );
-    const labels = labelsRaw ? labelsRaw.split(",") : [];
-    if (skipLabels.some((skip) => labels.includes(skip))) {
-      continue;
-    }
-    subIssueNumber = candidate.number;
-    break;
-  }
+  const subIssueNumber = findFirstEligibleIssue(
+    openSubIssues,
+    skipLabels,
+    repo,
+    cwd,
+  );
 
   if (subIssueNumber === undefined) {
     return {

--- a/src/pull-github-issues.test.ts
+++ b/src/pull-github-issues.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for pullGithubIssues() — the auto-drain entry point that discovers
+ * standalone issues from GitHub.
+ *
+ * Uses setExecImpl() from exec.ts to swap execSync with a mock,
+ * verifying the full flow (issue listing → label filtering → plan write)
+ * without requiring a real GitHub repo or gh CLI.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import type { PullIssueOptions } from "./issue-lifecycle.ts";
+import { setExecImpl } from "./exec.ts";
+import { pullGithubIssues } from "./issue-lifecycle.ts";
+
+// ---------------------------------------------------------------------------
+// Mock setup — swap execSync via DI
+// ---------------------------------------------------------------------------
+
+const mockExecSync = mock();
+let restoreExec: () => void;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "ralphai-standalone-pull-"));
+}
+
+function defaultOptions(dir: string): PullIssueOptions {
+  return {
+    backlogDir: join(dir, ".ralphai", "pipeline", "backlog"),
+    cwd: dir,
+    issueSource: "github",
+    standaloneLabel: "ralphai-standalone",
+    issueRepo: "owner/repo",
+    issueCommentProgress: false,
+  };
+}
+
+/**
+ * Build a command router that dispatches gh calls to handler functions.
+ * Unmatched commands throw.
+ */
+function mockGhCommands(
+  handlers: Record<string, (cmd: string) => string | Buffer>,
+): void {
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (cmd === "gh --version" || cmd === "gh auth status") {
+      return Buffer.from("ok");
+    }
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (cmd.includes(pattern)) {
+        return handler(cmd);
+      }
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  restoreExec = setExecImpl(mockExecSync as any);
+  mockExecSync.mockReset();
+});
+
+afterEach(() => {
+  restoreExec();
+});
+
+// ---------------------------------------------------------------------------
+// State-label filtering
+// ---------------------------------------------------------------------------
+
+describe("pullGithubIssues — state-label filtering", () => {
+  it("skips an issue with in-progress label and returns pulled:false", () => {
+    mockGhCommands({
+      "gh issue list": () => JSON.stringify([{ number: 42 }]),
+      // Label check for #42 — has in-progress
+      'gh issue view 42 --repo "owner/repo" --json labels': () => "in-progress",
+    });
+
+    const dir = makeTempDir();
+    const result = pullGithubIssues(defaultOptions(dir));
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("in-progress");
+  });
+
+  it("skips an issue with done label and returns pulled:false", () => {
+    mockGhCommands({
+      "gh issue list": () => JSON.stringify([{ number: 42 }]),
+      'gh issue view 42 --repo "owner/repo" --json labels': () => "done",
+    });
+
+    const dir = makeTempDir();
+    const result = pullGithubIssues(defaultOptions(dir));
+    expect(result.pulled).toBe(false);
+  });
+
+  it("skips an issue with stuck label and returns pulled:false", () => {
+    mockGhCommands({
+      "gh issue list": () => JSON.stringify([{ number: 42 }]),
+      'gh issue view 42 --repo "owner/repo" --json labels': () => "stuck",
+    });
+
+    const dir = makeTempDir();
+    const result = pullGithubIssues(defaultOptions(dir));
+    expect(result.pulled).toBe(false);
+  });
+
+  it("selects next eligible issue when oldest has in-progress", () => {
+    // gh issue list returns newest first, so [99, 50, 42] → oldest is 42
+    mockGhCommands({
+      "gh issue list": () =>
+        JSON.stringify([{ number: 99 }, { number: 50 }, { number: 42 }]),
+      // #42 (oldest) has in-progress
+      'gh issue view 42 --repo "owner/repo" --json labels': () => "in-progress",
+      // #50 (next oldest) has no skip labels — eligible
+      'gh issue view 50 --repo "owner/repo" --json labels': () => "",
+      'gh issue view 50 --repo "owner/repo" --json title --jq': () =>
+        "Eligible issue",
+      'gh issue view 50 --repo "owner/repo" --json body --jq': () =>
+        "Issue body",
+      'gh issue view 50 --repo "owner/repo" --json url --jq': () =>
+        "https://github.com/owner/repo/issues/50",
+      "gh api repos/owner/repo/issues/50/parent": () => {
+        throw new Error("404");
+      },
+      "gh api graphql": () =>
+        JSON.stringify({
+          data: {
+            repository: { issue: { blockedBy: { nodes: [] } } },
+          },
+        }),
+      "gh issue edit": () => "",
+    });
+
+    const dir = makeTempDir();
+    const result = pullGithubIssues(defaultOptions(dir));
+    expect(result.pulled).toBe(true);
+    expect(result.message).toContain("#50");
+  });
+
+  it("returns pulled:false when all candidates have state labels", () => {
+    mockGhCommands({
+      "gh issue list": () => JSON.stringify([{ number: 50 }, { number: 42 }]),
+      'gh issue view 42 --repo "owner/repo" --json labels': () => "in-progress",
+      'gh issue view 50 --repo "owner/repo" --json labels': () => "done",
+    });
+
+    const dir = makeTempDir();
+    const result = pullGithubIssues(defaultOptions(dir));
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("already");
+  });
+});


### PR DESCRIPTION
Fix pullGithubIssues() re-pulling standalone issues that already have in-progress, done, or stuck labels by adding per-candidate label filtering — the same pattern already used by pullPrdSubIssue(). The shared label-check logic is extracted into a findFirstEligibleIssue() helper used by both functions, and comprehensive tests are added for all filtering scenarios.

Closes #465

## Changes

### Bug Fixes

- skip standalone issues with state labels during drain pull


## Learnings

- The issue-lifecycle module (`src/issue-lifecycle.ts`) is the single source of truth for all issue-related operations. It uses `setExecImpl()` from `src/exec.ts` as a dependency injection mechanism for testing — test files call `setExecImpl(mockExecSync)` to swap out `execSync` without needing `mock.module()`, which means these test files do NOT need to be in the ISOLATED array in `scripts/test.ts`. The existing PRD sub-issue tests in `src/pull-prd-sub-issue.test.ts` provide a clean template for the `mockGhCommands` pattern: a record of command-fragment → handler pairs that dispatches based on `cmd.includes(pattern)`. The `gh issue list` command returns issues newest-first, so to iterate oldest-first you either use `last` in jq or reverse the parsed array.