### PR TITLE
fix: pass feedbackWrapperPath to executor.spawn during review pass

### DIFF
--- a/src/review-pass.test.ts
+++ b/src/review-pass.test.ts
@@ -583,4 +583,66 @@ describe("runReviewPass executor boundary", () => {
 
     expect(result.output).toBe("review suggestions applied");
   });
+
+  test("forwards feedbackWrapperPath to executor.spawn for Docker bind-mount", async () => {
+    execSync("git checkout -b feature", { cwd: dir, stdio: "pipe" });
+    writeFileSync(join(dir, "file.ts"), "x\n");
+    execSync('git add -A && git commit -m "add"', {
+      cwd: dir,
+      stdio: "pipe",
+    });
+
+    let capturedOpts: ExecutorSpawnOptions | undefined;
+    const mockExecutor: AgentExecutor = {
+      async spawn(opts: ExecutorSpawnOptions): Promise<ExecutorSpawnResult> {
+        capturedOpts = opts;
+        return { output: "", exitCode: 0, timedOut: false };
+      },
+    };
+
+    const wrapperPath =
+      "/home/user/.ralphai/repos/abc/pipeline/in-progress/my-plan/_ralphai_feedback.sh";
+
+    await runReviewPass({
+      baseBranch: "main",
+      agentCommand: "echo",
+      feedbackStep: wrapperPath,
+      iterationTimeout: 0,
+      cwd: dir,
+      executor: mockExecutor,
+      feedbackWrapperPath: wrapperPath,
+    });
+
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.feedbackWrapperPath).toBe(wrapperPath);
+  });
+
+  test("feedbackWrapperPath defaults to undefined when not provided", async () => {
+    execSync("git checkout -b feature", { cwd: dir, stdio: "pipe" });
+    writeFileSync(join(dir, "file.ts"), "x\n");
+    execSync('git add -A && git commit -m "add"', {
+      cwd: dir,
+      stdio: "pipe",
+    });
+
+    let capturedOpts: ExecutorSpawnOptions | undefined;
+    const mockExecutor: AgentExecutor = {
+      async spawn(opts: ExecutorSpawnOptions): Promise<ExecutorSpawnResult> {
+        capturedOpts = opts;
+        return { output: "", exitCode: 0, timedOut: false };
+      },
+    };
+
+    await runReviewPass({
+      baseBranch: "main",
+      agentCommand: "echo",
+      feedbackStep: "bun test",
+      iterationTimeout: 0,
+      cwd: dir,
+      executor: mockExecutor,
+    });
+
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.feedbackWrapperPath).toBeUndefined();
+  });
 });

--- a/src/review-pass.ts
+++ b/src/review-pass.ts
@@ -54,6 +54,13 @@ export interface RunReviewPassOptions {
   outputLogPath?: string;
   /** Optional IPC broadcast callback. */
   ipcBroadcast?: (msg: IpcMessage) => void;
+  /**
+   * Optional absolute path to the feedback wrapper script.
+   * When provided, the Docker executor bind-mounts this file into the
+   * container so the agent can execute it. Without this, the script path
+   * embedded in the prompt is unreachable from inside the sandbox.
+   */
+  feedbackWrapperPath?: string;
 }
 
 /** Result of a review pass. */
@@ -177,6 +184,7 @@ export async function runReviewPass(
     executor,
     outputLogPath,
     ipcBroadcast,
+    feedbackWrapperPath,
   } = options;
 
   // 1. Detect changed files
@@ -208,6 +216,7 @@ export async function runReviewPass(
     cwd,
     outputLogPath,
     ipcBroadcast,
+    feedbackWrapperPath,
   });
 
   // 6. Compare HEAD after agent invocation

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1155,6 +1155,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
                 ipcBroadcast: ipcServer
                   ? (msg) => ipcServer!.broadcast(msg)
                   : undefined,
+                feedbackWrapperPath: wrapperPath,
               });
               reviewDone = true;
 


### PR DESCRIPTION
## Summary

- The review pass embedded the feedback wrapper script's absolute path in the agent prompt but did not pass `feedbackWrapperPath` to `executor.spawn()`. The Docker executor uses this field to create a bind-mount (`-v`) so the script is accessible inside the container. Without the mount, Docker-sandboxed agents hit "No such file or directory" when trying to run the feedback script during the review pass.
- Adds `feedbackWrapperPath` to `RunReviewPassOptions`, threads it through to `executor.spawn()`, and passes it from the runner callsite.

## Root Cause

The main iteration correctly passes `feedbackWrapperPath: wrapperPath` to `executor.spawn()` (runner.ts:1010), but the review pass (review-pass.ts:204) did not include it. The `RunReviewPassOptions` interface lacked the field entirely. This only affects Docker-sandboxed runs — local executor runs are unaffected because the file is directly accessible on the host filesystem.

## Changes

- **src/review-pass.ts** — Add `feedbackWrapperPath?: string` to `RunReviewPassOptions`; destructure and forward to `executor.spawn()`
- **src/runner.ts** — Pass `feedbackWrapperPath: wrapperPath` in the `runReviewPass()` call
- **src/review-pass.test.ts** — Two new tests: verify `feedbackWrapperPath` is forwarded to `executor.spawn()`, and verify it defaults to `undefined` when not provided

## Testing

- 2599 tests pass, 0 fail
- Build and type-check pass