### PR TITLE
fix: TUI backlog picker produces invalid --plan flag format

### DIFF
--- a/src/tui/run-tui.test.ts
+++ b/src/tui/run-tui.test.ts
@@ -6,7 +6,7 @@
  * deferred until `ink-testing-library` is available.
  */
 
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach } from "bun:test";
 import type { Screen } from "./types.ts";
 import type { ConfirmData } from "./screens/confirm.tsx";
 

--- a/src/tui/run-tui.test.ts
+++ b/src/tui/run-tui.test.ts
@@ -101,7 +101,7 @@ describe("Screen confirm variant", () => {
       agentCommand: "",
       branch: "feat/plan",
       feedbackCommands: "",
-      runArgs: ["run", "--plan", "plan.md"],
+      runArgs: ["run", "--plan=plan.md"],
     };
 
     const screen: Screen = {
@@ -149,12 +149,12 @@ describe("exit-to-runner dispatch flow", () => {
       agentCommand: "claude",
       branch: "feat/test",
       feedbackCommands: "",
-      runArgs: ["run", "--plan", "test.md"],
+      runArgs: ["run", "--plan=test.md"],
     };
 
     const result = { type: "exit-to-runner" as const, args: data.runArgs };
     expect(result.type).toBe("exit-to-runner");
-    expect(result.args).toEqual(["run", "--plan", "test.md"]);
+    expect(result.args).toEqual(["run", "--plan=test.md"]);
   });
 
   it("confirm screen Esc produces navigate back to menu", () => {

--- a/src/tui/screens/backlog-picker.test.ts
+++ b/src/tui/screens/backlog-picker.test.ts
@@ -159,7 +159,7 @@ describe("backlogPickerSelect", () => {
 
     expect(result).toEqual({
       type: "exit-to-runner",
-      args: ["run", "--plan", "feat-login.md"],
+      args: ["run", "--plan=feat-login.md"],
     });
   });
 
@@ -176,7 +176,23 @@ describe("backlogPickerSelect", () => {
 
     expect(result).toEqual({
       type: "exit-to-runner",
-      args: ["run", "--plan", "gh-42-add-feature.md"],
+      args: ["run", "--plan=gh-42-add-feature.md"],
     });
+  });
+
+  it("produces args compatible with CLI --plan= validator", () => {
+    // The CLI argument validator (in ralphai.ts) uses /^--plan=/ to recognize
+    // the plan flag. Verify that backlogPickerSelect produces args that match
+    // this pattern, preventing "Unrecognized argument: --plan" errors.
+    const result = backlogPickerSelect("feat-login.md");
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("exit-to-runner");
+
+    if (result!.type === "exit-to-runner") {
+      const planArg = result!.args.find((a: string) => a !== "run");
+      expect(planArg).toBeDefined();
+      expect(/^--plan=/.test(planArg!)).toBe(true);
+      expect(planArg).toBe("--plan=feat-login.md");
+    }
   });
 });

--- a/src/tui/screens/backlog-picker.tsx
+++ b/src/tui/screens/backlog-picker.tsx
@@ -82,7 +82,7 @@ export function buildBacklogPickerItems(
 /**
  * Map a selected backlog picker value to a `DispatchResult`.
  *
- * Returns `exit-to-runner` with `["run", "--plan", filename]` for valid
+ * Returns `exit-to-runner` with `["run", "--plan=<filename>"]` for valid
  * plan filenames. Returns `null` for the back sentinel or unexpected
  * values.
  */
@@ -90,7 +90,7 @@ export function backlogPickerSelect(value: string): DispatchResult | null {
   if (value === "__back__") return null;
   if (!value) return null;
 
-  return { type: "exit-to-runner", args: ["run", "--plan", value] };
+  return { type: "exit-to-runner", args: ["run", `--plan=${value}`] };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tui/screens/confirm.test.ts
+++ b/src/tui/screens/confirm.test.ts
@@ -27,7 +27,7 @@ function makeData(overrides?: Partial<ConfirmData>): ConfirmData {
     agentCommand: "claude-code",
     branch: "ralphai/feat-login",
     feedbackCommands: "bun run build && bun run test",
-    runArgs: ["run", "--plan", "feat-login.md"],
+    runArgs: ["run", "--plan=feat-login.md"],
     ...overrides,
   };
 }
@@ -223,11 +223,11 @@ describe("confirmKeyHandler", () => {
 describe("resolveConfirmIntent", () => {
   describe("confirm intent", () => {
     it("returns exit-to-runner with the data's runArgs", () => {
-      const data = makeData({ runArgs: ["run", "--plan", "my-plan.md"] });
+      const data = makeData({ runArgs: ["run", "--plan=my-plan.md"] });
       const result = resolveConfirmIntent("confirm", data, { type: "menu" });
       expect(result).toEqual({
         type: "exit-to-runner",
-        args: ["run", "--plan", "my-plan.md"],
+        args: ["run", "--plan=my-plan.md"],
       });
     });
 

--- a/src/tui/screens/options.test.ts
+++ b/src/tui/screens/options.test.ts
@@ -41,7 +41,7 @@ function makeData(overrides?: Partial<ConfirmData>): ConfirmData {
     agentCommand: "claude-code",
     branch: "ralphai/feat-login",
     feedbackCommands: "bun run build && bun run test",
-    runArgs: ["run", "--plan", "feat-login.md"],
+    runArgs: ["run", "--plan=feat-login.md"],
     ...overrides,
   };
 }
@@ -126,11 +126,11 @@ describe("optionsKeyHandler", () => {
 describe("resolveOptionsIntent", () => {
   describe("confirm intent", () => {
     it("returns exit-to-runner with the data's runArgs", () => {
-      const data = makeData({ runArgs: ["run", "--plan", "my-plan.md"] });
+      const data = makeData({ runArgs: ["run", "--plan=my-plan.md"] });
       const result = resolveOptionsIntent("confirm", data, { type: "menu" });
       expect(result).toEqual({
         type: "exit-to-runner",
-        args: ["run", "--plan", "my-plan.md"],
+        args: ["run", "--plan=my-plan.md"],
       });
     });
 
@@ -286,28 +286,24 @@ describe("buildCheckboxItems", () => {
 describe("mergeWizardFlags", () => {
   it("inserts flags after 'run' in runArgs", () => {
     const result = mergeWizardFlags(
-      ["run", "--plan", "test.md"],
+      ["run", "--plan=test.md"],
       ["--gate-max-stuck=5", "--base-branch=dev"],
     );
     expect(result).toEqual([
       "run",
       "--gate-max-stuck=5",
       "--base-branch=dev",
-      "--plan",
-      "test.md",
+      "--plan=test.md",
     ]);
   });
 
   it("inserts flags at the start when no 'run' in args", () => {
-    const result = mergeWizardFlags(
-      ["--plan", "test.md"],
-      ["--gate-max-stuck=5"],
-    );
-    expect(result).toEqual(["--gate-max-stuck=5", "--plan", "test.md"]);
+    const result = mergeWizardFlags(["--plan=test.md"], ["--gate-max-stuck=5"]);
+    expect(result).toEqual(["--gate-max-stuck=5", "--plan=test.md"]);
   });
 
   it("returns original args unchanged when no wizard flags", () => {
-    const original = ["run", "--plan", "test.md"];
+    const original = ["run", "--plan=test.md"];
     const result = mergeWizardFlags(original, []);
     expect(result).toEqual(original);
     // Should be a new array, not the same reference
@@ -325,7 +321,7 @@ describe("mergeWizardFlags", () => {
   });
 
   it("does not modify the original runArgs array", () => {
-    const original = ["run", "--plan", "test.md"];
+    const original = ["run", "--plan=test.md"];
     const originalCopy = [...original];
     mergeWizardFlags(original, ["--gate-max-stuck=5"]);
     expect(original).toEqual(originalCopy);
@@ -341,10 +337,10 @@ describe("resolveWizardResult", () => {
     const values: Partial<Record<WizardConfigKey, string>> = {
       "gate.maxStuck": "5",
     };
-    const result = resolveWizardResult(values, ["run", "--plan", "test.md"]);
+    const result = resolveWizardResult(values, ["run", "--plan=test.md"]);
     expect(result).toEqual({
       type: "exit-to-runner",
-      args: ["run", "--gate-max-stuck=5", "--plan", "test.md"],
+      args: ["run", "--gate-max-stuck=5", "--plan=test.md"],
     });
   });
 
@@ -475,7 +471,7 @@ describe("wizard flow: pure logic end-to-end", () => {
       "gate.maxStuck": "10",
       sandbox: "docker",
     };
-    const runArgs = ["run", "--plan", "my-feature.md"];
+    const runArgs = ["run", "--plan=my-feature.md"];
 
     const result = resolveWizardResult(values, runArgs);
 
@@ -483,11 +479,10 @@ describe("wizard flow: pure logic end-to-end", () => {
     if (result.type === "exit-to-runner") {
       expect(result.args).toContain("--gate-max-stuck=10");
       expect(result.args).toContain("--sandbox=docker");
-      expect(result.args).toContain("--plan");
-      expect(result.args).toContain("my-feature.md");
-      // Wizard flags should appear before --plan
+      expect(result.args).toContain("--plan=my-feature.md");
+      // Wizard flags should appear before --plan=
       const maxStuckIdx = result.args.indexOf("--gate-max-stuck=10");
-      const planIdx = result.args.indexOf("--plan");
+      const planIdx = result.args.indexOf("--plan=my-feature.md");
       expect(maxStuckIdx).toBeLessThan(planIdx);
     }
   });

--- a/src/tui/types.test.ts
+++ b/src/tui/types.test.ts
@@ -214,15 +214,6 @@ describe("resolveAction", () => {
       }
     }
   });
-
-  it("no action returns undefined", () => {
-    for (const action of ACTION_TYPES) {
-      if (isActionType(action)) {
-        const result = resolveAction(action);
-        expect(result).not.toBeUndefined();
-      }
-    }
-  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tui/types.test.ts
+++ b/src/tui/types.test.ts
@@ -340,14 +340,14 @@ describe("titleFromRunArgs", () => {
     expect(titleFromRunArgs(["run", "42"])).toBe("Issue #42");
   });
 
-  it('returns plan filename for ["run", "--plan", "feat-login.md"]', () => {
-    expect(titleFromRunArgs(["run", "--plan", "feat-login.md"])).toBe(
+  it('returns plan filename for ["run", "--plan=feat-login.md"]', () => {
+    expect(titleFromRunArgs(["run", "--plan=feat-login.md"])).toBe(
       "feat-login.md",
     );
   });
 
   it("handles --plan with complex filenames", () => {
-    expect(titleFromRunArgs(["run", "--plan", "gh-42-add-feature.md"])).toBe(
+    expect(titleFromRunArgs(["run", "--plan=gh-42-add-feature.md"])).toBe(
       "gh-42-add-feature.md",
     );
   });
@@ -415,7 +415,7 @@ describe("branchFromRunArgs", () => {
   it('returns "(auto)" for any args', () => {
     expect(branchFromRunArgs(["run"])).toBe("(auto)");
     expect(branchFromRunArgs(["run", "42"])).toBe("(auto)");
-    expect(branchFromRunArgs(["run", "--plan", "feat.md"])).toBe("(auto)");
+    expect(branchFromRunArgs(["run", "--plan=feat.md"])).toBe("(auto)");
   });
 });
 
@@ -448,11 +448,11 @@ describe("buildConfirmDataFromArgs", () => {
 
   it("builds ConfirmData for plan run", () => {
     const data = buildConfirmDataFromArgs(
-      ["run", "--plan", "feat-login.md"],
+      ["run", "--plan=feat-login.md"],
       config,
     );
     expect(data.title).toBe("feat-login.md");
-    expect(data.runArgs).toEqual(["run", "--plan", "feat-login.md"]);
+    expect(data.runArgs).toEqual(["run", "--plan=feat-login.md"]);
   });
 
   it("uses config values for agent and feedback", () => {
@@ -534,7 +534,7 @@ describe("toConfirmNav", () => {
   it("sets backScreen to backlog-picker for backlog selections", () => {
     const result: DispatchResult = {
       type: "exit-to-runner",
-      args: ["run", "--plan", "feat.md"],
+      args: ["run", "--plan=feat.md"],
     };
     const backScreen: Screen = { type: "backlog-picker" };
     const converted = toConfirmNav(result, config, backScreen);
@@ -569,7 +569,7 @@ describe("toConfirmNav", () => {
   it("builds correct ConfirmData from run args and config", () => {
     const result: DispatchResult = {
       type: "exit-to-runner",
-      args: ["run", "--plan", "my-plan.md"],
+      args: ["run", "--plan=my-plan.md"],
     };
     const converted = toConfirmNav(result, config, { type: "backlog-picker" });
 
@@ -579,7 +579,7 @@ describe("toConfirmNav", () => {
         agentCommand: "claude-code",
         branch: "(auto)",
         feedbackCommands: "bun test",
-        runArgs: ["run", "--plan", "my-plan.md"],
+        runArgs: ["run", "--plan=my-plan.md"],
       });
     }
   });
@@ -755,7 +755,7 @@ describe("transition flows", () => {
     // Simulates what backlogPickerSelect returns
     const pickerResult: DispatchResult = {
       type: "exit-to-runner",
-      args: ["run", "--plan", "feat-login.md"],
+      args: ["run", "--plan=feat-login.md"],
     };
     const confirmNav = toConfirmNav(pickerResult, config, {
       type: "backlog-picker",

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -199,7 +199,7 @@ export interface RunConfig {
  *
  * - `["run"]` → next plan name from state, or "Auto-detect (next plan)"
  * - `["run", "42"]` → "Issue #42"
- * - `["run", "--plan", "feat-login.md"]` → "feat-login.md"
+ * - `["run", "--plan=feat-login.md"]` → "feat-login.md"
  *
  * When `state` is provided and the args indicate auto-detection,
  * resolves the actual next plan name using the same dependency-aware
@@ -219,10 +219,10 @@ export function titleFromRunArgs(
     return "Auto-detect (next plan)";
   }
 
-  // --plan <filename>
-  const planIdx = rest.indexOf("--plan");
-  if (planIdx !== -1 && planIdx + 1 < rest.length) {
-    return rest[planIdx + 1]!;
+  // --plan=<filename> (equals-sign format, matching CLI validator)
+  const planArg = rest.find((a) => a.startsWith("--plan="));
+  if (planArg) {
+    return planArg.slice("--plan=".length);
   }
 
   // Bare number → issue
@@ -241,7 +241,7 @@ export function titleFromRunArgs(
  *
  * - `["run"]` → "(auto)"
  * - `["run", "42"]` → "(auto)"
- * - `["run", "--plan", "feat-login.md"]` → "(auto)"
+ * - `["run", "--plan=feat-login.md"]` → "(auto)"
  */
 export function branchFromRunArgs(_args: string[]): string {
   return "(auto)";


### PR DESCRIPTION
Fix the TUI backlog picker to produce `--plan=<file>` (equals-sign format) instead of `--plan <file>` (space-separated format), which the CLI argument validator rejected as an unrecognized argument. Also updates `titleFromRunArgs()` to parse the corrected format and aligns all TUI test assertions with the fix.

Closes #491

## Changes

### Bug Fixes

- use --plan=<file> format in backlog picker to match CLI validator

### Refactoring

- remove unused imports and redundant test in TUI test files


## Learnings

- When a CLI tool uses a specific flag format (like `--flag=value` validated by regex), all code paths that construct those flags — including TUI components, wizards, and helpers — must produce the exact same format. Tests that encode the wrong format will pass in isolation but mask integration-level bugs. Adding at least one test that validates against the actual CLI pattern (e.g., checking `/^--plan=/` matches the produced arg) catches this class of mismatch.


<details><summary>Session context</summary>

- - `backlogPickerSelect()` is in `src/tui/screens/backlog-picker.tsx:89` — produces the args array when a plan is selected
- `titleFromRunArgs()` is in `src/tui/types.ts:209` — extracts human-readable title from run args
- `mergeWizardFlags()` is in `src/tui/screens/options.tsx:160` — splices wizard flags into args after "run"; didn't need code changes since it just does positional splicing, but tests needed format updates
- CLI validator: `isRecognizedRunFlag()` at `src/ralphai.ts:1704`, uses `RUN_FLAG_PATTERNS_EXTRA = [/^--plan=/, /^--tags=/]` at line 1666
- `validateRunArgs()` at `src/ralphai.ts:1710` — calls `isRecognizedRunFlag` for each arg, exits on failure
- `branchFromRunArgs()` at types.ts:246 — always returns "(auto)", only doc comment needed updating
- Test files touched: backlog-picker.test.ts, types.test.ts, confirm.test.ts, options.test.ts, run-tui.test.ts (7 files total including source)
- The `DispatchResult` type is a discriminated union; accessing `.args` requires narrowing via `.type === "exit-to-runner"` first

</details>


---

*A review pass was run to simplify the implementation.*