### PR TITLE
fix: scope terse mode to working commentary, preserve prose for documentation

### DIFF
--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -563,8 +563,9 @@ describe("assemblePrompt", () => {
     expect(prompt).not.toContain("TERSE MODE:");
   });
 
-  it("terse instruction mentions dropping articles, filler, pleasantries, and hedging", () => {
+  it("terse instruction scopes abbreviated style to working commentary only", () => {
     const prompt = assemblePrompt(baseOptions());
+    expect(prompt).toContain("working commentary");
     expect(prompt).toContain("articles");
     expect(prompt).toContain("filler");
     expect(prompt).toContain("pleasantries");
@@ -577,13 +578,21 @@ describe("assemblePrompt", () => {
     expect(prompt).toContain("exactly as-is");
   });
 
-  it("terse instruction exempts structured blocks, commit messages, and code", () => {
+  it("terse instruction requires normal prose for persisted content", () => {
+    const prompt = assemblePrompt(baseOptions());
+    expect(prompt).toContain("documentation files");
+    expect(prompt).toContain("code comments");
+    expect(prompt).toContain("commit messages");
+    expect(prompt).toContain("PR descriptions");
+    expect(prompt).toContain("normal, grammatical prose");
+    expect(prompt).toContain("must not use terse style");
+  });
+
+  it("terse instruction exempts structured XML blocks", () => {
     const prompt = assemblePrompt(baseOptions());
     expect(prompt).toContain("<learnings>");
     expect(prompt).toContain("<progress>");
     expect(prompt).toContain("<pr-summary>");
-    expect(prompt).toContain("commit messages");
-    expect(prompt).toContain("exempt from terse");
   });
 
   it("terse instruction appears before the file references", () => {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -71,14 +71,16 @@ export interface AssemblePromptOptions {
    */
   wrapperPath?: string;
   /**
-   * When true (default), the prompt includes a terse communication
-   * instruction directing the agent to drop filler words, articles,
-   * pleasantries, and hedging while keeping technical terms, code,
-   * commit messages, and structured XML blocks (`<learnings>`,
-   * `<progress>`, `<pr-summary>`) verbatim.
+   * When false (default), the prompt includes a terse communication
+   * instruction that limits abbreviated style to working commentary
+   * (status updates, reasoning notes, conversational replies). Content
+   * that persists or is read by humans — documentation files, code
+   * comments, commit messages, PR descriptions, error messages, and
+   * structured XML blocks — is explicitly required to use normal,
+   * grammatical prose.
    *
-   * When false, the terse instruction is omitted, allowing the agent
-   * to use full, unabridged prose.
+   * When true, the terse instruction is omitted entirely, allowing
+   * the agent to use full, unabridged prose everywhere.
    */
   verbose?: boolean;
   /**
@@ -318,7 +320,7 @@ Ralphai extracts this block and appends it to the progress file automatically. D
   // --- Terse communication instruction ---
   // Included by default (concise mode). Omitted when verbose is true.
   const terseInstruction = !verbose
-    ? `TERSE MODE: Keep all responses concise. Drop articles, filler words, pleasantries, and hedging. Fragments and short synonyms are fine. Keep technical terms, identifiers, and code exactly as-is. Write commit messages, PR summaries, and structured XML blocks (<learnings>, <progress>, <pr-summary>) normally — these are exempt from terse style.\n`
+    ? `TERSE MODE: Apply concise, abbreviated style ONLY to your working commentary — status updates, reasoning notes, and conversational replies. Drop articles, filler words, pleasantries, and hedging there; fragments and short synonyms are fine. For everything else — code, documentation files, code comments, JSDoc/TSDoc, commit messages, PR descriptions, error messages, and structured XML blocks (<learnings>, <progress>, <pr-summary>) — use normal, grammatical prose. These are read by humans or persisted in the codebase and must not use terse style. Keep technical terms, identifiers, and code exactly as-is everywhere.\n`
     : "";
 
   // --- Preamble resolution ---


### PR DESCRIPTION
## Summary

- Inverts the terse mode instruction framing: instead of "be terse everywhere, except these exemptions," the instruction now says "be terse only in working commentary (status updates, reasoning, conversational replies); use normal prose for everything else."
- Explicitly requires grammatical prose for documentation files, code comments, JSDoc/TSDoc, commit messages, PR descriptions, error messages, and structured XML blocks.
- Updates tests to verify the new scoping (working commentary only) and the normal-prose requirement for persisted content.

## Motivation

The previous terse instruction caused agents to write choppy, abbreviated prose in documentation files, code comments, and other human-facing content. The exemption list (commit messages, PR summaries, XML blocks) was too narrow — any content not explicitly listed got terse treatment. Inverting the framing gives a cleaner, more robust rule: terse is for agent chatter, everything else uses normal English.