### PR TITLE
docs: tighten README and reorder workflows GitHub-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ npx skills add mfaux/ralphai -g           # install agent skills (recommended)
 
 ## How It Works
 
-### 1. Label GitHub issues
+### 1. Plan with your agent
 
-Use two labels to tell Ralphai what to work on:
+Use the included skills to turn ideas into GitHub issues your agent can execute:
 
-- **`ralphai-prd`** — for features. Add sub-issues for each piece of work; Ralphai processes them sequentially on one branch and opens a single aggregate PR.
-- **`ralphai-standalone`** — for bugs and small tasks. Each gets its own branch and PR.
+- **Features** — ask your agent to `write-a-prd`, then `prd-to-issues` to decompose it into labeled sub-issues. Ralphai processes them sequentially on one branch and opens a single aggregate PR.
+- **Bugs & small tasks** — ask your agent to `triage-issue` to investigate and create a standalone issue. Each gets its own branch and PR.
 
-Sub-issues support dependencies via GitHub's native blocking relationships. Labels are [configurable](docs/cli-reference.md#config-keys).
+Both skills label the issues automatically (`ralphai-prd` / `ralphai-standalone`). You can also label issues by hand. Labels are [configurable](docs/cli-reference.md#config-keys).
 
 ### 2. Run
 
@@ -78,7 +78,7 @@ Running bare `ralphai` opens a TUI to browse the pipeline, pick issues, and laun
 
 ### Local plan files
 
-You can also drive Ralphai with local markdown files instead of GitHub issues. See [Workflows → Local plan files](docs/workflows.md#local-plan-files). The recommended workflow is GitHub issues: plan with a skill (`write-a-prd`, `triage-issue`), decompose with `prd-to-issues`, then let Ralphai run.
+You can also drive Ralphai with local markdown files instead of GitHub issues — see [Workflows → Local plan files](docs/workflows.md#local-plan-files).
 
 ## Day-to-Day
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,7 @@
 
 Put your AI coding agent on autopilot.
 
-Ralphai takes plans (markdown files) from a backlog and drives any CLI-based coding agent to implement them, with branch isolation, feedback loops, and stuck detection built in. You write the plans, or have your agent write them. Ralphai does the rest.
-
-Requires Node.js 18+ (or Bun/Deno) and a [supported CLI agent](#supported-agents).
-
-## Try It Now
-
-```bash
-npx ralphai init --yes           # configure agent and feedback commands
-npx ralphai                      # open the TUI and run a plan from the backlog
-```
-
-`init --yes` auto-detects installed agents, checking **Claude Code** and **OpenCode** first, then other supported agents. Falls back to OpenCode if none are found. Use `--agent-command=<cmd>` to override (e.g. `--agent-command='claude -p'`).
+Point Ralphai at a GitHub issue. It drives your AI coding agent through fresh-session iterations — with branch isolation, build/test feedback loops, and stuck detection — until the PR is ready.
 
 ## Why Ralphai?
 
@@ -27,205 +16,83 @@ Ralphai avoids this by starting each iteration with a **fresh agent session**: j
 
 [How it works →](docs/how-ralphai-works.md)
 
+## Try It Now
+
+```bash
+npx ralphai init --yes       # auto-detect agent and project setup
+ralphai run 42               # run GitHub issue #42
+```
+
+Ralphai creates an isolated worktree, drives your agent through build/test feedback loops, and opens a draft PR when done. `init --yes` auto-detects installed agents (checking **Claude Code** and **OpenCode** first) and your project's build/test commands.
+
 ## Install
 
+Requires Node.js 18+ (or Bun/Deno) and a [supported CLI agent](#supported-agents).
+
 ```bash
-npm install -g ralphai                          # install the CLI
-npx skills add mfaux/ralphai -g                 # install skills for your coding agent
+npm install -g ralphai                    # install the CLI
+npx skills add mfaux/ralphai -g           # install agent skills (recommended)
 ```
 
-Ralphai ships skills that teach your coding agent how to plan and execute work:
+<details>
+<summary>Included skills</summary>
 
 - **write-a-prd** — create a product requirements document through interactive interview
+- **prd-to-issues** — decompose a PRD into vertical-slice GitHub sub-issues
+- **triage-issue** — investigate bugs and create TDD fix plans
+- **tdd** — test-driven development with red-green-refactor loops
 - **improve-codebase-architecture** — find and propose module-deepening refactors
 - **request-refactor-plan** — plan structural changes with tiny, verifiable commits
-- **triage-issue** — investigate bugs and create TDD fix plans
-- **prd-to-issues** — decompose a PRD into vertical-slice GitHub sub-issues
-- **tdd** — test-driven development with red-green-refactor loops
-- **ralphai-planning** — write Ralphai plan files for autonomous execution
+- **ralphai-planning** — write local plan files for autonomous execution
 
-The recommended workflow: plan with a skill (write-a-prd, triage-issue, etc.), decompose PRDs with prd-to-issues, then let Ralphai run the issues autonomously.
+</details>
 
-## Get Started
+## How It Works
 
-In your project repository:
+### 1. Label GitHub issues
 
-```bash
-ralphai init                 # configure agent and feedback commands
-```
+Use two labels to tell Ralphai what to work on:
 
-Ralphai detects your project ecosystem and build scripts automatically. Supported ecosystems: **Node.js/TypeScript** and **C# / .NET** (full support, including monorepo workspace scoping), **Go**, **Rust**, **Python**, and **Java/Kotlin** (basic detection with auto-suggested build/test commands). When multiple ecosystems coexist (e.g., a .NET backend with a Node.js frontend), Ralphai detects all of them and merges their feedback commands. Use `--yes` to skip prompts and auto-detect your installed agent.
+- **`ralphai-prd`** — for features. Add sub-issues for each piece of work; Ralphai processes them sequentially on one branch and opens a single aggregate PR.
+- **`ralphai-standalone`** — for bugs and small tasks. Each gets its own branch and PR.
 
-Configuration and pipeline state are stored in `~/.ralphai/` (global state, not in your repo). See [Workflows](docs/workflows.md) for details.
+Sub-issues support dependencies via GitHub's native blocking relationships. Labels are [configurable](docs/cli-reference.md#config-keys).
 
-## Workflow
-
-### 1. Write plans
-
-Ask your coding agent to create plan files in the Ralphai backlog. If you installed the skills, the agent already knows the format and output directory.
-
-```
-Create a Ralphai plan for adding dark mode support.
-```
-
-### 2. Use the TUI
-
-For day-to-day use, start with the interactive menu:
+### 2. Run
 
 ```bash
-ralphai
+ralphai run 42               # run a specific issue (PRD or standalone)
+ralphai run --drain           # process all eligible issues until the queue is empty
+ralphai run --dry-run         # preview without changing anything
 ```
 
-This shows a pipeline summary header and an interactive menu. From here you can run the next queued plan, pick a specific plan from the backlog, or view pipeline status.
+Each run creates an isolated [worktree](docs/worktrees.md) on a conventional `<type>/<slug>` branch, iterates the agent with fresh build/test feedback, and opens a draft PR when done. Stuck sub-issues are skipped so progress continues.
 
-`ralphai` is the primary workflow for humans. Use it to browse the pipeline, inspect progress, and launch actions without remembering subcommands.
+### 3. Review the PR
 
-### 3. Run headlessly
+Ralphai surfaces extracted **learnings** in the draft PR — patterns the agent discovered during implementation. Promote useful ones to `AGENTS.md` or skill docs. [More on learnings →](docs/how-ralphai-works.md#learnings-system)
 
-Ralphai always creates or reuses a managed worktree on a **`<type>/<slug>`** branch (e.g. `feat/add-dark-mode`, `fix/broken-login`), so there is no need to create a feature branch yourself.
+### Interactive mode
+
+Running bare `ralphai` opens a TUI to browse the pipeline, pick issues, and launch runs without memorizing subcommands.
+
+### Local plan files
+
+You can also drive Ralphai with local markdown files instead of GitHub issues. See [Workflows → Local plan files](docs/workflows.md#local-plan-files). The recommended workflow is GitHub issues: plan with a skill (`write-a-prd`, `triage-issue`), decompose with `prd-to-issues`, then let Ralphai run.
+
+## Day-to-Day
 
 ```bash
-ralphai run
-```
-
-Each run creates or reuses an isolated worktree, works on a `<type>/<slug>` branch (conventional commit style), runs build/test/lint, commits, pushes, and opens a draft PR when `gh` is available.
-
-```bash
-ralphai run              # process one eligible work unit
-ralphai run 42           # run GitHub issue #42 (PRD or standalone)
-ralphai run --drain      # keep processing work until empty
+ralphai                  # open the interactive menu
+ralphai status           # see what's queued, running, and completed
+ralphai stop             # stop the active runner (or --all)
 ralphai run --resume     # commit dirty state and continue
-ralphai run --dry-run    # preview without changing anything
-```
-
-Ralphai already uses [git worktrees](docs/worktrees.md) for every run. Use `ralphai clean --worktrees` to remove completed or orphaned worktrees.
-
-Use `ralphai run` when you want a non-interactive command, such as automation, quick terminal execution, or resuming work directly.
-
-### 4. Steer
-
-Plans flow through the pipeline:
-
-```
-parked/    backlog/  →  in-progress/  →  out/
-```
-
-Park unready plans in `parked/`. Ralphai ignores that folder.
-Plans are flat `.md` files in `backlog/` (for example `backlog/my-plan.md`). The runner creates a slug folder automatically when moving a plan to `in-progress/`.
-
-### 5. Pause, stop, and resume
-
-**Headless (`ralphai run`):** Press Ctrl-C to stop the runner. It finishes the current iteration cleanly, then exits. Work is preserved in `in-progress/<slug>/`.
-
-**Stop a runner:** Use `ralphai stop` to send SIGTERM to running plan runners. Pass a plan slug to stop a specific runner, or use `--all` to stop all runners. Use `--dry-run` to preview which processes would be stopped.
-
-**Resuming:** Reopen `ralphai` or run `ralphai run` to pick up where the agent left off. Ralphai auto-detects in-progress work. Use `--resume` to commit any dirty working tree state before continuing.
-
-```bash
-ralphai status           # see what's queued, in progress, and any problems
-ralphai stop             # stop the running plan runner (auto-selects if only one)
-ralphai stop my-plan     # stop a specific plan runner by slug
-ralphai stop --all       # stop all running plan runners
-ralphai doctor           # validate your setup (agent, feedback commands, config)
-ralphai reset            # reset in-progress plans (local -> backlog, GH -> removed)
+ralphai doctor           # validate setup (agent, feedback, config, git)
+ralphai reset            # reset stuck plans
 ralphai clean            # remove archived plans and orphaned worktrees
-ralphai clean --archive  # clean only archived plans
-ralphai clean --worktrees # clean only orphaned worktrees
 ```
 
-### 6. Close the learnings loop
-
-Ralphai extracts learnings from the agent's output during each run and surfaces them in the **Learnings** section of the draft PR. Review them when reviewing the PR and promote useful lessons to `AGENTS.md` or skill docs. [More on learnings ->](docs/how-ralphai-works.md#learnings-system)
-
-## GitHub Issues & PRDs
-
-For multi-step features, **PRDs (Product Requirements Documents)** are the recommended way to work. Create a GitHub issue, label it with the PRD label (`ralphai-prd` by default, configurable via `prdLabel`), and add sub-issues for each piece of work. Then point Ralphai at it:
-
-```bash
-ralphai run 42           # run PRD #42: all sub-issues on one branch
-```
-
-Ralphai processes sub-issues sequentially on a single `feat/<prd-slug>` branch, skips any that get stuck, and opens one aggregate draft PR when done. Sub-issues support dependencies via GitHub's native blocking relationships.
-
-For **standalone issues** — one-off bugs, small tasks — label them with `ralphai-standalone` (configurable via `standaloneLabel`) and either target them directly or let the drain loop pick them up:
-
-```bash
-ralphai run 57           # run standalone issue #57
-ralphai run              # auto-pulls from GitHub when the backlog is empty
-```
-
-Each standalone issue gets its own branch and PR, the same as a local plan file.
-
-Both workflows require the `gh` CLI and `issueSource: "github"` in config. Ralphai creates 6 GitHub labels — 3 family labels (`standaloneLabel`, `subissueLabel`, `prdLabel`) plus 3 shared state labels (`in-progress`, `done`, `stuck`). Family labels are configurable via `config.json` or environment variables. See the [CLI Reference](docs/cli-reference.md#config-keys) for all options.
-
-## Multi-Repo Management
-
-Ralphai tracks every initialized repo automatically. Run `ralphai repos` from anywhere to see all known repos with pipeline summaries, or use `--repo` to target a specific repo without `cd`-ing into it.
-
-```bash
-ralphai repos                           # list all known repos with plan counts
-ralphai repos --clean                   # remove stale entries (dead paths, no plans)
-ralphai status --repo=my-app            # check status of a different repo
-ralphai config backlog-dir --repo=~/work/api  # get backlog path by repo path
-```
-
-The `--repo` flag works with `status`, `reset`, `clean`, `uninstall`, `doctor`, `config`. It is blocked for `run` and `init`, which must be run inside the target repo.
-
-## Interactive Menu
-
-Running bare `ralphai` in a terminal launches an interactive menu with a pipeline summary header showing plan counts (backlog, running, completed). From the menu you can:
-
-- **Run next plan** — auto-detects the next ready plan (respecting dependency ordering) and hands off to the runner. When the backlog is empty but GitHub issues are configured, it will pull from GitHub.
-- **Pick from backlog** — browse all backlog plans with scope and dependency info, then select one to run.
-- **View pipeline status** — display detailed pipeline status.
-- **Doctor** — run health checks (agent, feedback commands, config, git).
-- **Clean worktrees** — remove archived plans and orphaned worktrees.
-- **View config** — display the fully resolved configuration with source tracking.
-- **Edit config** — re-run the init wizard to update settings.
-
-```bash
-ralphai                  # launches the interactive menu (TTY only)
-```
-
-The menu re-gathers pipeline state before each display so data is always fresh. Selecting a run action hands off to the runner (the menu does not re-appear). Ctrl+C or selecting "Quit" exits cleanly. If you run `ralphai` in an un-initialized repo, it offers to run `ralphai init` first, then proceeds to the menu.
-
-For most people, this is the main way to use Ralphai. Reach for `ralphai run` when you want headless execution.
-
-## Manage Your Installation
-
-```bash
-ralphai update           # update to the latest version
-ralphai uninstall        # remove Ralphai from this project
-ralphai uninstall --global  # remove all global state and uninstall the CLI
-```
-
-## Monorepo Support
-
-`ralphai init` automatically detects workspace packages from `pnpm-workspace.yaml`, the `workspaces` field in `package.json`, or `.sln` files (for .NET projects). In mixed repos (e.g., Node.js + .NET), workspaces from both ecosystems are merged. Both `--yes` and interactive modes display detected workspaces and rely on automatic scope filtering at runtime.
-
-Plans can target a specific package by adding `scope` to the frontmatter:
-
-```md
----
-scope: packages/web
----
-```
-
-When a plan has a scope, Ralphai rewrites feedback commands to target the scoped package. For Node.js, this uses the package manager's workspace filter (e.g., `pnpm --filter @org/web build`). For .NET, the project path is appended to dotnet commands (e.g., `dotnet build src/Api`).
-
-`ralphai status` annotates each plan with its scope when declared, and `ralphai doctor` validates per-workspace feedback commands when a `workspaces` config exists (failures produce warnings, not hard errors).
-
-For custom per-package overrides, add a `workspaces` key to `config.json`:
-
-```json
-{
-  "workspaces": {
-    "packages/web": {
-      "feedbackCommands": ["pnpm --filter web build", "pnpm --filter web test"]
-    }
-  }
-}
-```
+Press **Ctrl-C** during a headless run to stop cleanly after the current iteration. Work is preserved and `ralphai run` picks up where it left off.
 
 ## Supported Agents
 
@@ -251,8 +118,9 @@ Ralphai works with any CLI agent that accepts a prompt argument. **Claude Code**
 
 - [CLI Reference](docs/cli-reference.md) — all commands, flags, and configuration
 - [How Ralphai Works](docs/how-ralphai-works.md) — context rot, feedback loops, stuck detection
-- [Worktrees](docs/worktrees.md) — parallel runs in isolated directories
+- [Hooks, Gates, and Prompt Controls](docs/hooks.md) — advanced customization
 - [Workflows](docs/workflows.md) — common patterns and recipes
+- [Worktrees](docs/worktrees.md) — parallel runs in isolated directories
 - [Troubleshooting](docs/troubleshooting.md) — common issues and fixes
 
 ## Acknowledgements
@@ -261,6 +129,7 @@ Ralphai works with any CLI agent that accepts a prompt argument. **Claude Code**
 - [Getting Started With Ralph](https://www.aihero.dev/getting-started-with-ralph) by Matt Pocock
 - [mattpocock/skills](https://github.com/mattpocock/skills) — inspiration for the planning and TDD skills
 - [Sandcastle](https://github.com/ai-hero/sandcastle) by AI Hero — demonstrated the ephemeral-container-per-invocation pattern for agent sandboxing
+- [Caveman](https://github.com/JuliusBrussee/caveman) by Julius Brussee — inspiration for the caveman communication skill
 - [Vercel CLI](https://github.com/vercel/vercel) for CLI DX inspiration
 
 ## License

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -4,24 +4,6 @@ Common patterns for working with Ralphai. Each recipe shows the command and what
 
 Back to the [README](../README.md) for setup and quickstart. See the [CLI Reference](cli-reference.md) for all flags.
 
-## Browse plans with the interactive menu
-
-```bash
-ralphai
-```
-
-Running `ralphai` with no arguments in a terminal opens the interactive menu. The menu is organized into groups — **START**, **MANAGE**, and **TOOLS** — with hotkeys for quick action. Use arrow keys to navigate, **Enter** to select, and **Esc** to go back from sub-screens. On wide terminals (≥120 columns), a contextual detail pane shows information about the highlighted item. Press **q** to quit.
-
-This is the primary workflow for humans. Use it to browse the backlog, inspect pipeline state, and launch runs without switching commands.
-
-## Drain the backlog
-
-```bash
-ralphai run
-```
-
-Processes one eligible work unit, creating or reusing the matching branch and PR. Use `--drain` to keep processing dependency-ready plans sequentially until the queue is empty. When the backlog is empty, Ralphai checks for PRD sub-issues, then regular GitHub issues. HITL-labeled sub-issues are skipped during auto-drain.
-
 ## Work from a PRD (recommended for features)
 
 For multi-step features, create a PRD (Product Requirements Document) on GitHub:
@@ -73,6 +55,43 @@ On clean exit (code 0), the HITL label is removed and `done` is added. On abnorm
 
 ```bash
 ralphai hitl 55 --dry-run    # preview without spawning agent or touching labels
+```
+
+## Drain the backlog
+
+```bash
+ralphai run --drain
+```
+
+Processes dependency-ready plans sequentially until the queue is empty. When the local backlog is empty, Ralphai checks for PRD sub-issues, then regular GitHub issues. HITL-labeled sub-issues are skipped during auto-drain.
+
+## Browse plans with the interactive menu
+
+```bash
+ralphai
+```
+
+Running `ralphai` with no arguments in a terminal opens the interactive menu. The menu is organized into groups — **START**, **MANAGE**, and **TOOLS** — with hotkeys for quick action. Use arrow keys to navigate, **Enter** to select, and **Esc** to go back from sub-screens. On wide terminals (≥120 columns), a contextual detail pane shows information about the highlighted item. Press **q** to quit.
+
+This is the primary workflow for humans. Use it to browse the backlog, inspect pipeline state, and launch runs without switching commands.
+
+## Local plan files
+
+You can drive Ralphai with local markdown files instead of GitHub issues. Place `.md` files in the backlog directory and Ralphai processes them the same way — branch isolation, feedback loops, draft PRs.
+
+Plans flow through the pipeline:
+
+```
+parked/    backlog/  →  in-progress/  →  out/
+```
+
+Park unready plans in `parked/`. Ralphai ignores that folder. Plans are flat `.md` files in `backlog/` (for example `backlog/my-plan.md`). The runner creates a slug folder automatically when moving a plan to `in-progress/`.
+
+Ask your coding agent to create plan files using the `ralphai-planning` skill, or write them by hand. Configuration and pipeline state are stored in `~/.ralphai/` (global state, not in your repo).
+
+```bash
+ralphai run                      # process the next queued plan
+ralphai run --plan=dark-mode.md  # target a specific plan
 ```
 
 ## Parallel runs
@@ -206,14 +225,6 @@ ralphai run
 ```
 
 Drains the entire backlog on one worktree per plan and opens/updates a draft PR for each. Stuck detection (`--gate-max-stuck`, default 3 consecutive iterations with no commits) skips runaway plans and continues to the next.
-
-## Work on a specific plan
-
-```bash
-ralphai run --plan=dark-mode.md
-```
-
-Targets a specific backlog plan instead of letting Ralphai pick. Creates an isolated worktree with a `feat/dark-mode` branch (type derived from the plan title).
 
 ## Manage multiple repos
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -6,10 +6,10 @@ Back to the [README](../README.md) for setup and quickstart. See the [CLI Refere
 
 ## Work from a PRD (recommended for features)
 
-For multi-step features, create a PRD (Product Requirements Document) on GitHub:
+For multi-step features, use the planning skills to go from idea to executable issues:
 
-1. Create a GitHub issue for the feature. Label it with the PRD label (`ralphai-prd` by default, configurable via `issue.prdLabel`).
-2. Add sub-issues for each piece of work. Use GitHub's native blocking relationships for ordering.
+1. Ask your agent to **`write-a-prd`** — it interviews you and creates a PRD as a GitHub issue, labeled `ralphai-prd`.
+2. Ask your agent to **`prd-to-issues`** — it decomposes the PRD into vertical-slice sub-issues with GitHub blocking relationships for ordering.
 3. Point Ralphai at the PRD:
 
 ```bash
@@ -18,11 +18,13 @@ ralphai run 42           # issue #42: detected as PRD via label, processes sub-i
 
 Ralphai creates a single worktree on a `feat/<prd-slug>` branch and processes sub-issues one at a time. Stuck sub-issues are skipped — the PRD continues to the next. Sub-issues labeled with the HITL label (`ralphai-subissue-hitl` by default, configurable via `issue.hitlLabel`) are also skipped — they require human review. Sub-issues that depend on a HITL sub-issue are skipped as blocked. When all sub-issues are done (or skipped), Ralphai opens one aggregate draft PR listing completed, stuck, HITL, and blocked items.
 
+You can also create PRD issues and sub-issues by hand — just apply the `ralphai-prd` label (configurable via `issue.prdLabel`) and add sub-issues. The skills automate this.
+
 The interactive menu also supports PRDs: select "Pick from GitHub" (or press **g**) and PRD issues appear with their sub-issue tree.
 
 ## Run a single GitHub issue
 
-For one-off bugs or small tasks, label a GitHub issue with `ralphai-standalone` (configurable via `issue.standaloneLabel`) and target it directly:
+For one-off bugs or small tasks, ask your agent to **`triage-issue`** — it investigates the problem and creates a labeled standalone issue. Or label any GitHub issue with `ralphai-standalone` (configurable via `issue.standaloneLabel`) and target it directly:
 
 ```bash
 ralphai run 57           # run standalone issue #57: one branch, one PR


### PR DESCRIPTION
## Summary

Rewrites the README to be shorter and GitHub-issue-workflow-first. Reorders `docs/workflows.md` to match.

### README changes (270 → 137 lines)

- **Lead with GitHub issues** as THE workflow instead of local plan files
- New sub-headline: *"Point Ralphai at a GitHub issue…"*
- Quickstart now shows `ralphai run 42` (issue workflow) instead of the TUI
- Collapse skills list into a `<details>` block
- Cut sections moved to docs/: multi-repo, monorepo, interactive menu detail, pipeline dirs
- Add `docs/hooks.md` to Reference links
- Local plan files: one-sentence footnote with link to workflows.md
- Add Julius Brussee / Caveman acknowledgment

### workflows.md changes

- **Reorder sections**: PRD → standalone → HITL → drain → TUI → local plans (was: TUI → drain → PRD → …)
- **Add `Local plan files` section** with pipeline directory content (`parked/ → backlog/ → in-progress/ → out/`) moved from README
- `Drain the backlog` updated to show `--drain` flag directly