### PR TITLE
feat: require --drain for backlog draining

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ ralphai run
 Each run creates or reuses an isolated worktree, works on a `<type>/<slug>` branch (conventional commit style), runs build/test/lint, commits, pushes, and opens a draft PR when `gh` is available.
 
 ```bash
-ralphai run              # drain the backlog: one branch/PR per plan
+ralphai run              # process one eligible work unit
 ralphai run 42           # run GitHub issue #42 (PRD or standalone)
-ralphai run --once       # process a single plan then exit
+ralphai run --drain      # keep processing work until empty
 ralphai run --resume     # commit dirty state and continue
 ralphai run --dry-run    # preview without changing anything
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -153,7 +153,7 @@ What it does:
 --hooks-after-run=<cmd>              Hook to run after each plan completes
 --hooks-feedback-timeout=<sec>       Timeout per feedback command at the gate (default: 300)
 --base-branch=<branch>               Override base branch (default: main)
---once                               Process a single work unit then exit
+--drain                              Keep processing eligible work until none remains
 --gate-max-stuck=<n>                 Stuck threshold before abort (default: 3)
 --gate-max-rejections=<n>            Max gate rejections before force-accept (default: 2, 0 = never)
 --gate-max-iterations=<n>            Max runner iterations before stuck (default: 0 = unlimited)
@@ -195,7 +195,7 @@ Requires an interactive terminal (TTY). In non-TTY contexts, prints an error wit
 
 ### Drain Mode
 
-By default, `ralphai run` drains the backlog — processing plans sequentially, one branch and PR per plan, until the queue is empty. Use `--once` to process a single work unit and exit.
+By default, `ralphai run` processes a single eligible work unit and exits. Use `--drain` to keep processing plans sequentially, one branch and PR per plan, until the queue is empty.
 
 - Each plan gets its own worktree branch and draft PR
 - Stuck plans are skipped and reported in the exit summary

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -200,14 +200,14 @@ The plan stays in `in-progress/<slug>/` so you can inspect and resume it.
 
 ## Drain Mode
 
-By default, `ralphai run` drains the backlog — processing plans sequentially until the queue is empty. Each plan gets its own worktree branch and draft PR.
+By default, `ralphai run` processes a single eligible work unit, then exits. Use `--drain` to keep processing plans sequentially until the queue is empty. Each completed plan gets its own worktree branch and draft PR.
 
 1. **Each completed plan** -> pushes the branch and creates a draft PR
 2. **Stuck plans** -> skipped, logged, and reported in the exit summary
 3. **Backlog empty** -> Ralphai checks for PRD sub-issues, then regular GitHub issues. Sub-issues labeled with the HITL label (`ralphai-subissue-hitl` by default, configurable via `issue.hitlLabel`) are skipped during auto-drain — they require human attention.
 4. **Nothing left** -> exits with a summary: "Completed N, skipped M (stuck)"
 
-Use `--once` to process a single work unit and exit instead of draining.
+Use `--drain` to keep going until no eligible work remains.
 
 ## Label-Driven Dispatch
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,7 +20,7 @@ This is the primary workflow for humans. Use it to browse the backlog, inspect p
 ralphai run
 ```
 
-Processes all dependency-ready plans sequentially, one branch and PR per plan. When the backlog is empty, Ralphai checks for PRD sub-issues, then regular GitHub issues. HITL-labeled sub-issues are skipped during auto-drain. Use `--once` to process a single plan and exit.
+Processes one eligible work unit, creating or reusing the matching branch and PR. Use `--drain` to keep processing dependency-ready plans sequentially until the queue is empty. When the backlog is empty, Ralphai checks for PRD sub-issues, then regular GitHub issues. HITL-labeled sub-issues are skipped during auto-drain.
 
 ## Work from a PRD (recommended for features)
 

--- a/src/auto-detect-drain.test.ts
+++ b/src/auto-detect-drain.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for auto-detect drain: each standalone plan gets its own
+ * Tests for auto-detect run behavior: each standalone plan gets its own
  * branch and worktree when processed via `ralphai run` (no target).
  *
  * Covers:
  *   - Each plan gets a unique <type>/<slug> branch (conventional commit style)
