### PR TITLE
feat: Implement 'Resume Stalled Plan' TUI screen

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -88,7 +88,7 @@ Some menu actions open sub-screens instead of exiting the TUI:
 - **Pick from GitHub** — list of open GitHub issues (standalone + PRD)
 - **Run with options** — config wizard to override run options before launch
 - **Confirm** — review run details (target, agent, feedback commands) before launching
-- **Stop / Reset / Status / Doctor / Clean** — inline sub-screens for pipeline management
+- **Stop / Reset / Status / Doctor / Clean / Resume stalled** — inline sub-screens for pipeline management
 
 Press `Esc` to return from any sub-screen to the main menu.
 
@@ -437,22 +437,22 @@ Ralphai uses GitHub labels to identify which issues to process and to track thei
 
 Family labels tell Ralphai what kind of issue it's looking at:
 
-| Config Key              | Default                   | Env Var                          | Description                        |
-| ----------------------- | ------------------------- | -------------------------------- | ---------------------------------- |
-| `issue.prdLabel`        | `"ralphai-prd"`           | `RALPHAI_ISSUE_PRD_LABEL`        | PRD parent issues.                 |
-| `issue.standaloneLabel` | `"ralphai-standalone"`    | `RALPHAI_ISSUE_STANDALONE_LABEL` | Standalone issues.                 |
-| `issue.subissueLabel`   | `"ralphai-subissue"`      | `RALPHAI_ISSUE_SUBISSUE_LABEL`   | PRD sub-issues.                    |
-| `issue.hitlLabel`       | `"ralphai-subissue-hitl"` | `RALPHAI_ISSUE_HITL_LABEL`       | Sub-issues requiring human input.  |
+| Config Key              | Default                   | Env Var                          | Description                       |
+| ----------------------- | ------------------------- | -------------------------------- | --------------------------------- |
+| `issue.prdLabel`        | `"ralphai-prd"`           | `RALPHAI_ISSUE_PRD_LABEL`        | PRD parent issues.                |
+| `issue.standaloneLabel` | `"ralphai-standalone"`    | `RALPHAI_ISSUE_STANDALONE_LABEL` | Standalone issues.                |
+| `issue.subissueLabel`   | `"ralphai-subissue"`      | `RALPHAI_ISSUE_SUBISSUE_LABEL`   | PRD sub-issues.                   |
+| `issue.hitlLabel`       | `"ralphai-subissue-hitl"` | `RALPHAI_ISSUE_HITL_LABEL`       | Sub-issues requiring human input. |
 
 ### State Labels
 
 State labels track progress. Ralphai adds and removes these automatically:
 
-| Config Key              | Default           | Env Var                           | Description                              |
-| ----------------------- | ----------------- | --------------------------------- | ---------------------------------------- |
-| `issue.inProgressLabel` | `"in-progress"`   | `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | Added when an issue is being worked on.  |
-| `issue.doneLabel`       | `"done"`          | `RALPHAI_ISSUE_DONE_LABEL`        | Added when work completes successfully.  |
-| `issue.stuckLabel`      | `"stuck"`         | `RALPHAI_ISSUE_STUCK_LABEL`       | Added when the agent gets stuck.         |
+| Config Key              | Default         | Env Var                           | Description                             |
+| ----------------------- | --------------- | --------------------------------- | --------------------------------------- |
+| `issue.inProgressLabel` | `"in-progress"` | `RALPHAI_ISSUE_IN_PROGRESS_LABEL` | Added when an issue is being worked on. |
+| `issue.doneLabel`       | `"done"`        | `RALPHAI_ISSUE_DONE_LABEL`        | Added when work completes successfully. |
+| `issue.stuckLabel`      | `"stuck"`       | `RALPHAI_ISSUE_STUCK_LABEL`       | Added when the agent gets stuck.        |
 
 ### Customizing Labels
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -206,7 +206,7 @@ The runner handles SIGTERM gracefully: it finishes the current iteration, preser
 ralphai run
 ```
 
