### PR TITLE
fix: completed standalone issues retain stale in-progress label alongside done label

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -243,3 +243,19 @@ If you still see permission denied errors, check these common causes:
   ```
 - **Rootless Docker** — UID/GID mapping may prevent the container user from accessing host files. Ensure the container user has read/write access to the worktree directory.
 - **Read-only credential mounts** — Credential files (e.g., `.gitconfig`, API key files) are intentionally mounted read-only (`:ro`). If the agent attempts to write to these paths, it will fail. This is by design — credential files should not be modified by the agent.
+
+## "Completed issue still has `in-progress` label"
+
+In earlier versions, a race condition could leave both `in-progress` and `done` labels on a completed issue. This happened when a duplicate pull re-added `in-progress` after the done transition had already removed it. This is now fixed — the pull transition checks for the `done` label and refuses to add `in-progress` if it is present.
+
+If you find an issue with stale labels from before the fix, remove the label manually:
+
+```bash
+gh issue edit <NUMBER> --remove-label in-progress
+```
+
+To audit all issues for inconsistent labels:
+
+```bash
+gh issue list --label done --label in-progress --state all
+```

--- a/src/issue-lifecycle.ts
+++ b/src/issue-lifecycle.ts
@@ -1817,14 +1817,9 @@ export function discoverPrdTarget(
     );
   }
 
-  const openSubIssues: PrdSubIssue[] = allSubIssues
-    .filter((si) => si.state === "open")
-    .map((si) => ({
-      number: si.number,
-      title: si.title,
-      state: si.state,
-      node_id: si.node_id,
-    }));
+  const openSubIssues: PrdSubIssue[] = allSubIssues.filter(
+    (si) => si.state === "open",
+  );
 
   const allCompleted = allSubIssues.length > 0 && openSubIssues.length === 0;
 

--- a/src/issue-lifecycle.ts
+++ b/src/issue-lifecycle.ts
@@ -136,6 +136,32 @@ export function transitionPull(
   if (dryRun) {
     return dryRunSkip(`Issue #${issue.number}: add ${IN_PROGRESS_LABEL}`);
   }
