### PR TITLE
fix: improve learnings quality — filter junk, tighten prompt, fix test fixtures

### DIFF
--- a/src/progress.test.ts
+++ b/src/progress.test.ts
@@ -292,16 +292,16 @@ describe("parseLearningContent", () => {
   });
 
   // <entry> tag stripping behavior
-  it("returns null for a single none", () => {
-    expect(parseLearningContent("none")).toBeNull();
-  });
-
   it('returns null for <entry> with whitespace around "status: none"', () => {
     expect(parseLearningContent("<entry>  status: none  </entry>")).toBeNull();
   });
 
   it("returns null when all entries are status: none", () => {
-    expect(parseLearningContent("none")).toBeNull();
+    expect(
+      parseLearningContent(
+        "<entry>status: none</entry><entry>status: none</entry>",
+      ),
+    ).toBeNull();
   });
 
   it("extracts real content and ignores status: none entries", () => {

--- a/src/progress.test.ts
+++ b/src/progress.test.ts
@@ -290,4 +290,49 @@ describe("parseLearningContent", () => {
       "Always use path.join() for cross-platform paths.\nNever hardcode / separators.";
     expect(parseLearningContent(block)).toBe(block);
   });
+
+  // <entry> tag stripping behavior
+  it("returns null for a single <entry>status: none</entry>", () => {
+    expect(parseLearningContent("<entry>status: none</entry>")).toBeNull();
+  });
+
+  it('returns null for <entry> with whitespace around "status: none"', () => {
+    expect(parseLearningContent("<entry>  status: none  </entry>")).toBeNull();
+  });
+
+  it("returns null when all entries are status: none", () => {
+    expect(
+      parseLearningContent(
+        "<entry>status: none</entry><entry>status: none</entry>",
+      ),
+    ).toBeNull();
+  });
+
+  it("extracts real content and ignores status: none entries", () => {
+    expect(
+      parseLearningContent(
+        "<entry>Real lesson here.</entry><entry>status: none</entry>",
+      ),
+    ).toBe("Real lesson here.");
+  });
+
+  it("returns content from a single <entry> with real content", () => {
+    expect(
+      parseLearningContent(
+        "<entry>The mock.module pattern requires all exports.</entry>",
+      ),
+    ).toBe("The mock.module pattern requires all exports.");
+  });
+
+  it("returns null for STATUS: NONE (case-insensitive) inside <entry>", () => {
+    expect(parseLearningContent("<entry>STATUS: NONE</entry>")).toBeNull();
+  });
+
+  it("joins multiple real entries with newline", () => {
+    expect(
+      parseLearningContent(
+        "<entry>First lesson.</entry><entry>Second lesson.</entry>",
+      ),
+    ).toBe("First lesson.\nSecond lesson.");
+  });
 });

--- a/src/progress.test.ts
+++ b/src/progress.test.ts
@@ -292,8 +292,8 @@ describe("parseLearningContent", () => {
   });
 
   // <entry> tag stripping behavior
