### PR TITLE
fix: fetchAndWriteIssuePlan writes plan unconditionally with no pipeline de-duplication

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -185,6 +185,23 @@ The `ralphai worktree clean` and `ralphai worktree list` subcommands have been r
 
 Running the old commands prints a redirect message with the replacement command.
 
+## "Issue #N already has a plan in the pipeline"
+
+When pulling a GitHub issue (via `ralphai run <number>` or auto-drain), Ralphai checks the backlog and in-progress directories for an existing plan file matching the same issue number. If found, the pull is rejected:
+
+```
+Issue #42 already has a plan in the pipeline: gh-42-fix-the-widget.md
+```
+
+This prevents duplicate runs of the same issue. Archived (completed) issues are not checked, so re-running a previously completed issue works as expected.
+
+**Steps:**
+
+1. Run `ralphai status` to see which plans are active.
+2. If the existing plan is stuck or abandoned, reset it: `ralphai reset <slug>` (moves the plan back to the backlog and cleans up the worktree).
+3. If the existing plan is still in the backlog and hasn't started, delete the plan file manually from `pipeline/backlog/`.
+4. Re-run: `ralphai run <number>`
+
 ## Docker Sandboxing Issues
 
 ### "Docker is not installed"

--- a/src/issue-dedup.test.ts
+++ b/src/issue-dedup.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Tests for pipeline de-duplication guard in fetchAndWriteIssuePlan().
+ *
+ * Verifies that pulling an issue that already exists in the pipeline
+ * (backlog or in-progress) is rejected, while archived issues can be
+ * re-pulled.
+ *
+ * Uses setExecImpl() to swap execSync with a mock, and real temp dirs
+ * to exercise the filesystem guard.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import type { PullIssueOptions } from "./issue-lifecycle.ts";
+import { setExecImpl } from "./exec.ts";
+import {
+  pullGithubIssues,
+  pullGithubIssueByNumber,
+  pullPrdSubIssue,
+} from "./issue-lifecycle.ts";
+
+// ---------------------------------------------------------------------------
+// Mock setup
+// ---------------------------------------------------------------------------
+
+const mockExecSync = mock();
+let restoreExec: () => void;
+
+beforeEach(() => {
+  restoreExec = setExecImpl(mockExecSync as any);
+  mockExecSync.mockReset();
+});
+
+afterEach(() => {
+  restoreExec();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "ralphai-dedup-"));
+}
+
+function ensureDir(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Build a command router that dispatches gh calls to handler functions.
+ */
+function mockGhCommands(
+  handlers: Record<string, (cmd: string) => string | Buffer>,
+): void {
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (cmd === "gh --version" || cmd === "gh auth status") {
+      return Buffer.from("ok");
+    }
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (cmd.includes(pattern)) {
+        return handler(cmd);
+      }
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+}
+
+/** Mock gh commands for a successful single-issue fetch (standalone). */
+function mockIssue42Fetch(): void {
+  mockGhCommands({
+    "gh issue list": () => JSON.stringify([{ number: 42 }]),
+    'gh issue view 42 --repo "owner/repo" --json labels': () => "",
+    'gh issue view 42 --repo "owner/repo" --json title --jq': () =>
+      "Fix the widget",
+    'gh issue view 42 --repo "owner/repo" --json body --jq': () =>
+      "Widget is broken",
+    'gh issue view 42 --repo "owner/repo" --json url --jq': () =>
+      "https://github.com/owner/repo/issues/42",
+    "gh api repos/owner/repo/issues/42/parent": () => {
+      throw new Error("404");
+    },
+    "gh api graphql": () =>
+      JSON.stringify({
+        data: {
+          repository: { issue: { blockedBy: { nodes: [] } } },
+        },
+      }),
+    "gh issue edit": () => "",
+  });
+}
+
+/** Mock gh commands for pullGithubIssueByNumber (no label filtering step). */
+function mockIssue42FetchDirect(): void {
+  mockGhCommands({
+    'gh issue view 42 --repo "owner/repo" --json title --jq': () =>
+      "Fix the widget",
+    'gh issue view 42 --repo "owner/repo" --json body --jq': () =>
+      "Widget is broken",
+    'gh issue view 42 --repo "owner/repo" --json url --jq': () =>
+      "https://github.com/owner/repo/issues/42",
+    "gh api repos/owner/repo/issues/42/parent": () => {
+      throw new Error("404");
+    },
+    "gh api graphql": () =>
+      JSON.stringify({
+        data: {
+          repository: { issue: { blockedBy: { nodes: [] } } },
+        },
+      }),
+    "gh issue edit": () => "",
+  });
+}
+
+function defaultOptions(dir: string): PullIssueOptions {
+  return {
+    backlogDir: join(dir, "pipeline", "backlog"),
+    wipDir: join(dir, "pipeline", "in-progress"),
+    cwd: dir,
+    issueSource: "github",
+    standaloneLabel: "ralphai-standalone",
+    issueRepo: "owner/repo",
+    issueCommentProgress: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cycle 1: duplicate rejection when plan exists in in-progress
+// ---------------------------------------------------------------------------
+
+describe("pipeline de-duplication — in-progress guard", () => {
+  it("rejects pull when plan for same issue exists in in-progress (slug-folder)", () => {
+    mockIssue42Fetch();
+
+    const dir = makeTempDir();
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+
+    // Create existing in-progress slug-folder for issue #42
+    const wipSlugDir = join(opts.wipDir!, "gh-42-fix-the-widget");
+    ensureDir(wipSlugDir);
+    writeFileSync(
+      join(wipSlugDir, "gh-42-fix-the-widget.md"),
+      "---\nissue: 42\n---\n# Fix the widget\n",
+    );
+
+    const result = pullGithubIssues(opts);
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("42");
+    expect(result.message).toContain("already");
+  });
+
+  it("rejects pull when plan for same issue exists in in-progress (flat file)", () => {
+    mockIssue42Fetch();
+
+    const dir = makeTempDir();
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+    ensureDir(opts.wipDir!);
+
+    // Create flat file in wip dir (edge case)
+    writeFileSync(
+      join(opts.wipDir!, "gh-42-fix-the-widget.md"),
+      "---\nissue: 42\n---\n# Fix the widget\n",
+    );
+
+    const result = pullGithubIssues(opts);
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("42");
+    expect(result.message).toContain("already");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cycle 2: duplicate rejection when plan exists in backlog
+// ---------------------------------------------------------------------------
+
+describe("pipeline de-duplication — backlog guard", () => {
+  it("rejects pull when plan for same issue already exists in backlog", () => {
+    mockIssue42Fetch();
+
+    const dir = makeTempDir();
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+    ensureDir(opts.wipDir!);
+
+    // Create existing backlog plan for issue #42
+    writeFileSync(
+      join(opts.backlogDir, "gh-42-fix-the-widget.md"),
+      "---\nissue: 42\n---\n# Fix the widget\n",
+    );
+
+    const result = pullGithubIssues(opts);
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("42");
+    expect(result.message).toContain("already");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cycle 3: explicit-target path (pullGithubIssueByNumber) respects guard
+// ---------------------------------------------------------------------------
+
+describe("pipeline de-duplication — pullGithubIssueByNumber", () => {
+  it("rejects when issue is already in-progress", () => {
+    mockIssue42FetchDirect();
+
+    const dir = makeTempDir();
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+
+    // Create existing in-progress plan
+    const wipSlugDir = join(opts.wipDir!, "gh-42-fix-the-widget");
+    ensureDir(wipSlugDir);
+    writeFileSync(
+      join(wipSlugDir, "gh-42-fix-the-widget.md"),
+      "---\nissue: 42\n---\n",
+    );
+
+    const result = pullGithubIssueByNumber({ ...opts, issueNumber: 42 });
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("42");
+    expect(result.message).toContain("already");
+  });
+
+  it("rejects when issue is already in backlog", () => {
+    mockIssue42FetchDirect();
+
+    const dir = makeTempDir();
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+    ensureDir(opts.wipDir!);
+
+    writeFileSync(
+      join(opts.backlogDir, "gh-42-fix-the-widget.md"),
+      "---\nissue: 42\n---\n",
+    );
+
+    const result = pullGithubIssueByNumber({ ...opts, issueNumber: 42 });
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("42");
+    expect(result.message).toContain("already");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cycle 4: archived issues can be re-pulled
+// ---------------------------------------------------------------------------
+
+describe("pipeline de-duplication — archive does NOT block", () => {
+  it("allows re-pulling an issue that only exists in archive", () => {
+    mockIssue42FetchDirect();
+
+    const dir = makeTempDir();
+    const archiveDir = join(dir, "pipeline", "out");
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+    ensureDir(opts.wipDir!);
+    ensureDir(archiveDir);
+
+    // Create archived plan for issue #42 (slug-folder in out/)
+    const archiveSlugDir = join(archiveDir, "gh-42-fix-the-widget");
+    ensureDir(archiveSlugDir);
+    writeFileSync(
+      join(archiveSlugDir, "gh-42-fix-the-widget.md"),
+      "---\nissue: 42\n---\n",
+    );
+
+    // Should succeed — archive does not block
+    const result = pullGithubIssueByNumber({ ...opts, issueNumber: 42 });
+    expect(result.pulled).toBe(true);
+    expect(result.planPath).toBeDefined();
+  });
+
+  it("allows re-pulling via pullGithubIssues when only in archive", () => {
+    mockIssue42Fetch();
+
+    const dir = makeTempDir();
+    const archiveDir = join(dir, "pipeline", "out");
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+    ensureDir(opts.wipDir!);
+    ensureDir(archiveDir);
+
+    // Archived plan
+    const archiveSlugDir = join(archiveDir, "gh-42-fix-the-widget");
+    ensureDir(archiveSlugDir);
+    writeFileSync(
+      join(archiveSlugDir, "gh-42-fix-the-widget.md"),
+      "---\nissue: 42\n---\n",
+    );
+
+    const result = pullGithubIssues(opts);
+    expect(result.pulled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slug mismatch: different title same issue number
+// ---------------------------------------------------------------------------
+
+describe("pipeline de-duplication — slug mismatch", () => {
+  it("rejects pull even when existing plan has a different slug for same issue number", () => {
+    mockIssue42FetchDirect();
+
+    const dir = makeTempDir();
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+    ensureDir(opts.wipDir!);
+
+    // Existing backlog plan has different slug (title changed)
+    writeFileSync(
+      join(opts.backlogDir, "gh-42-old-title.md"),
+      "---\nissue: 42\n---\n# Old title\n",
+    );
+
+    const result = pullGithubIssueByNumber({ ...opts, issueNumber: 42 });
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("42");
+    expect(result.message).toContain("already");
+  });
+
+  it("rejects pull when existing in-progress slug-folder has different name for same issue", () => {
+    mockIssue42Fetch();
+
+    const dir = makeTempDir();
+    const opts = defaultOptions(dir);
+    ensureDir(opts.backlogDir);
+
+    // In-progress slug-folder with different slug
+    const wipSlugDir = join(opts.wipDir!, "gh-42-original-name");
+    ensureDir(wipSlugDir);
+    writeFileSync(
+      join(wipSlugDir, "gh-42-original-name.md"),
+      "---\nissue: 42\n---\n",
+    );
+
+    const result = pullGithubIssues(opts);
+    expect(result.pulled).toBe(false);
+    expect(result.message).toContain("42");
+  });
+});

--- a/src/issue-lifecycle.ts
+++ b/src/issue-lifecycle.ts
@@ -5,7 +5,7 @@
  *
  * Also re-exports pure naming utilities from issue-naming.ts.
  */
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { execQuiet, checkGhAvailable } from "./exec.ts";
 import type { ExecOptions } from "./exec.ts";
@@ -507,6 +507,8 @@ export function validateSubissue(
 export interface PullIssueOptions {
   /** The backlog directory where plan files are written. */
   backlogDir: string;
+  /** The in-progress directory — checked for de-duplication to avoid double-pulling an issue. */
+  wipDir?: string;
   /** Working directory (for git remote detection). */
   cwd: string;
   /** Configured issue source — must be "github" to proceed. */
@@ -1042,10 +1044,34 @@ export function discoverParentIssue(
 // Internal: shared pull logic
 // ---------------------------------------------------------------------------
 
+/**
+ * Check whether a plan file for the given issue number already exists in a
+ * directory. Scans both flat files and slug-folders matching the
+ * `gh-{N}-` prefix. Returns the matching entry name or undefined.
+ */
+function findExistingPlanForIssue(
+  dir: string,
+  issueNumber: string,
+): string | undefined {
+  if (!existsSync(dir)) return undefined;
+  const prefix = `gh-${issueNumber}-`;
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(prefix)) {
+        return entry.name;
+      }
+    }
+  } catch {
+    // ignore read errors (permission, etc.)
+  }
+  return undefined;
+}
+
 interface FetchAndWriteOptions {
   repo: string;
   issueNumber: string;
   backlogDir: string;
+  wipDir?: string;
   cwd: string;
   issueCommentProgress: boolean;
   issuePrdLabel?: string;
@@ -1058,6 +1084,20 @@ interface FetchAndWriteOptions {
  */
 function fetchAndWriteIssuePlan(opts: FetchAndWriteOptions): PullIssueResult {
   const { repo, issueNumber, backlogDir, cwd, issueCommentProgress } = opts;
+
+  // De-duplication: reject if a plan for this issue already exists in
+  // backlog or in-progress. Archive is intentionally not checked so that
+  // completed issues can be re-pulled.
+  for (const dir of [backlogDir, opts.wipDir]) {
+    if (!dir) continue;
+    const existing = findExistingPlanForIssue(dir, issueNumber);
+    if (existing) {
+      return {
+        pulled: false,
+        message: `Issue #${issueNumber} already has a plan in the pipeline: ${existing}`,
+      };
+    }
+  }
 
   const title = execQuiet(
     `gh issue view ${issueNumber} --repo "${repo}" --json title --jq '.title'`,
@@ -1243,6 +1283,7 @@ export function pullGithubIssues(options: PullIssueOptions): PullIssueResult {
     repo,
     issueNumber: String(issueNumber),
     backlogDir,
+    wipDir: options.wipDir,
     cwd,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,
@@ -1383,6 +1424,7 @@ export function pullPrdSubIssue(options: PullIssueOptions): PullIssueResult {
     repo,
     issueNumber: String(subIssueNumber),
     backlogDir,
+    wipDir: options.wipDir,
     cwd,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,
@@ -1599,6 +1641,7 @@ export function pullGithubIssueByNumber(
     repo,
     issueNumber: String(issueNumber),
     backlogDir,
+    wipDir: options.wipDir,
     cwd,
     issueCommentProgress,
     issuePrdLabel: options.issuePrdLabel,

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -2015,10 +2015,11 @@ async function runIssueTarget(
     cwd,
     runArgs,
   );
-  const { backlogDir } = getRepoPipelineDirs(resolvedWorktreeDir);
+  const { backlogDir, wipDir } = getRepoPipelineDirs(resolvedWorktreeDir);
 
   const pullResult = pullGithubIssueByNumber({
     backlogDir,
+    wipDir,
     cwd: resolvedWorktreeDir,
     issueSource: "github",
     standaloneLabel: worktreeConfig.standaloneLabel,
@@ -2220,10 +2221,11 @@ async function runPrdIssueTarget(
     console.log("----------------------------------------");
 
     // Pull the sub-issue into a plan file
-    const { backlogDir } = getRepoPipelineDirs(resolvedWorktreeDir);
+    const { backlogDir, wipDir } = getRepoPipelineDirs(resolvedWorktreeDir);
 
     const pullResult = pullGithubIssueByNumber({
       backlogDir,
+      wipDir,
       cwd: resolvedWorktreeDir,
       issueSource: "github",
       standaloneLabel: worktreeConfig.standaloneLabel,
@@ -2767,9 +2769,10 @@ async function runRalphaiInManagedWorktree(
       ? {
           issueSource: resolvedIssueSource,
           pullFn: () => {
-            const { backlogDir } = getRepoPipelineDirs(cwd);
+            const { backlogDir, wipDir } = getRepoPipelineDirs(cwd);
             const pullOpts: PullIssueOptions = {
               backlogDir,
+              wipDir,
               cwd,
               issueSource: resolvedIssueSource,
               standaloneLabel: resolvedIssueLabel,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -710,6 +710,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         const issueHitlLabel = cfg.issueHitlLabel;
         const pullOpts = {
           backlogDir: dirs.backlogDir,
+          wipDir: dirs.wipDir,
           cwd,
           issueSource,
           standaloneLabel,


### PR DESCRIPTION
Add a pipeline de-duplication guard to prevent the same GitHub issue from being pulled twice. Before writing a plan file, `fetchAndWriteIssuePlan` now scans both the backlog and in-progress directories for existing plans matching the same issue number and rejects duplicates with a clear message. Archived issues are intentionally not checked so completed work can be re-run.

Closes #466

## Changes

### Bug Fixes

- reject duplicate issue pulls with pipeline de-duplication guard


## Learnings

- When using the Edit tool to replace code blocks that appear multiple times in a file (e.g., `fetchAndWriteIssuePlan` call sites that share nearly identical structure), include enough surrounding context to disambiguate. In this case, three callers of `fetchAndWriteIssuePlan` had very similar argument blocks; an edit targeting one accidentally modified another. The PRD caller used `subIssueNumber` while others used `issueNumber`, and the edit inadvertently changed the variable name. Always include the unique trailing context (like the section separator comment) to anchor the match.

Key files and APIs for issue pulling:
- `src/issue-lifecycle.ts`: `fetchAndWriteIssuePlan()` (private), `pullGithubIssues()`, `pullPrdSubIssue()`, `pullGithubIssueByNumber()` — all three public functions delegate to the private one.
- `src/issue-lifecycle.ts:findExistingPlanForIssue()` — new helper that scans a directory for `gh-{N}-*` entries.
- `PullIssueOptions` now has an optional `wipDir?: string` field for de-duplication.
- Callers in `src/runner.ts` (drain loop) and `src/ralphai.ts` (explicit target, PRD sub-issue loop, drain fallback) all pass `wipDir` from `getRepoPipelineDirs()`.
- JSDoc comments containing `*/` anywhere in the text will prematurely close the comment block — avoid glob patterns like `gh-{N}-*/` inside JSDoc.