+
+  // Guard: refuse to add in-progress if the issue already has the done label.
+  // This prevents a duplicate/retry pull from corrupting the label state of
+  // a completed issue.  Fail-open: if the label fetch fails we proceed — the
+  // worst case is the same as the previous (unguarded) behavior.
+  const labelsRaw = execQuiet(
+    `gh issue view ${issue.number} --repo "${issue.repo}" --json labels`,
+    cwd,
+  );
+  if (labelsRaw) {
+    try {
+      const data: { labels?: Array<{ name: string }> } = JSON.parse(labelsRaw);
+      const labels = (data.labels ?? []).map((l) => l.name);
+      if (labels.includes(DONE_LABEL)) {
+        return {
+          ok: false,
+          message:
+            `Refused to add ${IN_PROGRESS_LABEL} to issue #${issue.number}: ` +
+            `already has ${DONE_LABEL} label`,
+        };
+      }
+    } catch {
+      // JSON parse failure — proceed with the edit (fail-open)
+    }
+  }
+
   const result = execQuiet(
     `gh issue edit ${issue.number} --repo "${issue.repo}" ` +
       `--add-label "${IN_PROGRESS_LABEL}"`,

--- a/src/label-lifecycle.test.ts
+++ b/src/label-lifecycle.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for core label transition functions (transitionPull, transitionDone,
+ * transitionStuck, transitionReset).
+ *
+ * Uses setExecImpl() from exec.ts to swap execSync with a mock,
+ * verifying transition guard logic without requiring gh CLI.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { setExecImpl } from "./exec.ts";
+import {
+  transitionPull,
+  transitionDone,
+  DONE_LABEL,
+  IN_PROGRESS_LABEL,
+} from "./issue-lifecycle.ts";
+import type { IssueMeta } from "./issue-lifecycle.ts";
+
+// ---------------------------------------------------------------------------
+// Mock setup
+// ---------------------------------------------------------------------------
+
+const mockExecSync = mock();
+let restoreExec: () => void;
+
+const issue: IssueMeta = { number: 42, repo: "acme/widgets" };
+
+beforeEach(() => {
+  restoreExec = setExecImpl(mockExecSync as any);
+  mockExecSync.mockReset();
+});
+
+afterEach(() => {
+  restoreExec();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Route gh commands to handler functions. Unmatched commands throw.
+ */
+function mockGhCommands(
+  handlers: Record<string, (cmd: string) => string>,
+): void {
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (cmd === "gh --version" || cmd === "gh auth status") {
+      return "ok";
+    }
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (cmd.includes(pattern)) {
+        return handler(cmd);
+      }
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// transitionPull — guard against done label
+// ---------------------------------------------------------------------------
+
+describe("transitionPull", () => {
+  it("refuses to add in-progress when issue already has done label", () => {
+    let editCalled = false;
+    mockGhCommands({
+      "gh issue view": () => JSON.stringify({ labels: [{ name: DONE_LABEL }] }),
+      "gh issue edit": () => {
+        editCalled = true;
+        return "";
+      },
+    });
+
+    const result = transitionPull(issue, "/tmp");
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("done");
+    expect(editCalled).toBe(false);
+  });
+
+  it("proceeds normally when issue does not have done label", () => {
+    mockGhCommands({
+      "gh issue view": () =>
+        JSON.stringify({ labels: [{ name: IN_PROGRESS_LABEL }] }),
+      "gh issue edit": () => "",
+    });
+
+    const result = transitionPull(issue, "/tmp");
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain(IN_PROGRESS_LABEL);
+  });
+
+  it("proceeds when label fetch fails (fail-open)", () => {
+    mockGhCommands({
+      "gh issue view": () => {
+        throw new Error("network failure");
+      },
+      "gh issue edit": () => "",
+    });
+
+    const result = transitionPull(issue, "/tmp");
+    expect(result.ok).toBe(true);
+  });
+
+  it("skips label check in dry-run mode", () => {
+    // No mock needed — dry-run should not call gh at all
+    const result = transitionPull(issue, "/tmp", true);
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transitionDone — idempotency
+// ---------------------------------------------------------------------------
+
+describe("transitionDone", () => {
+  it("succeeds when issue already has both in-progress and done labels", () => {
+    mockGhCommands({
+      "gh issue edit": () => "",
+    });
+
+    const result = transitionDone(issue, "/tmp");
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain(DONE_LABEL);
+  });
+
+  it("succeeds on a clean issue with no prior state labels", () => {
+    mockGhCommands({
+      "gh issue edit": () => "",
+    });
+
+    const result = transitionDone(issue, "/tmp");
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/pr-lifecycle.test.ts
+++ b/src/pr-lifecycle.test.ts
@@ -156,6 +156,25 @@ describe("archiveRun", () => {
 
     expect(result.archived).toBe(true);
   });
+
+  it("handles ENOENT gracefully when plan folder was already archived", () => {
+    // Simulate a concurrent runner that already moved the slug-folder.
+    // The wipFiles reference a directory that does not exist on disk.
+    const wipDir = join(ctx.dir, "in-progress", "already-gone");
+    const archiveDir = join(ctx.dir, "out");
+
+    // Do NOT create wipDir — it's already been archived by another runner.
+    // But archiveRun reads frontmatter first, so provide a valid wipFiles
+    // path that points to a non-existent directory.
+    const result = archiveRun({
+      wipFiles: [join(wipDir, "plan.md")],
+      archiveDir,
+      cwd: ctx.dir,
+    });
+
+    expect(result.archived).toBe(false);
+    expect(result.message).toContain("already archived");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/pr-lifecycle.ts
+++ b/src/pr-lifecycle.ts
@@ -462,7 +462,23 @@ export function archiveRun(options: ArchiveRunOptions): {
   }
 
   const dest = join(archiveDir, planSlug);
-  renameSync(planDir, dest);
+  try {
+    renameSync(planDir, dest);
+  } catch (err: unknown) {
+    // If the source directory no longer exists (ENOENT), another runner
+    // already archived it — this is expected in the concurrent/retry scenario.
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return {
+        archived: false,
+        message: `Plan ${planSlug} was already archived by another runner`,
+      };
+    }
+    throw err;
+  }
 
   // Post-completion hooks for linked GitHub issues
   if (issueSource === "github" && issueNumber && checkGhAvailable()) {


### PR DESCRIPTION
Prevent completed GitHub issues from retaining stale `in-progress` labels by adding a guard to `transitionPull` that checks for the `done` label before adding `in-progress`, and by making `archiveRun` handle ENOENT gracefully when a concurrent runner has already archived the plan folder. Includes troubleshooting docs for manually cleaning up issues affected before the fix.

Closes #467

## Changes

### Bug Fixes

- prevent stale in-progress label on completed standalone issues

### Refactoring

- remove redundant identity map in discoverPrdTarget


## Learnings

- The `setExecImpl()` DI pattern in `src/exec.ts` swaps the underlying `execSync` for all modules that use `execQuiet`, `execOk`, etc. When writing mock handlers, return plain strings (not `Buffer`) because `execQuiet` passes `encoding: "utf-8"` which makes real `execSync` return strings, and then calls `.trim()` — `Buffer` lacks `.trim()`, causing the mock to silently fail inside the try/catch and return `null`. This was a subtle source of false test passes.

The `mockGhCommands` pattern used in `pull-github-issues.test.ts` dispatches by substring match (`cmd.includes(pattern)`). Be careful with overlapping patterns like `"gh issue view"` vs `"gh issue edit"` — they don't overlap because neither contains the other, but patterns like `"gh issue"` would match both. Always use the most specific command prefix as the pattern key.

Label transition functions live in `src/issue-lifecycle.ts` (lines 131–250 for core transitions, 263–351 for PRD propagation). There were NO existing unit tests for these — the comment in `issue-lifecycle.test.ts` referencing `label-lifecycle.test.ts` was aspirational. The new `src/label-lifecycle.test.ts` file fills this gap.

`archiveRun` lives in `src/pr-lifecycle.ts` (line 437) and is the single callsite for `transitionDone`. The `renameSync` on line 465 was the fragile point — no error handling for concurrent archive scenarios.


---

*A review pass was run to simplify the implementation.*