- *   - --once processes exactly one plan
- *   - Worktrees are cleaned up between plans
+ *   - default run processes exactly one plan
+ *   - --drain processes multiple plans and cleans up between them
  *   - Plans with prd: frontmatter route through the PRD flow, not standalone
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -110,7 +110,7 @@ function addPrdSubIssuePlan(
 // ---------------------------------------------------------------------------
 
 describe.skipIf(process.platform === "win32")(
-  "auto-detect drain: branch-per-plan",
+  "auto-detect run behavior: branch-per-plan",
   () => {
     let dir: string;
     let ralphaiHome: string;
@@ -131,7 +131,7 @@ describe.skipIf(process.platform === "win32")(
       else process.env.RALPHAI_HOME = savedHome;
     });
 
-    test("two unrelated plans get distinct branches", () => {
+    test("default run processes only one plan", () => {
       initWithAgent(dir, testEnv());
       process.env.RALPHAI_HOME = ralphaiHome;
       addPlans(dir, testEnv(), [
@@ -147,10 +147,10 @@ describe.skipIf(process.platform === "win32")(
       });
 
       expect(branches).toContain("feat/plan-first-plan");
-      expect(branches).toContain("feat/plan-second-plan");
+      expect(branches).not.toContain("feat/plan-second-plan");
     });
 
-    test("--once processes exactly one plan when two are available", () => {
+    test("--drain processes both plans when two are available", () => {
       initWithAgent(dir, testEnv());
       process.env.RALPHAI_HOME = ralphaiHome;
       const backlogDir = addPlans(dir, testEnv(), [
@@ -158,7 +158,7 @@ describe.skipIf(process.platform === "win32")(
         { slug: "bbb-second", title: "Second Plan" },
       ]);
 
-      runCli(["run", "--once"], dir, testEnv(), 60000);
+      runCli(["run", "--drain"], dir, testEnv(), 60000);
 
       const branches = execSync("git branch --list", {
         cwd: dir,
@@ -166,8 +166,8 @@ describe.skipIf(process.platform === "win32")(
       });
 
       expect(branches).toContain("feat/plan-first-plan");
-      expect(branches).not.toContain("feat/plan-second-plan");
-      expect(existsSync(join(backlogDir, "bbb-second.md"))).toBe(true);
+      expect(branches).toContain("feat/plan-second-plan");
+      expect(existsSync(join(backlogDir, "bbb-second.md"))).toBe(false);
     });
 
     test("worktrees are cleaned up between plans in drain loop", () => {
@@ -178,7 +178,7 @@ describe.skipIf(process.platform === "win32")(
         { slug: "bbb-second", title: "Second Plan" },
       ]);
 
-      runCli(["run"], dir, testEnv(), 60000);
+      runCli(["run", "--drain"], dir, testEnv(), 60000);
 
       // After drain, earlier plan's worktree directory should be removed
       const worktreeBase = join(dir, "..", ".ralphai-worktrees");

--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -96,6 +96,16 @@ describe("CLI help and flags", () => {
     expect(result.stdout).toContain("--no-color");
   });
 
+  it("run --help shows run usage with --drain", async () => {
+    const result = await runCliInProcess(["run", "--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("run");
+    expect(result.stdout).toContain("--drain");
+    expect(result.stdout).not.toContain(
+      "--once                           Run a single plan then exit",
+    );
+  });
+
   it("status --once prints once and exits", async () => {
     const env = { RALPHAI_HOME: join(ctx.dir, ".ralphai-home") };
     await runCliInProcess(["init", "--yes"], ctx.dir, env);

--- a/src/dry-run-safety.test.ts
+++ b/src/dry-run-safety.test.ts
@@ -96,7 +96,7 @@ describe("dry-run safety — runner auto-drain path", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await runRunner(opts);
@@ -128,7 +128,7 @@ describe("dry-run safety — runner auto-drain path", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await runRunner(opts);
@@ -161,7 +161,7 @@ describe("dry-run safety — runner auto-drain path", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const output = await captureConsoleLog(async () => {
@@ -212,7 +212,7 @@ describe("dry-run safety — informational messages", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     // This should complete without making any API calls.

--- a/src/prd-pr.test.ts
+++ b/src/prd-pr.test.ts
@@ -110,7 +110,7 @@ describe("skipPrCreation flag", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: true,
+      drain: true,
       skipPrCreation: true,
     };
 
@@ -143,7 +143,7 @@ describe("skipPrCreation flag", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: true,
+      drain: true,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -177,7 +177,7 @@ describe("skipPrCreation flag", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: true,
+      drain: true,
       skipPrCreation: true,
     };
 
@@ -235,7 +235,7 @@ describe("runner result learnings", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: true,
+      drain: true,
       skipPrCreation: true,
     };
 
@@ -271,7 +271,7 @@ describe("runner result learnings", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: true,
+      drain: true,
       skipPrCreation: true,
     };
 

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -563,8 +563,9 @@ describe("assemblePrompt", () => {
     expect(prompt).not.toContain("TERSE MODE:");
   });
 
-  it("terse instruction mentions dropping articles, filler, pleasantries, and hedging", () => {
+  it("terse instruction scopes abbreviated style to working commentary only", () => {
     const prompt = assemblePrompt(baseOptions());
+    expect(prompt).toContain("working commentary");
     expect(prompt).toContain("articles");
     expect(prompt).toContain("filler");
     expect(prompt).toContain("pleasantries");
@@ -577,13 +578,21 @@ describe("assemblePrompt", () => {
     expect(prompt).toContain("exactly as-is");
   });
 
-  it("terse instruction exempts structured blocks, commit messages, and code", () => {
+  it("terse instruction requires normal prose for persisted content", () => {
+    const prompt = assemblePrompt(baseOptions());
+    expect(prompt).toContain("documentation files");
+    expect(prompt).toContain("code comments");
+    expect(prompt).toContain("commit messages");
+    expect(prompt).toContain("PR descriptions");
+    expect(prompt).toContain("normal, grammatical prose");
+    expect(prompt).toContain("must not use terse style");
+  });
+
+  it("terse instruction exempts structured XML blocks", () => {
     const prompt = assemblePrompt(baseOptions());
     expect(prompt).toContain("<learnings>");
     expect(prompt).toContain("<progress>");
     expect(prompt).toContain("<pr-summary>");
-    expect(prompt).toContain("commit messages");
-    expect(prompt).toContain("exempt from terse");
   });
 
   it("terse instruction appears before the file references", () => {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -71,14 +71,16 @@ export interface AssemblePromptOptions {
    */
   wrapperPath?: string;
   /**
-   * When true (default), the prompt includes a terse communication
-   * instruction directing the agent to drop filler words, articles,
-   * pleasantries, and hedging while keeping technical terms, code,
-   * commit messages, and structured XML blocks (`<learnings>`,
-   * `<progress>`, `<pr-summary>`) verbatim.
+   * When false (default), the prompt includes a terse communication
+   * instruction that limits abbreviated style to working commentary
+   * (status updates, reasoning notes, conversational replies). Content
+   * that persists or is read by humans — documentation files, code
+   * comments, commit messages, PR descriptions, error messages, and
+   * structured XML blocks — is explicitly required to use normal,
+   * grammatical prose.
    *
-   * When false, the terse instruction is omitted, allowing the agent
-   * to use full, unabridged prose.
+   * When true, the terse instruction is omitted entirely, allowing
+   * the agent to use full, unabridged prose everywhere.
    */
   verbose?: boolean;
   /**
@@ -318,7 +320,7 @@ Ralphai extracts this block and appends it to the progress file automatically. D
   // --- Terse communication instruction ---
   // Included by default (concise mode). Omitted when verbose is true.
   const terseInstruction = !verbose
-    ? `TERSE MODE: Keep all responses concise. Drop articles, filler words, pleasantries, and hedging. Fragments and short synonyms are fine. Keep technical terms, identifiers, and code exactly as-is. Write commit messages, PR summaries, and structured XML blocks (<learnings>, <progress>, <pr-summary>) normally — these are exempt from terse style.\n`
+    ? `TERSE MODE: Apply concise, abbreviated style ONLY to your working commentary — status updates, reasoning notes, and conversational replies. Drop articles, filler words, pleasantries, and hedging there; fragments and short synonyms are fine. For everything else — code, documentation files, code comments, JSDoc/TSDoc, commit messages, PR descriptions, error messages, and structured XML blocks (<learnings>, <progress>, <pr-summary>) — use normal, grammatical prose. These are read by humans or persisted in the codebase and must not use terse style. Keep technical terms, identifiers, and code exactly as-is everywhere.\n`
     : "";
 
   // --- Preamble resolution ---

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -1653,7 +1653,7 @@ const KNOWN_RUN_FLAGS = new Set([
   "--resume",
   "-r",
   "--allow-dirty",
-  "--once",
+  "--drain",
   "--show-config",
   "--wizard",
   "-w",
@@ -1706,6 +1706,14 @@ function isRecognizedRunFlag(arg: string): boolean {
 }
 
 function validateRunArgs(runArgs: string[]): void {
+  if (runArgs.includes("--once")) {
+    console.error(
+      "ERROR: --once was removed from 'ralphai run'. Use 'ralphai run' for one work unit or 'ralphai run --drain' to keep going.",
+    );
+    showRunHelp();
+    process.exit(1);
+  }
+
   for (const arg of runArgs) {
     if (!isRecognizedRunFlag(arg)) {
       console.error(`ERROR: Unrecognized argument: ${arg}`);
@@ -1730,7 +1738,7 @@ function showRunHelp(): void {
     "Options:",
     "  --dry-run, -n                    Preview what Ralphai would do without mutating state",
     "  --wizard, -w                     Interactively configure run options before starting",
-    "  --once                           Run a single plan then exit (default: drain backlog)",
+    "  --drain                          Keep processing eligible work until none remains",
     "  --resume, -r                     Commit dirty state and continue",
     "  --allow-dirty                    Skip the clean working tree check",
     "  --plan=<file>                    Target a specific backlog plan (default: auto-detect)",
@@ -1789,11 +1797,11 @@ function showRunHelp(): void {
     "Precedence: CLI flags > env vars > config file > built-in defaults",
     "",
     "Examples:",
-    "  ralphai run                                             # auto-detect work and run",
+    "  ralphai run                                             # process one auto-detected work unit",
     "  ralphai run 42                                          # fetch issue #42, create branch, run",
     "  ralphai run my-feature.md                               # run a specific plan file",
     "  ralphai run --dry-run                                   # preview only",
-    "  ralphai run --once                                      # run a single plan then exit",
+    "  ralphai run --drain                                     # keep processing work until empty",
     "  ralphai run --resume                                    # recover dirty state and continue",
     "  ralphai run --agent-command='claude -p'                 # use Claude Code",
     "  ralphai run --agent-command='opencode run --agent build'  # use OpenCode",
@@ -2105,21 +2113,18 @@ async function runIssueTarget(
   console.log("Running ralphai in worktree...");
 
   // Build runner options: single-target, no drain.
-  // --once ensures the runner exits after completing this single issue
-  // instead of draining the backlog or pulling more GitHub issues.
   const activeWorktrees = listRalphaiWorktrees(cwd);
   const activeWorktree = activeWorktrees.find((wt) => wt.branch === branch);
   const shouldResume = activeWorktree !== undefined;
   const hasResumeFlag = runArgs.includes("--resume") || runArgs.includes("-r");
-  const hasOnceFlag = runArgs.includes("--once");
+  const runnerRunArgs = runArgs.filter((arg) => arg !== "--drain");
   const worktreeRunOptions: RalphaiOptions = {
     ...options,
     subcommand: "run",
     runTarget: undefined, // already handled
     runArgs: [
       ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
-      ...(!hasOnceFlag ? ["--once"] : []),
-      ...runArgs,
+      ...runnerRunArgs,
     ],
   };
 
@@ -2357,19 +2362,16 @@ async function runPrdIssueTarget(
     const shouldResume = activeWorktree !== undefined || !isFirstSubIssue;
     const hasResumeFlag =
       runArgs.includes("--resume") || runArgs.includes("-r");
-    // --once ensures the runner exits after completing this single sub-issue,
-    // so the outer for-loop (not the runner's drain loop) controls sequencing.
-    // Without this, the runner re-fetches the PRD body, finds the same
-    // unchecked sub-issue, and re-pulls it.
-    const hasOnceFlag = runArgs.includes("--once");
+    // Strip --drain so the outer PRD loop, not the inner runner loop,
+    // controls sub-issue sequencing.
+    const runnerRunArgs = runArgs.filter((arg) => arg !== "--drain");
     const worktreeRunOptions: RalphaiOptions = {
       ...options,
       subcommand: "run",
       runTarget: undefined,
       runArgs: [
         ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
-        ...(!hasOnceFlag ? ["--once"] : []),
-        ...runArgs,
+        ...runnerRunArgs,
       ],
     };
 
@@ -2536,6 +2538,8 @@ async function runPlanTarget(
   if (!planFlagAlreadySet) {
     runArgs = [...runArgs, `--plan=${planPath}`];
   }
+
+  runArgs = runArgs.filter((arg) => arg !== "--drain");
 
   // Validate the plan file exists before proceeding
   const { backlogDir, wipDir } = getRepoPipelineDirs(cwd);
@@ -2872,7 +2876,7 @@ async function runRalphaiInManagedWorktree(
 
   ensureRepoHasCommit(cwd);
 
-  const hasOnce = runArgs.includes("--once");
+  const hasDrain = runArgs.includes("--drain");
 
   // Build GitHub fallback options so selectPlanForWorktree can pull an issue
   // when the local backlog is empty and issueSource is "github".
@@ -2903,10 +2907,10 @@ async function runRalphaiInManagedWorktree(
         }
       : undefined;
 
-  // --- Drain loop: each plan gets its own branch and worktree ---
+  // --- Auto-detect loop: default single work unit; --drain keeps going ---
   // This mirrors how runPrdIssueTarget sequences sub-issues: the outer loop
   // controls plan selection and worktree lifecycle, while the runner processes
-  // a single plan per invocation (--once).
+  // a single plan per invocation by default.
   let plansProcessed = 0;
 
   while (true) {
@@ -3009,14 +3013,13 @@ async function runRalphaiInManagedWorktree(
       plan.source === "in-progress" || activeWorktree !== undefined;
     const hasResumeFlag =
       runArgs.includes("--resume") || runArgs.includes("-r");
-    const hasOnceFlag = runArgs.includes("--once");
+    const runnerRunArgs = runArgs.filter((arg) => arg !== "--drain");
     const worktreeRunOptions: RalphaiOptions = {
       ...options,
       subcommand: "run",
       runArgs: [
         ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
-        ...(!hasOnceFlag ? ["--once"] : []),
-        ...runArgs,
+        ...runnerRunArgs,
       ],
     };
 
@@ -3029,9 +3032,9 @@ async function runRalphaiInManagedWorktree(
     plansProcessed++;
 
     // --- Clean up worktree between plans so the next one starts fresh ---
-    // Skip cleanup on --once (the single worktree may still be useful) and
+    // Skip cleanup in single-run mode (the worktree may still be useful) and
     // when this was a pre-existing worktree we reused.
-    if (!hasOnce && !activeWorktree) {
+    if (hasDrain && !activeWorktree) {
       try {
         execSync(`git worktree remove --force "${resolvedWorktreeDir}"`, {
           cwd,
@@ -3043,8 +3046,8 @@ async function runRalphaiInManagedWorktree(
       }
     }
 
-    // --- --once: stop after a single plan ---
-    if (hasOnce) {
+    // --- Default mode: stop after a single plan ---
+    if (!hasDrain) {
       break;
     }
 
@@ -3074,7 +3077,7 @@ async function runRalphaiRunner(
   const isDryRun = runArgs.includes("--dry-run") || runArgs.includes("-n");
   let hasAllowDirty = runArgs.includes("--allow-dirty");
   const hasResume = runArgs.includes("--resume") || runArgs.includes("-r");
-  const hasOnce = runArgs.includes("--once");
+  const hasDrain = runArgs.includes("--drain");
   const hasVerbose = runArgs.includes("--verbose");
   const hasShowConfig = runArgs.includes("--show-config");
   const planFlag = runArgs.find((a) => a.startsWith("--plan="));
@@ -3216,7 +3219,7 @@ async function runRalphaiRunner(
     dryRun: isDryRun,
     resume: hasResume,
     allowDirty: hasAllowDirty,
-    once: hasOnce,
+    drain: hasDrain,
     plan: targetPlan,
     filterTags,
     prd: prdIssue,

--- a/src/runner-config.test.ts
+++ b/src/runner-config.test.ts
@@ -74,7 +74,19 @@ describe("runner config", () => {
       expect(result.exitCode).toBe(0);
       const combined = result.stdout + result.stderr;
       expect(combined).toContain("--dry-run");
-      expect(combined).toContain("--once");
+      expect(combined).toContain("--drain");
+    });
+
+    it("run --once fails with guidance", async () => {
+      const result = await runCliInProcess(
+        ["run", "--once"],
+        ctx.dir,
+        testEnv(),
+      );
+      expect(result.exitCode).not.toBe(0);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain("--once was removed");
+      expect(combined).toContain("ralphai run --drain");
     });
 
     it("run 3 is treated as an issue target (requires GitHub)", async () => {

--- a/src/runner-drain.test.ts
+++ b/src/runner-drain.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for drain-by-default, --once, and exit summary behavior.
+ * Tests for default single-run, --drain, and exit summary behavior.
  *
  * These cover ACs from issue #212:
- *   - Drain: multiple plans processed sequentially until queue empty
- *   - --once: single plan processed then exit
+ *   - Default: single plan processed then exit
+ *   - --drain: multiple plans processed sequentially until queue empty
  *   - Exit summary: "Completed N, skipped M (stuck)" with stuck slugs
  *   - Priority: in-progress plan resumes before backlog plans
  */
@@ -75,10 +75,10 @@ const completeAgent = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\"
 const stuckAgent = `bash -c 'N=$RALPHAI_NONCE; echo "doing nothing"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
 
 // ---------------------------------------------------------------------------
-// Drain behavior
+// Default single-run behavior
 // ---------------------------------------------------------------------------
 
-describe("drain-by-default", () => {
+describe("default single-run", () => {
   let dir: string;
   let savedHome: string | undefined;
 
@@ -92,7 +92,7 @@ describe("drain-by-default", () => {
     else process.env.RALPHAI_HOME = savedHome;
   });
 
-  test("processes multiple backlog plans sequentially", async () => {
+  test("processes only one backlog plan by default", async () => {
     const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
     const worktreeDir = createManagedWorktree(dir, "plan-a");
 
@@ -117,15 +117,16 @@ describe("drain-by-default", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const output = await captureLogs(() => runRunner(opts));
 
-    // Both plans should be archived
+    // Only the first plan (alphabetically) should be archived
     expect(existsSync(join(archiveDir, "plan-a", "plan-a.md"))).toBe(true);
-    expect(existsSync(join(archiveDir, "plan-b", "plan-b.md"))).toBe(true);
-    expect(output).toContain("Completed 2");
+    expect(existsSync(join(archiveDir, "plan-b", "plan-b.md"))).toBe(false);
+    expect(existsSync(join(backlogDir, "plan-b.md"))).toBe(true);
+    expect(output).toContain("Completed 1");
   });
 
   test("summary reports completed count for single plan", async () => {
@@ -148,7 +149,7 @@ describe("drain-by-default", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: true,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -157,10 +158,10 @@ describe("drain-by-default", () => {
 });
 
 // ---------------------------------------------------------------------------
-// --once flag
+// --drain flag
 // ---------------------------------------------------------------------------
 
-describe("--once flag", () => {
+describe("--drain flag", () => {
   let dir: string;
   let savedHome: string | undefined;
 
@@ -174,7 +175,7 @@ describe("--once flag", () => {
     else process.env.RALPHAI_HOME = savedHome;
   });
 
-  test("processes only one plan then exits", async () => {
+  test("processes multiple plans sequentially", async () => {
     const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
     const worktreeDir = createManagedWorktree(dir, "first");
 
@@ -198,17 +199,16 @@ describe("--once flag", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: true, // key difference
+      drain: true,
     };
 
     const output = await captureLogs(() => runRunner(opts));
 
-    // Only the first plan (alphabetically) should be archived
+    // Both plans should be archived in drain mode
     expect(existsSync(join(archiveDir, "first", "first.md"))).toBe(true);
-    // Second plan should still be in backlog
-    expect(existsSync(join(backlogDir, "second.md"))).toBe(true);
-    expect(existsSync(join(archiveDir, "second", "second.md"))).toBe(false);
-    expect(output).toContain("Completed 1");
+    expect(existsSync(join(archiveDir, "second", "second.md"))).toBe(true);
+    expect(existsSync(join(backlogDir, "second.md"))).toBe(false);
+    expect(output).toContain("Completed 2");
   });
 });
 
@@ -250,7 +250,7 @@ describe("exit summary", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: true,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -291,7 +291,7 @@ describe("exit summary", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: true,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -319,7 +319,7 @@ describe("exit summary", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -381,14 +381,14 @@ describe("priority: in-progress before backlog", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: true, // only process one to verify priority
+      drain: false, // only process one to verify priority
     };
 
     const output = await captureLogs(() => runRunner(opts));
 
     // In-progress plan should be archived (it was processed first)
     expect(existsSync(join(archiveDir, "resumed", "resumed.md"))).toBe(true);
-    // Backlog plan should still be in backlog (--once stopped after first)
+    // Backlog plan should still be in backlog (default single-run stopped after first)
     expect(existsSync(join(backlogDir, "zzz-later.md"))).toBe(true);
     expect(output).toContain("in-progress");
   });

--- a/src/runner-gate-tuning.test.ts
+++ b/src/runner-gate-tuning.test.ts
@@ -111,7 +111,7 @@ describe("runRunner — gate.maxRejections", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const { output, result } = await captureLogs(() => runRunner(opts));
@@ -152,7 +152,7 @@ describe("runRunner — gate.maxRejections", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const { output, result } = await captureLogs(() => runRunner(opts));
@@ -221,7 +221,7 @@ describe("runRunner — gate.maxIterations", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const { output, result } = await captureLogs(() => runRunner(opts));
@@ -258,7 +258,7 @@ describe("runRunner — gate.maxIterations", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const { output, result } = await captureLogs(() => runRunner(opts));

--- a/src/runner-github-drain.test.ts
+++ b/src/runner-github-drain.test.ts
@@ -2,7 +2,7 @@
  * Tests for runner drain behavior with GitHub issue pulls.
  *
  * Uses mock.module to control pullGithubIssues and pullPrdSubIssue so
- * we can test the single-issue-then-stop vs PRD-continues-draining
+ * we can test default single-run vs explicit --drain behavior
  * behavior without requiring a real GitHub repo.
  *
  * Separate file because mock.module() leaks across tests in the same
@@ -161,12 +161,12 @@ describe("runner GitHub drain behavior", () => {
     else process.env.RALPHAI_HOME = savedHome;
   });
 
-  test("stops after completing a single regular GitHub issue pull", async () => {
+  test("stops after completing a single regular GitHub issue pull by default", async () => {
     const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
     const worktreeDir = createManagedWorktree(dir, "gh-issue-a");
 
-    // Mock: PRD returns nothing, regular pull has 3 available issues
-    // The runner should only process ONE, then stop.
+    // Mock: PRD returns nothing, regular pull has 3 available issues.
+    // Default mode should only process ONE, then stop.
     mockPullPrdSubIssue.mockImplementation(() => ({
       pulled: false,
       message: "No PRD sub-issues",
@@ -191,7 +191,7 @@ describe("runner GitHub drain behavior", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false, // NOT using --once, drain should still stop after one GitHub issue
+      drain: false,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -211,7 +211,52 @@ describe("runner GitHub drain behavior", () => {
     expect(output).toContain("Completed 1");
   });
 
-  test("continues draining when pulling PRD sub-issues", async () => {
+  test("continues draining across regular GitHub issues with --drain", async () => {
+    const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
+    const worktreeDir = createManagedWorktree(dir, "gh-issue-a");
+
+    mockPullPrdSubIssue.mockImplementation(() => ({
+      pulled: false,
+      message: "No PRD sub-issues",
+    }));
+    mockPullGithubIssues.mockImplementation(
+      makePullGithubMultiple(backlogDir, [
+        "gh-issue-a",
+        "gh-issue-b",
+        "gh-issue-c",
+      ]),
+    );
+
+    const opts: RunnerOptions = {
+      config: makeTestResolvedConfig({
+        agent: { command: completeAgent },
+        issue: { source: "github" },
+        gate: { review: false },
+      }),
+      cwd: worktreeDir,
+      isWorktree: true,
+      mainWorktree: dir,
+      dryRun: false,
+      resume: false,
+      allowDirty: false,
+      drain: true,
+    };
+
+    const output = await captureLogs(() => runRunner(opts));
+
+    expect(existsSync(join(archiveDir, "gh-issue-a", "gh-issue-a.md"))).toBe(
+      true,
+    );
+    expect(existsSync(join(archiveDir, "gh-issue-b", "gh-issue-b.md"))).toBe(
+      true,
+    );
+    expect(existsSync(join(archiveDir, "gh-issue-c", "gh-issue-c.md"))).toBe(
+      true,
+    );
+    expect(output).toContain("Completed 3");
+  });
+
+  test("continues draining when pulling PRD sub-issues with --drain", async () => {
     const { backlogDir, archiveDir } = setupGlobalPipeline(dir);
     const worktreeDir = createManagedWorktree(dir, "prd-sub-a");
 
@@ -236,7 +281,7 @@ describe("runner GitHub drain behavior", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: true,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -280,7 +325,7 @@ describe("runner GitHub drain behavior", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: true,
     };
 
     await captureLogs(() => runRunner(opts));
@@ -315,7 +360,7 @@ describe("runner GitHub drain behavior", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: true,
     };
 
     await captureLogs(() => runRunner(opts));
@@ -353,7 +398,7 @@ describe("runner GitHub drain behavior", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await captureLogs(() => runRunner(opts));
@@ -391,7 +436,7 @@ describe("runner GitHub drain behavior", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await captureLogs(() => runRunner(opts));
@@ -448,14 +493,14 @@ describe("runner GitHub drain behavior", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await captureLogs(() => runRunner(opts));
 
-    // PRD should be tried first in the priority chain
+    // PRD should be tried first in the priority chain. Once one sub-issue is
+    // pulled, this runner invocation processes that work unit and returns.
     expect(callOrder[0]).toBe("prd");
-    // After PRD sub-issues are exhausted, standalone is tried
-    expect(callOrder).toContain("standalone");
+    expect(callOrder).not.toContain("standalone");
   });
 });

--- a/src/runner-learnings.test.ts
+++ b/src/runner-learnings.test.ts
@@ -117,7 +117,7 @@ describe("runRunner — in-memory learnings", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];
@@ -168,7 +168,7 @@ describe("runRunner — in-memory learnings", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];
@@ -211,7 +211,7 @@ describe("runRunner — in-memory learnings", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];
@@ -257,7 +257,7 @@ describe("runRunner — in-memory learnings", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];

--- a/src/runner-resume.test.ts
+++ b/src/runner-resume.test.ts
@@ -87,7 +87,7 @@ describe("runRunner — resume", () => {
       dryRun: false,
       resume: true,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];

--- a/src/runner-review-pass.test.ts
+++ b/src/runner-review-pass.test.ts
@@ -107,7 +107,7 @@ describe("runRunner — review pass", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -149,7 +149,7 @@ describe("runRunner — review pass", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -186,7 +186,7 @@ describe("runRunner — review pass", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const output = await captureLogs(() => runRunner(opts));
@@ -227,7 +227,7 @@ describe("runRunner — review pass", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await captureLogs(() => runRunner(opts));

--- a/src/runner-zero-completion.test.ts
+++ b/src/runner-zero-completion.test.ts
@@ -101,7 +101,7 @@ describe("runRunner — zero-completion guard", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];
@@ -165,7 +165,7 @@ describe("runRunner — zero-completion guard", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -91,7 +91,7 @@ describe("runRunner — dry-run", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     // Should not throw
@@ -109,7 +109,7 @@ describe("runRunner — dry-run", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const logs: string[] = [];
@@ -143,7 +143,7 @@ describe("runRunner — dry-run", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     // dry-run should not create branches or modify state
@@ -195,7 +195,7 @@ describe("runRunner — completion", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await runRunner(opts);
@@ -227,7 +227,7 @@ describe("runRunner — completion", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     await runRunner(opts);
@@ -263,7 +263,7 @@ describe("runRunner — completion", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     // Stuck plans are now skipped instead of process.exit(1).
@@ -328,7 +328,7 @@ describe("runRunner — RunnerResult", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const origLog = console.log;
@@ -366,7 +366,7 @@ describe("runRunner — RunnerResult", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const result = await runRunner(opts);
@@ -397,7 +397,7 @@ describe("runRunner — RunnerResult", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const result = await runRunner(opts);
@@ -424,7 +424,7 @@ describe("runRunner — RunnerResult", () => {
       dryRun: true,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     const result = await runRunner(opts);
@@ -463,7 +463,7 @@ describe("runRunner — no work", () => {
       dryRun: false,
       resume: false,
       allowDirty: false,
-      once: false,
+      drain: false,
     };
 
     // Should not throw — just prints "nothing to do" and returns

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -217,8 +217,8 @@ export interface RunnerOptions {
   resume: boolean;
   /** Whether --allow-dirty was passed. */
   allowDirty: boolean;
-  /** Whether --once was passed (process a single plan then exit). */
-  once: boolean;
+  /** Whether --drain was passed (keep processing plans until no work remains). */
+  drain: boolean;
   /** Target a specific backlog plan by filename (e.g. "my-plan.md"). */
   plan?: string;
   /** Filter plans to those matching ANY of these tags (OR semantics). */
@@ -579,7 +579,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
     resume,
     plan,
     filterTags,
-    once,
+    drain,
     skipPrCreation,
     verbose: agentVerbose,
   } = opts;
@@ -718,18 +718,13 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
     resolvedPreamble = readFileSync(preamblePath, "utf-8");
   }
 
-  // --- Main plan loop (drain-by-default) ---
+  // --- Main plan loop (single plan by default; --drain continues) ---
   let plansCompleted = 0;
   let lastPrSummary: string | undefined;
   const skippedSlugs = new Set<string>();
   const stuckSlugs: string[] = [];
   let activePidFile: string | null = null;
   let activeIpcServer: IpcServer | null = null;
-
-  // When a regular (non-PRD) GitHub issue is pulled, the runner should
-  // process exactly that one issue and then stop. PRD sub-issues are
-  // different — the runner continues draining all sub-issues.
-  let pulledRegularGithubIssue = false;
 
   while (!interrupted) {
     console.log();
@@ -775,10 +770,6 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
 
         const issueResult = pullGithubIssues(pullOpts);
         if (issueResult.pulled) {
-          // Regular GitHub issue pulled — process it, then stop the drain
-          // loop after completion. (PRD sub-issues use `continue` above
-          // without setting this flag, so they keep draining.)
-          pulledRegularGithubIssue = true;
           continue;
         }
 
@@ -1453,17 +1444,12 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
         break;
       }
 
-      // --- --once: stop after a single completed (or stuck) plan ---
-      if (once) {
+      // --- Default mode: stop after a single completed (or stuck) plan ---
+      if (!drain) {
         break;
       }
 
-      // --- Stop after a pulled regular GitHub issue (not PRD sub-issues) ---
-      if (pulledRegularGithubIssue) {
-        break;
-      }
-
-      // Loop back to pick the next plan (drain-by-default)
+      // Loop back to pick the next plan when --drain is active.
     } finally {
       // --- hooks.afterRun: runs once per plan on all exit paths ---
       if (afterRunHook) {


### PR DESCRIPTION
## Summary
- change `ralphai run` to process a single eligible work unit by default, and require `--drain` to keep processing until no work remains
- hard-break `ralphai run --once` with explicit guidance to use default single-run behavior or `--drain`
- update runner behavior, tests, help text, README, and CLI/docs to match the new semantics

## Testing
- bun test src/runner-drain.test.ts src/runner-github-drain.test.ts src/auto-detect-drain.test.ts src/runner-config.test.ts src/cli-help.test.ts
- bun run build