-  it("returns null for a single <entry>status: none</entry>", () => {
-    expect(parseLearningContent("<entry>status: none</entry>")).toBeNull();
+  it("returns null for a single none", () => {
+    expect(parseLearningContent("none")).toBeNull();
   });
 
   it('returns null for <entry> with whitespace around "status: none"', () => {
@@ -301,19 +301,13 @@ describe("parseLearningContent", () => {
   });
 
   it("returns null when all entries are status: none", () => {
-    expect(
-      parseLearningContent(
-        "<entry>status: none</entry><entry>status: none</entry>",
-      ),
-    ).toBeNull();
+    expect(parseLearningContent("none")).toBeNull();
   });
 
   it("extracts real content and ignores status: none entries", () => {
-    expect(
-      parseLearningContent(
-        "<entry>Real lesson here.</entry><entry>status: none</entry>",
-      ),
-    ).toBe("Real lesson here.");
+    expect(parseLearningContent("<entry>Real lesson here.</entry>none")).toBe(
+      "Real lesson here.",
+    );
   });
 
   it("returns content from a single <entry> with real content", () => {

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -250,14 +250,32 @@ describe("assemblePrompt", () => {
 
   // --- Richer learnings guidance ---
 
-  it("learnings prompt asks for file paths, APIs/signatures, architecture constraints, and error resolutions", () => {
+  it("learnings prompt does not contain removed file-path or API example bullets", () => {
     const prompt = assemblePrompt(baseOptions());
-    expect(prompt).toContain("File paths modified or discovered");
-    expect(prompt).toContain("Exported APIs and their signatures");
-    expect(prompt).toContain("Architecture constraints or patterns observed");
+    expect(prompt).not.toContain("File paths modified or discovered");
+    expect(prompt).not.toContain("Exported APIs and their signatures");
+  });
+
+  it("learnings prompt includes negative guidance about what not to log", () => {
+    const prompt = assemblePrompt(baseOptions());
+    expect(prompt).toContain("Do NOT log:");
+    expect(prompt).toContain("session notes that go stale immediately");
+  });
+
+  it("learnings prompt includes durability quality-gate heuristic", () => {
+    const prompt = assemblePrompt(baseOptions());
     expect(prompt).toContain(
-      "Error messages encountered and how they were resolved",
+      "would this still be useful if the codebase had changed since this iteration?",
     );
+    expect(prompt).toContain("session note, not a learning");
+  });
+
+  it("learnings prompt retains guidance about behavioral patterns and architecture constraints", () => {
+    const prompt = assemblePrompt(baseOptions());
+    expect(prompt).toContain("behavioral patterns");
+    expect(prompt).toContain("architectural constraints");
+    expect(prompt).toContain("recurring failure modes");
+    expect(prompt).toContain("project conventions");
   });
 
   it("learnings guidance remains freeform prose (no structured schema)", () => {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -349,11 +349,10 @@ Add JWT-based authentication with login/logout endpoints, replacing the previous
 ${prSummaryClose}${
     enableLearnings
       ? `
-REQUIRED: At the very end of your response, include a ${learningsOpen}...${learningsClose} block. If you made a mistake or learned something this iteration, write a durable, generalizable lesson as freeform prose — something worth considering for AGENTS.md. Do not log one-off typos or dead ends. When reporting learnings, include specifics that help future iterations hit the ground running:
-- File paths modified or discovered (e.g. "the validation logic lives in src/validators/input.ts")
-- Exported APIs and their signatures (e.g. "parseConfig(path: string): Config is the main entry point")
-- Architecture constraints or patterns observed (e.g. "all DB access goes through the repository layer, never direct queries")
-- Error messages encountered and how they were resolved (e.g. "TS2345 type mismatch fixed by narrowing the union with a type guard")
+REQUIRED: At the very end of your response, include a ${learningsOpen}...${learningsClose} block. If you made a mistake or learned something this iteration, write a durable, generalizable lesson as freeform prose — something worth considering for AGENTS.md. Do not log one-off typos or dead ends.
+A learning must be durable: ask yourself "would this still be useful if the codebase had changed since this iteration?" If the answer is no, it is a session note, not a learning — omit it.
+Do NOT log: where a specific file lives, what a function signature looks like after you just read it, or a narration of your exploration steps. These are session notes that go stale immediately.
+DO log: behavioral patterns, architectural constraints, recurring failure modes, and project conventions that would help a future agent avoid a class of mistakes.
 Use:
 ${learningsOpen}
 Your freeform prose lesson here.

--- a/src/runner-drain.test.ts
+++ b/src/runner-drain.test.ts
@@ -71,8 +71,8 @@ async function captureLogs(fn: () => Promise<unknown>): Promise<string> {
   return logs.join("\n");
 }
 
-const completeAgent = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Done"; echo "**Status:** Complete"; echo "Finished."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
-const stuckAgent = `bash -c 'N=$RALPHAI_NONCE; echo "doing nothing"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+const completeAgent = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Done"; echo "**Status:** Complete"; echo "Finished."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
+const stuckAgent = `bash -c 'N=$RALPHAI_NONCE; echo "doing nothing"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
 // ---------------------------------------------------------------------------
 // Default single-run behavior
@@ -278,7 +278,7 @@ describe("exit summary", () => {
     const counterFile = join(dir, ".agent-counter");
     writeFileSync(counterFile, "0");
     // Agent that completes on first call, then does nothing on subsequent calls
-    const mixedAgent = `bash -c 'N=$RALPHAI_NONCE; count=$(cat "${counterFile}"); if [ "$count" = "0" ]; then echo 1 > "${counterFile}"; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Do"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"; else echo "doing nothing"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"; fi'`;
+    const mixedAgent = `bash -c 'N=$RALPHAI_NONCE; count=$(cat "${counterFile}"); if [ "$count" = "0" ]; then echo 1 > "${counterFile}"; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Do"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"; else echo "doing nothing"; echo "<learnings nonce=\\"$N\\">none</learnings>"; fi'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({

--- a/src/runner-gate-tuning.test.ts
+++ b/src/runner-gate-tuning.test.ts
@@ -98,7 +98,7 @@ describe("runRunner — gate.maxRejections", () => {
 
     // Agent makes a commit and outputs COMPLETE without completing tasks.
     // With maxRejections=0, the first gate failure should mark stuck.
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -138,7 +138,7 @@ describe("runRunner — gate.maxRejections", () => {
     // The feedback command always fails, so the gate always rejects.
     // With maxRejections=5, it should reject 5 times then force-accept
     // (partial progress since 1/1 tasks done).
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -208,7 +208,7 @@ describe("runRunner — gate.maxIterations", () => {
 
     // Agent makes a commit each time but never claims COMPLETE.
     // With maxIterations=3, should be marked stuck after 3 iterations.
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work iteration"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work iteration"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -245,7 +245,7 @@ describe("runRunner — gate.maxIterations", () => {
 
     // Agent completes the task on first iteration and claims COMPLETE.
     // maxIterations=0 should not interfere.
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({

--- a/src/runner-github-drain.test.ts
+++ b/src/runner-github-drain.test.ts
@@ -92,7 +92,7 @@ async function captureLogs(fn: () => Promise<unknown>): Promise<string> {
   return logs.join("\n");
 }
 
-const completeAgent = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Do"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+const completeAgent = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Do"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
 /**
  * Helper: create a mock pullGithubIssues that writes a NEW plan file to the

--- a/src/runner-review-pass.test.ts
+++ b/src/runner-review-pass.test.ts
@@ -94,7 +94,7 @@ describe("runRunner — review pass", () => {
       "# Plan: Review Disabled\n\n## Implementation Tasks\n\n### Task 1: Test\n",
     );
 
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -136,7 +136,7 @@ describe("runRunner — review pass", () => {
     );
 
     // Agent that outputs COMPLETE (the review pass agent will just be echo)
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -173,7 +173,7 @@ describe("runRunner — review pass", () => {
       "# Plan: No Files\n\n## Implementation Tasks\n\n### Task 1: Test\n",
     );
 
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -214,7 +214,7 @@ describe("runRunner — review pass", () => {
       "# Plan: Review Log Header\n\n## Implementation Tasks\n\n### Task 1: Test\n",
     );
 
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({

--- a/src/runner-zero-completion.test.ts
+++ b/src/runner-zero-completion.test.ts
@@ -88,7 +88,7 @@ describe("runRunner — zero-completion guard", () => {
     // Agent that makes a commit each iteration (avoiding stuck detection)
     // but outputs COMPLETE without updating progress (zero tasks completed).
     // It needs to run 3 times: 1 initial + 2 rejections = exhausts budget.
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "iteration-marker-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work iteration" --allow-empty-message; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "iteration-marker-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work iteration" --allow-empty-message; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -152,7 +152,7 @@ describe("runRunner — zero-completion guard", () => {
     // Agent that makes a commit, reports 1/3 tasks done in progress,
     // and claims COMPLETE. The gate will reject because only 1/3 done,
     // but after exhausting the budget it should force-accept (partial progress).
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "work-$(date +%s%N)" >> work.txt; git add -A; git commit -m "work"; echo "<progress nonce=\\"$N\\">"; echo "- [x] First task"; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({

--- a/src/runner-zero-completion.test.ts
+++ b/src/runner-zero-completion.test.ts
@@ -49,6 +49,22 @@ function setupGlobalPipeline(cwd: string) {
   return { ralphaiHome, ...dirs };
 }
 
+/** Capture console.log output during an async function. */
+async function captureLogs(
+  fn: () => Promise<RunnerResult>,
+): Promise<{ output: string; result: RunnerResult }> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  let result: RunnerResult;
+  try {
+    result = await fn();
+  } finally {
+    console.log = origLog;
+  }
+  return { output: logs.join("\n"), result };
+}
+
 // ---------------------------------------------------------------------------
 // Zero-completion guard tests
 // ---------------------------------------------------------------------------
@@ -104,20 +120,7 @@ describe("runRunner — zero-completion guard", () => {
       drain: false,
     };
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => {
-      logs.push(args.map(String).join(" "));
-    };
-
-    let result: RunnerResult;
-    try {
-      result = await runRunner(opts);
-    } finally {
-      console.log = origLog;
-    }
-
-    const output = logs.join("\n");
+    const { output, result } = await captureLogs(() => runRunner(opts));
 
     // Plan should be marked as stuck, NOT accepted
     expect(result.stuckSlugs).toContain("zero-comp");
@@ -168,18 +171,7 @@ describe("runRunner — zero-completion guard", () => {
       drain: false,
     };
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => {
-      logs.push(args.map(String).join(" "));
-    };
-
-    let result: RunnerResult;
-    try {
-      result = await runRunner(opts);
-    } finally {
-      console.log = origLog;
-    }
+    const { result } = await captureLogs(() => runRunner(opts));
 
     // Plan should NOT be stuck — it should be force-accepted
     expect(result.stuckSlugs).not.toContain("partial-comp");

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -182,7 +182,7 @@ describe("runRunner — completion", () => {
     );
 
     // Agent command that outputs progress, COMPLETE marker, and learnings
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -214,7 +214,7 @@ describe("runRunner — completion", () => {
       "# Plan: Log Test\n\n## Implementation Tasks\n\n### Task 1: Verify logging\n",
     );
 
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "agent-says-hello"; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Verify logging"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "agent-says-hello"; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Verify logging"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -250,7 +250,7 @@ describe("runRunner — completion", () => {
     );
 
     // Agent that does nothing (no commits, no COMPLETE)
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "doing nothing"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "doing nothing"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -315,7 +315,7 @@ describe("runRunner — RunnerResult", () => {
     );
 
     // Agent that does nothing (no commits, no COMPLETE)
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "doing nothing"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "doing nothing"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({
@@ -353,7 +353,7 @@ describe("runRunner — RunnerResult", () => {
       "# Plan: Success\n\n### Task 1: Test\n",
     );
 
-    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\"><entry>status: none</entry></learnings>"'`;
+    const agentScript = `bash -c 'N=$RALPHAI_NONCE; echo "<progress nonce=\\"$N\\">"; echo "### Task 1: Test"; echo "**Status:** Complete"; echo "Done."; echo "</progress>"; echo "<promise nonce=\\"$N\\">COMPLETE</promise>"; echo "<learnings nonce=\\"$N\\">none</learnings>"'`;
 
     const opts: RunnerOptions = {
       config: makeTestResolvedConfig({

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -4,13 +4,7 @@
  * Focuses on key runner behaviors (dry-run, stuck detection, completion detection).
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import {
-  mkdtempSync,
-  mkdirSync,
-  writeFileSync,
-  existsSync,
-  readFileSync,
-} from "fs";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { execSync } from "child_process";
@@ -50,16 +44,24 @@ function createManagedWorktree(mainDir: string, slug: string): string {
  * Sets RALPHAI_HOME to a temp dir so global-state functions resolve there.
  * Returns the pipeline dirs.
  */
-function setupGlobalPipeline(cwd: string): {
-  ralphaiHome: string;
-  backlogDir: string;
-  wipDir: string;
-  archiveDir: string;
-} {
+function setupGlobalPipeline(cwd: string) {
   const ralphaiHome = mkdtempSync(join(tmpdir(), "ralphai-home-"));
   process.env.RALPHAI_HOME = ralphaiHome;
   const dirs = getRepoPipelineDirs(cwd, { RALPHAI_HOME: ralphaiHome });
   return { ralphaiHome, ...dirs };
+}
+
+/** Capture console.log output during an async function. */
+async function captureLogs(fn: () => Promise<unknown>): Promise<string> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+  }
+  return logs.join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -112,16 +114,8 @@ describe("runRunner — dry-run", () => {
       drain: false,
     };
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-    try {
-      await runRunner(opts);
-    } finally {
-      console.log = origLog;
-    }
+    const output = await captureLogs(() => runRunner(opts));
 
-    const output = logs.join("\n");
     // issueSource defaults to "none", so peek.message should appear
     expect(output).toContain("No runnable work found.");
     expect(output).toContain("not 'github'");
@@ -268,19 +262,8 @@ describe("runRunner — completion", () => {
 
     // Stuck plans are now skipped instead of process.exit(1).
     // The runner should exit normally after exhausting the backlog.
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => {
-      logs.push(args.map(String).join(" "));
-    };
+    const output = await captureLogs(() => runRunner(opts));
 
-    try {
-      await runRunner(opts);
-    } finally {
-      console.log = origLog;
-    }
-
-    const output = logs.join("\n");
     expect(output).toContain("Stuck:");
     expect(output).toContain("skipped 1 (stuck)");
     expect(output).toContain("stuck");

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -176,11 +176,37 @@ export function appendProgressBlock(
 
 /**
  * Parse the content of a `<learnings>` block into either a prose string or
- * null. Returns null if the content is the literal string "none"
- * (case-insensitive), only whitespace, or empty. Otherwise returns the
- * trimmed prose text.
+ * null.
+ *
+ * If the block contains one or more `<entry>` tags, each tag's inner text is
+ * extracted and evaluated individually. Entries whose trimmed text is empty or
+ * matches `status: none` (case-insensitive) are discarded. If all entries are
+ * discarded, the function returns null. Otherwise the surviving entry texts are
+ * joined with newlines and returned.
+ *
+ * When no `<entry>` tags are present, the function falls back to the original
+ * behavior: returns null if the trimmed content is empty or equals "none"
+ * (case-insensitive), otherwise returns the trimmed text.
  */
 export function parseLearningContent(block: string): string | null {
+  const entryPattern = /<entry>([\s\S]*?)<\/entry>/gi;
+  const entries: string[] = [];
+  let match: RegExpExecArray | null;
+
+  // Collect all <entry> matches
+  while ((match = entryPattern.exec(block)) !== null) {
+    if (match[1] !== undefined) entries.push(match[1]);
+  }
+
+  if (entries.length > 0) {
+    const real = entries
+      .map((e) => e.trim())
+      .filter((e) => e.length > 0 && e.toLowerCase() !== "status: none");
+    if (real.length === 0) return null;
+    return real.join("\n");
+  }
+
+  // No <entry> tags — fall back to original logic
   const trimmed = block.trim();
   if (trimmed.length === 0) return null;
   if (trimmed.toLowerCase() === "none") return null;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1056,8 +1056,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
 
     // Derive a feedback hint command from hooks.feedback for scope hint text.
     // Uses the first configured command (e.g. "bun test" from "bun test,bun run build").
-    const firstFeedbackCmd = feedbackCommands.split(",")[0]?.trim() ?? "";
-    const feedbackHintCmd = firstFeedbackCmd || "";
+    const feedbackHintCmd = feedbackCommands.split(",")[0]?.trim() ?? "";
 
     // Resolve feedback scope: explicit frontmatter overrides auto-detection.
     const fmFeedbackScope = extractFeedbackScope(planFile);


### PR DESCRIPTION
PRD #476: fix: improve learnings quality — filter junk, tighten prompt, fix test fixtures

## Summary

- **#478:** Hardens `parseLearningContent` in `src/runner.ts` to strip XML `<entry>` wrapper tags that agents sometimes hallucinate instead of writing bare `none`. Entries whose trimmed text is empty or matches `status: none` (case-insensitive) are now discarded, preventing junk bullets from leaking into PR bodies. Blocks with no `<entry>` tags continue to use the original trim-and-none-check logic unchanged.
- **#479:** This PR aligns mock agent scripts in six test files with the prompt-instructed sentinel format by replacing `<entry>status: none</entry>` with the bare word `none` inside `<learnings>` blocks. The change is purely cosmetic for test fixtures — no logic is altered — but ensures consistency between what the prompt instructs agents to output and what the tests actually produce.
- **#480:** Rewrites the learnings prompt instruction in `assemblePrompt()` to discourage session-scoped code-navigation notes and encourage genuinely durable behavioral lessons. The four old example bullets about file paths and API signatures are replaced with explicit negative guidance ("Do NOT log: where a specific file lives, what a function signature looks like...") and a durability quality gate ("would this still be useful if the codebase had changed?"). Tests in `prompt.test.ts` are updated to assert on the new phrases.

Closes #476
Closes #478
Closes #479
Closes #480

## Completed Sub-Issues

- [x] #478
- [x] #479
- [x] #480

## Changes

### Bug Fixes

- tighten learnings instruction — remove code-navigation examples, add negative guidance and quality gate
- strip <entry> tags and filter status: none in parseLearningContent

### Refactoring

- extract captureLogs helper and remove unused import in runner tests
- remove duplicate parseLearningContent tests and fix entry-based none test
- collapse redundant feedbackHintCmd intermediate variable

### Tests

- replace <entry>status: none</entry> with bare none in test fixtures


## Learnings

- The `parseLearningContent` function is a pure export in `src/runner.ts` (around line 183) and its unit tests live in `src/progress.test.ts`. TypeScript's strict mode treats regex capture groups (`match[1]`) as `string | undefined`, so a guard like `if (match[1] !== undefined)` is required before pushing to a `string[]` array — otherwise `tsc --noEmit` raises TS2345. The feedback script runs three commands in sequence: `bun run build`, `bun run test:fast`, and `bun run type-check`; all three must pass before committing.