-Ralphai auto-detects in-progress work and picks up where it left off. You can also reopen the interactive menu (`ralphai`) to see current progress and launch a new run from there.
+Ralphai auto-detects in-progress work and picks up where it left off. You can also reopen the interactive menu (`ralphai`) to see current progress and launch a new run from there. Stalled plans can also be resumed directly from the TUI via the "Resume stalled plan" action (hotkey **r**) — it shows a picker when multiple plans are stalled, or a Y/N confirmation for a single plan, then routes through the confirm screen before launching.
 
 If the agent left uncommitted changes from a previous run, use `--resume` to commit the dirty state before continuing:
 

--- a/src/tui/app.test.ts
+++ b/src/tui/app.test.ts
@@ -172,64 +172,6 @@ describe("handleAction", () => {
     });
   });
 
-  describe("navigate actions", () => {
-    it("pick-from-backlog navigates to backlog-picker", () => {
-      const result = handleAction("pick-from-backlog");
-      expect(result).toEqual({
-        type: "navigate",
-        screen: { type: "backlog-picker" },
-      });
-    });
-
-    it("pick-from-github navigates to issue-picker", () => {
-      const result = handleAction("pick-from-github");
-      expect(result).toEqual({
-        type: "navigate",
-        screen: { type: "issue-picker" },
-      });
-    });
-
-    it("stop-running navigates to stop screen", () => {
-      const result = handleAction("stop-running");
-      expect(result).toEqual({
-        type: "navigate",
-        screen: { type: "stop" },
-      });
-    });
-
-    it("reset-plan navigates to reset screen", () => {
-      const result = handleAction("reset-plan");
-      expect(result).toEqual({
-        type: "navigate",
-        screen: { type: "reset" },
-      });
-    });
-
-    it("view-status navigates to status screen", () => {
-      const result = handleAction("view-status");
-      expect(result).toEqual({
-        type: "navigate",
-        screen: { type: "status" },
-      });
-    });
-
-    it("doctor navigates to doctor screen", () => {
-      const result = handleAction("doctor");
-      expect(result).toEqual({
-        type: "navigate",
-        screen: { type: "doctor" },
-      });
-    });
-
-    it("clean navigates to clean screen", () => {
-      const result = handleAction("clean");
-      expect(result).toEqual({
-        type: "navigate",
-        screen: { type: "clean" },
-      });
-    });
-  });
-
   describe("consistency with menu items", () => {
     it("handles all 12 action types", () => {
       let count = 0;

--- a/src/tui/app.test.ts
+++ b/src/tui/app.test.ts
@@ -8,7 +8,6 @@
 
 import { describe, it, expect } from "bun:test";
 import { handleAction } from "./app.tsx";
-import type { ActionType } from "./types.ts";
 import { ACTION_TYPES, toConfirmNav, toOptionsNav } from "./types.ts";
 import type { RunConfig } from "./types.ts";
 
@@ -69,15 +68,70 @@ describe("handleAction", () => {
     });
   });
 
-  describe("stay actions", () => {
-    const stayActions: ActionType[] = ["resume-stalled"];
-
-    for (const action of stayActions) {
-      it(`${action} returns stay`, () => {
-        const result = handleAction(action);
-        expect(result).toEqual({ type: "stay" });
+  describe("navigate actions", () => {
+    it("pick-from-backlog navigates to backlog-picker", () => {
+      const result = handleAction("pick-from-backlog");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "backlog-picker" },
       });
-    }
+    });
+
+    it("pick-from-github navigates to issue-picker", () => {
+      const result = handleAction("pick-from-github");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "issue-picker" },
+      });
+    });
+
+    it("stop-running navigates to stop screen", () => {
+      const result = handleAction("stop-running");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "stop" },
+      });
+    });
+
+    it("reset-plan navigates to reset screen", () => {
+      const result = handleAction("reset-plan");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "reset" },
+      });
+    });
+
+    it("view-status navigates to status screen", () => {
+      const result = handleAction("view-status");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "status" },
+      });
+    });
+
+    it("doctor navigates to doctor screen", () => {
+      const result = handleAction("doctor");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "doctor" },
+      });
+    });
+
+    it("clean navigates to clean screen", () => {
+      const result = handleAction("clean");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "clean" },
+      });
+    });
+
+    it("resume-stalled navigates to resume-stalled screen", () => {
+      const result = handleAction("resume-stalled");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "resume-stalled" },
+      });
+    });
   });
 
   describe("settings action", () => {

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -41,9 +41,11 @@ import { ResetScreen } from "./screens/reset.tsx";
 import { StatusScreen } from "./screens/status.tsx";
 import { DoctorScreen } from "./screens/doctor.tsx";
 import { CleanScreen } from "./screens/clean.tsx";
+import { ResumeStalledScreen } from "./screens/resume.tsx";
 import {
   runningPlans,
   resettablePlans,
+  stalledPlans,
 } from "../interactive/pipeline-actions.ts";
 import { runRalphaiStop } from "../stop.ts";
 import { resetPlanBySlug } from "../ralphai.ts";
@@ -343,6 +345,15 @@ export function App({
             onResult={dispatch}
             backScreen={screen.backScreen}
             resolvedConfig={resolvedConfig}
+            isActive={true}
+          />
+        );
+
+      case "resume-stalled":
+        return (
+          <ResumeStalledScreen
+            stalledPlans={pipeline.state ? stalledPlans(pipeline.state) : []}
+            onResult={dispatchViaConfirm({ type: "resume-stalled" })}
             isActive={true}
           />
         );

--- a/src/tui/components/screen-frame.tsx
+++ b/src/tui/components/screen-frame.tsx
@@ -46,6 +46,7 @@ export const SCREEN_LABELS: Record<Screen["type"], string> = {
   "backlog-picker": "backlog",
   confirm: "confirm",
   options: "options",
+  "resume-stalled": "resume",
   stop: "stop",
   reset: "reset",
   status: "status",

--- a/src/tui/screens/resume.test.ts
+++ b/src/tui/screens/resume.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the resume screen's pure helper functions.
+ *
+ * Tests the exported helpers from `src/tui/screens/resume.tsx`:
+ * - `buildResumeItems` — converts stalled plans to ListItem[] with progress hints
+ * - `resumeSelect` — maps a selected value to a ResumeIntent
+ * - `buildResumeConfirmItems` — builds Y/N confirmation items for a single plan
+ * - `confirmResumeSelect` — maps a confirmation value to a ResumeIntent
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { InProgressPlan } from "../../plan-lifecycle.ts";
+import {
+  buildResumeItems,
+  resumeSelect,
+  buildResumeConfirmItems,
+  confirmResumeSelect,
+} from "./resume.tsx";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStalledPlan(overrides?: Partial<InProgressPlan>): InProgressPlan {
+  return {
+    filename: "plan-1.md",
+    slug: "plan-1",
+    scope: "",
+    totalTasks: undefined,
+    tasksCompleted: 0,
+    hasWorktree: false,
+    liveness: { tag: "stalled" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildResumeItems
+// ---------------------------------------------------------------------------
+
+describe("buildResumeItems", () => {
+  it("returns only a Back item for empty plans array", () => {
+    const items = buildResumeItems([]);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.value).toBe("__back__");
+    expect(items[0]!.label).toBe("Back");
+  });
+
+  it("creates items with progress hints when totalTasks is defined", () => {
+    const plans = [
+      makeStalledPlan({
+        filename: "feat-auth.md",
+        slug: "feat-auth",
+        totalTasks: 5,
+        tasksCompleted: 3,
+      }),
+    ];
+    const items = buildResumeItems(plans);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]!.value).toBe("feat-auth");
+    expect(items[0]!.label).toBe("feat-auth.md");
+    expect(items[0]!.hint).toBe("3/5 tasks");
+    expect(items[0]!.disabled).toBeFalsy();
+  });
+
+  it("omits hint when totalTasks is undefined", () => {
+    const plans = [
+      makeStalledPlan({
+        filename: "feat-auth.md",
+        slug: "feat-auth",
+        totalTasks: undefined,
+      }),
+    ];
+    const items = buildResumeItems(plans);
+
+    expect(items[0]!.hint).toBeUndefined();
+  });
+
+  it("shows progress hint with zero completed tasks", () => {
+    const plans = [
+      makeStalledPlan({
+        totalTasks: 5,
+        tasksCompleted: 0,
+      }),
+    ];
+    const items = buildResumeItems(plans);
+
+    expect(items[0]!.hint).toBe("0/5 tasks");
+  });
+
+  it("handles multiple stalled plans", () => {
+    const plans = [
+      makeStalledPlan({
+        slug: "plan-a",
+        filename: "plan-a.md",
+        totalTasks: 3,
+        tasksCompleted: 1,
+      }),
+      makeStalledPlan({
+        slug: "plan-b",
+        filename: "plan-b.md",
+        totalTasks: 10,
+        tasksCompleted: 7,
+      }),
+    ];
+    const items = buildResumeItems(plans);
+
+    expect(items).toHaveLength(3); // 2 plans + Back
+    expect(items[0]!.hint).toBe("1/3 tasks");
+    expect(items[1]!.hint).toBe("7/10 tasks");
+    expect(items[2]!.value).toBe("__back__");
+  });
+
+  it("always appends a Back item as the last entry", () => {
+    const plans = [makeStalledPlan()];
+    const items = buildResumeItems(plans);
+    const last = items[items.length - 1]!;
+    expect(last.value).toBe("__back__");
+    expect(last.label).toBe("Back");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resumeSelect
+// ---------------------------------------------------------------------------
+
+describe("resumeSelect", () => {
+  it("returns resume intent for a plan slug", () => {
+    const plans = [
+      makeStalledPlan({ slug: "feat-auth", filename: "feat-auth.md" }),
+    ];
+    const intent = resumeSelect("feat-auth", plans);
+    expect(intent).toEqual({
+      type: "resume",
+      slug: "feat-auth",
+      filename: "feat-auth.md",
+    });
+  });
+
+  it("returns back intent for __back__ sentinel", () => {
+    const intent = resumeSelect("__back__", []);
+    expect(intent).toEqual({ type: "back" });
+  });
+
+  it("treats any non-back value as a plan slug", () => {
+    const plans = [
+      makeStalledPlan({
+        slug: "gh-42-some-plan",
+        filename: "gh-42-some-plan.md",
+      }),
+    ];
+    const intent = resumeSelect("gh-42-some-plan", plans);
+    expect(intent).toEqual({
+      type: "resume",
+      slug: "gh-42-some-plan",
+      filename: "gh-42-some-plan.md",
+    });
+  });
+
+  it("falls back to slug-based filename when plan is not found", () => {
+    const intent = resumeSelect("missing-plan", []);
+    expect(intent).toEqual({
+      type: "resume",
+      slug: "missing-plan",
+      filename: "missing-plan.md",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildResumeConfirmItems
+// ---------------------------------------------------------------------------
+
+describe("buildResumeConfirmItems", () => {
+  it("builds two items: confirm and back", () => {
+    const plan = makeStalledPlan({ slug: "my-plan", totalTasks: 5 });
+    const items = buildResumeConfirmItems(plan);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]!.value).toBe("__confirm__");
+    expect(items[1]!.value).toBe("__back__");
+  });
+
+  it("includes slug and progress in the confirm label", () => {
+    const plan = makeStalledPlan({
+      slug: "feat-auth",
+      totalTasks: 5,
+      tasksCompleted: 3,
+    });
+    const items = buildResumeConfirmItems(plan);
+
+    expect(items[0]!.label).toContain("feat-auth");
+    expect(items[0]!.label).toContain("3/5 tasks");
+  });
+
+  it("omits progress when totalTasks is undefined", () => {
+    const plan = makeStalledPlan({
+      slug: "feat-x",
+      totalTasks: undefined,
+    });
+    const items = buildResumeConfirmItems(plan);
+
+    expect(items[0]!.label).toContain("feat-x");
+    expect(items[0]!.label).not.toContain("tasks");
+  });
+
+  it("shows progress with zero completed tasks", () => {
+    const plan = makeStalledPlan({
+      slug: "feat-y",
+      totalTasks: 5,
+      tasksCompleted: 0,
+    });
+    const items = buildResumeConfirmItems(plan);
+
+    expect(items[0]!.label).toContain("0/5 tasks");
+  });
+
+  it("back item has descriptive label", () => {
+    const plan = makeStalledPlan();
+    const items = buildResumeConfirmItems(plan);
+
+    expect(items[1]!.label).toBe("No, go back");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confirmResumeSelect
+// ---------------------------------------------------------------------------
+
+describe("confirmResumeSelect", () => {
+  it("returns resume intent when __confirm__ is selected", () => {
+    const intent = confirmResumeSelect("__confirm__", "my-plan", "my-plan.md");
+    expect(intent).toEqual({
+      type: "resume",
+      slug: "my-plan",
+      filename: "my-plan.md",
+    });
+  });
+
+  it("returns back intent when __back__ is selected", () => {
+    const intent = confirmResumeSelect("__back__", "my-plan", "my-plan.md");
+    expect(intent).toEqual({ type: "back" });
+  });
+
+  it("returns back intent for any non-confirm value", () => {
+    const intent = confirmResumeSelect("unexpected", "my-plan", "my-plan.md");
+    expect(intent).toEqual({ type: "back" });
+  });
+});

--- a/src/tui/screens/resume.tsx
+++ b/src/tui/screens/resume.tsx
@@ -1,18 +1,31 @@
 /**
- * Resume stalled plan screen helpers for the TUI.
+ * Resume stalled plan screen for the TUI.
  *
- * Pure helpers that build list items and map selections to typed intents
- * for the resume-stalled screen. No React rendering — that will be
- * composed separately by the screen component.
+ * Shows a list of stalled plans to resume, or a confirmation prompt when
+ * only one plan is stalled. Uses the `SelectableList` component.
  *
- * Exported helpers:
+ * - Single stalled plan: Y/N confirmation with progress hint
+ * - Multiple stalled plans: picker with progress hints
+ * - On resume intent: produces `exit-to-runner` with
+ *   `["run", "--plan=<slug>.md", "--resume"]`
+ * - Esc: returns to main menu
+ *
+ * Pure helpers are exported for unit testing:
  * - `buildResumeItems` — maps stalled plans to ListItem[] with progress hints
  * - `resumeSelect` — maps a selected value to a ResumeIntent
  * - `buildResumeConfirmItems` — builds Y/N confirmation items for a single plan
  * - `confirmResumeSelect` — maps a confirmation value to a ResumeIntent
  */
 
-import type { ListItem } from "../components/selectable-list.tsx";
+import { useMemo, useCallback } from "react";
+import { Box, Text } from "ink";
+
+import type {
+  ListItem,
+  ItemRenderProps,
+} from "../components/selectable-list.tsx";
+import { SelectableList } from "../components/selectable-list.tsx";
+import type { DispatchResult } from "../types.ts";
 import type { InProgressPlan } from "../../plan-lifecycle.ts";
 
 // ---------------------------------------------------------------------------
@@ -114,4 +127,156 @@ export function confirmResumeSelect(
 ): ResumeIntent {
   if (value === "__confirm__") return { type: "resume", slug, filename };
   return { type: "back" };
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ResumeStalledScreenProps {
+  /** Stalled plans from pipeline state. */
+  stalledPlans: InProgressPlan[];
+  /** Called when the user selects a plan or navigates back. */
+  onResult: (result: DispatchResult) => void;
+  /** Whether keyboard input is active. @default true */
+  isActive?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Custom item renderer
+// ---------------------------------------------------------------------------
+
+function ResumeListItem({
+  item,
+  isCursor,
+  isDisabled,
+}: {
+  item: ListItem;
+  isCursor: boolean;
+  isDisabled: boolean;
+}) {
+  const cursor = isCursor ? "\u276F " : "  ";
+  const labelColor = isDisabled ? "gray" : isCursor ? "cyan" : undefined;
+
+  return (
+    <Box>
+      <Text color={isCursor ? "cyan" : undefined}>{cursor}</Text>
+      <Text color={labelColor} dimColor={isDisabled}>
+        {item.label}
+      </Text>
+      {item.hint ? <Text dimColor> {item.hint}</Text> : null}
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ResumeStalledScreen component
+// ---------------------------------------------------------------------------
+
+export function ResumeStalledScreen({
+  stalledPlans: plans,
+  onResult,
+  isActive = true,
+}: ResumeStalledScreenProps) {
+  const handleBack = useCallback(() => {
+    onResult({ type: "navigate", screen: { type: "menu" } });
+  }, [onResult]);
+
+  const renderItem = useCallback(
+    (item: ListItem, props: ItemRenderProps) => (
+      <ResumeListItem
+        item={item}
+        isCursor={props.isCursor}
+        isDisabled={props.isDisabled}
+      />
+    ),
+    [],
+  );
+
+  // --- Dispatch intent ---
+  const handleIntent = useCallback(
+    (intent: ResumeIntent) => {
+      if (intent.type === "back") {
+        handleBack();
+        return;
+      }
+      // Produce exit-to-runner with resume args
+      onResult({
+        type: "exit-to-runner",
+        args: ["run", `--plan=${intent.filename}`, "--resume"],
+      });
+    },
+    [onResult, handleBack],
+  );
+
+  // --- Empty state ---
+  if (plans.length === 0) {
+    return (
+      <Box flexDirection="column" paddingLeft={1}>
+        <Text>No stalled plans</Text>
+        <Box marginTop={1}>
+          <SelectableList
+            items={[{ value: "__back__", label: "Back" }]}
+            onSelect={handleBack}
+            onBack={handleBack}
+            isActive={isActive}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  // --- Single plan: confirmation prompt ---
+  if (plans.length === 1) {
+    const plan = plans[0]!;
+    const confirmItems = useMemo(() => buildResumeConfirmItems(plan), [plan]);
+
+    const handleConfirmSelect = useCallback(
+      (value: string) => {
+        handleIntent(confirmResumeSelect(value, plan.slug, plan.filename));
+      },
+      [plan.slug, plan.filename, handleIntent],
+    );
+
+    return (
+      <Box flexDirection="column">
+        <Box paddingLeft={1} marginBottom={1}>
+          <Text bold>Resume stalled plan?</Text>
+        </Box>
+        <SelectableList
+          items={confirmItems}
+          onSelect={handleConfirmSelect}
+          onBack={handleBack}
+          isActive={isActive}
+          renderItem={renderItem}
+        />
+      </Box>
+    );
+  }
+
+  // --- Multiple plans: picker ---
+  const listItems = useMemo(() => buildResumeItems(plans), [plans]);
+
+  const handlePickerSelect = useCallback(
+    (value: string) => {
+      handleIntent(resumeSelect(value, plans));
+    },
+    [handleIntent, plans],
+  );
+
+  return (
+    <Box flexDirection="column">
+      <Box paddingLeft={1} marginBottom={1}>
+        <Text bold>Pick a stalled plan to resume</Text>
+        <Text dimColor> ({plans.length} stalled)</Text>
+      </Box>
+      <SelectableList
+        items={listItems}
+        onSelect={handlePickerSelect}
+        onBack={handleBack}
+        isActive={isActive}
+        renderItem={renderItem}
+      />
+    </Box>
+  );
 }

--- a/src/tui/screens/resume.tsx
+++ b/src/tui/screens/resume.tsx
@@ -1,0 +1,117 @@
+/**
+ * Resume stalled plan screen helpers for the TUI.
+ *
+ * Pure helpers that build list items and map selections to typed intents
+ * for the resume-stalled screen. No React rendering — that will be
+ * composed separately by the screen component.
+ *
+ * Exported helpers:
+ * - `buildResumeItems` — maps stalled plans to ListItem[] with progress hints
+ * - `resumeSelect` — maps a selected value to a ResumeIntent
+ * - `buildResumeConfirmItems` — builds Y/N confirmation items for a single plan
+ * - `confirmResumeSelect` — maps a confirmation value to a ResumeIntent
+ */
+
+import type { ListItem } from "../components/selectable-list.tsx";
+import type { InProgressPlan } from "../../plan-lifecycle.ts";
+
+// ---------------------------------------------------------------------------
+// Intent types
+// ---------------------------------------------------------------------------
+
+/** What the resume screen should do after a selection. */
+export type ResumeIntent =
+  | { type: "resume"; slug: string; filename: string }
+  | { type: "back" };
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert stalled plans into a flat `ListItem[]` for the picker.
+ *
+ * Each plan shows its filename as the label, with a progress hint
+ * (e.g. "3/5 tasks") when `totalTasks` is defined. Appends a "Back"
+ * item with `__back__` value.
+ */
+export function buildResumeItems(plans: InProgressPlan[]): ListItem[] {
+  const items: ListItem[] = plans.map((plan) => {
+    const hint =
+      plan.totalTasks !== undefined
+        ? `${plan.tasksCompleted}/${plan.totalTasks} tasks`
+        : undefined;
+
+    return {
+      value: plan.slug,
+      label: plan.filename,
+      hint,
+    };
+  });
+
+  items.push({
+    value: "__back__",
+    label: "Back",
+  });
+
+  return items;
+}
+
+/**
+ * Map a selected picker value to a `ResumeIntent`.
+ *
+ * Returns `{ type: "resume", slug, filename }` for plan values, or
+ * `{ type: "back" }` for the back sentinel. The `plans` array is used
+ * to look up the filename for the selected slug.
+ */
+export function resumeSelect(
+  value: string,
+  plans: InProgressPlan[],
+): ResumeIntent {
+  if (value === "__back__") return { type: "back" };
+  const plan = plans.find((p) => p.slug === value);
+  return {
+    type: "resume",
+    slug: value,
+    filename: plan?.filename ?? `${value}.md`,
+  };
+}
+
+/**
+ * Build Y/N confirmation items for resuming a single stalled plan.
+ *
+ * The "Yes" label includes the slug and progress information when
+ * `totalTasks` is defined.
+ */
+export function buildResumeConfirmItems(plan: InProgressPlan): ListItem[] {
+  const progressStr =
+    plan.totalTasks !== undefined
+      ? ` (${plan.tasksCompleted}/${plan.totalTasks} tasks)`
+      : "";
+
+  return [
+    {
+      value: "__confirm__",
+      label: `Yes, resume '${plan.slug}'${progressStr}`,
+    },
+    {
+      value: "__back__",
+      label: "No, go back",
+    },
+  ];
+}
+
+/**
+ * Map a confirmation value to a `ResumeIntent`.
+ *
+ * Returns `{ type: "resume", slug, filename }` for `__confirm__`,
+ * or `{ type: "back" }` for any other value.
+ */
+export function confirmResumeSelect(
+  value: string,
+  slug: string,
+  filename: string,
+): ResumeIntent {
+  if (value === "__confirm__") return { type: "resume", slug, filename };
+  return { type: "back" };
+}

--- a/src/tui/types.test.ts
+++ b/src/tui/types.test.ts
@@ -134,17 +134,6 @@ describe("resolveAction", () => {
     });
   });
 
-  describe("stay actions (future sub-screens)", () => {
-    const stayActions: ActionType[] = ["resume-stalled"];
-
-    for (const action of stayActions) {
-      it(`${action} returns stay`, () => {
-        const result = resolveAction(action);
-        expect(result.type).toBe("stay");
-      });
-    }
-  });
-
   describe("navigate actions (picker sub-screens)", () => {
     it("pick-from-backlog navigates to backlog-picker", () => {
       const result = resolveAction("pick-from-backlog");
@@ -199,6 +188,14 @@ describe("resolveAction", () => {
       expect(result).toEqual({
         type: "navigate",
         screen: { type: "clean" },
+      });
+    });
+
+    it("resume-stalled navigates to resume-stalled screen", () => {
+      const result = resolveAction("resume-stalled");
+      expect(result).toEqual({
+        type: "navigate",
+        screen: { type: "resume-stalled" },
       });
     });
   });
@@ -355,6 +352,12 @@ describe("titleFromRunArgs", () => {
 
   it("handles large issue numbers", () => {
     expect(titleFromRunArgs(["run", "9999"])).toBe("Issue #9999");
+  });
+
+  it('extracts plan name from ["run", "--plan=feat-login.md", "--resume"]', () => {
+    expect(titleFromRunArgs(["run", "--plan=feat-login.md", "--resume"])).toBe(
+      "feat-login.md",
+    );
   });
 
   it("resolves next plan name from pipeline state for bare run", () => {
@@ -800,6 +803,15 @@ describe("transition flows", () => {
     expect(result).toEqual({
       type: "navigate",
       screen: { type: "clean" },
+    });
+  });
+
+  it("resume-stalled → resume-stalled screen (no confirm interception)", () => {
+    const actionResult = resolveAction("resume-stalled");
+    const result = toConfirmNav(actionResult, config, { type: "menu" });
+    expect(result).toEqual({
+      type: "navigate",
+      screen: { type: "resume-stalled" },
     });
   });
 });

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -84,6 +84,7 @@ export type Screen =
   | { type: "backlog-picker" }
   | { type: "confirm"; data: ConfirmData; backScreen?: Screen }
   | { type: "options"; data: ConfirmData; backScreen?: Screen }
+  | { type: "resume-stalled" }
   | { type: "stop" }
   | { type: "reset" }
   | { type: "status" }
@@ -113,10 +114,8 @@ export type DispatchResult =
  * Map an `ActionType` to a `DispatchResult`.
  *
  * This is a pure function that determines the routing outcome for each
- * action. Actions that require sub-screens or the agent runner will
- * evolve as those screens are built — for now, actions that would
- * normally show a sub-menu return `"stay"` (the sub-screen is not yet
- * implemented), and actions that launch the runner return
+ * action. Actions that require sub-screens navigate to the appropriate
+ * screen, while actions that launch the agent runner return
  * `"exit-to-runner"`.
  */
 export function resolveAction(action: ActionType): DispatchResult {
@@ -149,6 +148,8 @@ export function resolveAction(action: ActionType): DispatchResult {
       return { type: "navigate", screen: { type: "doctor" } };
     case "clean":
       return { type: "navigate", screen: { type: "clean" } };
+    case "resume-stalled":
+      return { type: "navigate", screen: { type: "resume-stalled" } };
 
     // --- Actions that exit the TUI and launch the runner (options) ---
     // "run-with-options" produces exit-to-runner with default ["run"]
@@ -160,12 +161,6 @@ export function resolveAction(action: ActionType): DispatchResult {
     // --- Actions that exit the TUI and launch a non-runner command ---
     case "settings":
       return { type: "exit-to-runner", args: ["init", "--force"] };
-
-    // --- Actions that will navigate to sub-screens (stubbed as "stay") ---
-    // These will be updated to `{ type: "navigate", screen: ... }` as
-    // their respective screens are implemented.
-    case "resume-stalled":
-      return { type: "stay" };
   }
 }
 


### PR DESCRIPTION
PRD #494: feat: Implement 'Resume Stalled Plan' TUI screen

## Summary

- **#495:** Add the pure data-layer helpers and tests for the resume-stalled TUI screen, following the established StopScreen helper pattern. Implements `buildResumeItems`, `resumeSelect`, `buildResumeConfirmItems`, and `confirmResumeSelect` with comprehensive test coverage for progress hints, sentinel handling, edge cases, and confirmation flows.
- **#496:** Wire the resume-stalled screen end-to-end in the TUI: selecting "Resume stalled plan" from the menu now navigates to a dedicated screen that shows a Y/N confirmation for a single stalled plan or a picker for multiple, routing through the confirm screen before launching the runner with `--resume`. This completes the last stubbed TUI menu action.

Closes #494
Closes #495
Closes #496

## Completed Sub-Issues

- [x] #495
- [x] #496

## Changes

### Features

- wire resume-stalled screen into TUI with confirm flow
- add resume-stalled screen pure helpers and tests

### Refactoring

- remove duplicate navigate-actions test block in app.test.ts


## Learnings

- When a plan specifies a function signature that cannot satisfy its own return type (e.g., `resumeSelect(value: string): ResumeIntent` where `ResumeIntent` includes a `filename` not derivable from the value alone), it's better to add the minimal extra parameter needed rather than encode compound data into string values. Keep the deviation small and document why.
- When a completion gate rejects due to progress tracking rather than actual code issues, the fix is to ensure the progress block accurately enumerates all completed acceptance criteria. The gate parses `- [x]` items from the progress block, so every acceptance criterion must be explicitly listed as checked for the gate to pass.