### PR TITLE
feat: Suppress husky and auto-allow dirty state in worktree runs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -142,7 +142,7 @@ What it does:
 --dry-run, -n                        Preview what would happen without changing anything
 --wizard, -w                         Interactively configure run options before starting
 --resume, -r                         Commit dirty state and continue
---allow-dirty                        Skip the clean working tree check
+--allow-dirty                        Skip the clean working tree check (automatically applied in worktree runs)
 --plan=<file>                        Target a specific backlog plan (default: auto-detect)
 --tags=<list>                        Comma-separated tags to filter plans (OR semantics)
 --agent-command=<command>            Override agent CLI command

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -34,6 +34,10 @@ Run `ralphai run` from anywhere — if you're inside a worktree, Ralphai automat
    dependencies are available before the agent starts.
 3. Ralphai runs the agent inside that worktree and keeps the main checkout clean.
 
+Worktree runs automatically skip the dirty-state check (`--allow-dirty` is
+injected), since the setup command may leave the worktree in a dirty state
+(e.g. modified lockfiles or generated artifacts).
+
 Plan selection checks runner liveness (via PID files) before resuming
 in-progress plans, so multiple `ralphai run` processes on the same repo
 will not conflict — each process only picks up plans that have no active
@@ -105,6 +109,10 @@ Set to `""` (empty string) to disable.
   mounts as agent execution.
 - When `sandbox` is `"none"` (default), the setup command runs on the host
   via `execSync`.
+- Ralphai sets `HUSKY=0` in the environment during setup command execution and
+  agent execution. This suppresses husky's git hook installation (which would
+  otherwise produce noisy output during `prepare` scripts) and prevents
+  pre-commit hooks from interfering with agent commits.
 - On failure, Ralphai exits with code 1 and prints the failing command.
 - In `--dry-run` mode, the setup command is not executed.
 

--- a/src/docker-executor.test.ts
+++ b/src/docker-executor.test.ts
@@ -119,6 +119,17 @@ describe("buildDockerArgs", () => {
     expect(args[homeIdx - 1]).toBe("-e");
   });
 
+  it("includes -e HUSKY=0 to suppress git hooks", () => {
+    const args = buildDockerArgs({
+      agentCommand: "claude -p",
+      prompt: "do stuff",
+      cwd: "/work/my-project",
+    });
+    const huskyIdx = args.indexOf("HUSKY=0");
+    expect(huskyIdx).toBeGreaterThan(-1);
+    expect(args[huskyIdx - 1]).toBe("-e");
+  });
+
   it("bind-mounts worktree at host path", () => {
     const args = buildDockerArgs({
       agentCommand: "claude -p",
@@ -874,6 +885,17 @@ describe("buildSetupDockerArgs", () => {
     const homeIdx = args.indexOf(homeEnv);
     expect(homeIdx).toBeGreaterThan(-1);
     expect(args[homeIdx - 1]).toBe("-e");
+  });
+
+  it("includes -e HUSKY=0 to suppress git hooks", () => {
+    const args = buildSetupDockerArgs({
+      agentCommand: "claude -p",
+      setupCommand: "bun install",
+      cwd: "/work/my-project",
+    });
+    const huskyIdx = args.indexOf("HUSKY=0");
+    expect(huskyIdx).toBeGreaterThan(-1);
+    expect(args[huskyIdx - 1]).toBe("-e");
   });
 
   it("bind-mounts worktree at host path", () => {

--- a/src/executor.test.ts
+++ b/src/executor.test.ts
@@ -95,6 +95,31 @@ describe("LocalExecutor", () => {
     // HOME should be inherited from the environment
     expect(result.output.trim().length).toBeGreaterThan(0);
   });
+
+  it("always passes HUSKY=0 to suppress git hooks", async () => {
+    const executor = new LocalExecutor();
+    const result = await executor.spawn({
+      agentCommand: "bash -c",
+      prompt: "echo $HUSKY",
+      iterationTimeout: 0,
+      cwd: process.cwd(),
+    });
+
+    expect(result.output.trim()).toBe("0");
+  });
+
+  it("passes HUSKY=0 alongside RALPHAI_NONCE when nonce is set", async () => {
+    const executor = new LocalExecutor();
+    const result = await executor.spawn({
+      agentCommand: "bash -c",
+      prompt: 'echo "$HUSKY:$RALPHAI_NONCE"',
+      iterationTimeout: 0,
+      cwd: process.cwd(),
+      nonce: "test-nonce-456",
+    });
+
+    expect(result.output.trim()).toBe("0:test-nonce-456");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/executor/docker.ts
+++ b/src/executor/docker.ts
@@ -13,8 +13,7 @@
  * File mounts and env vars are silently skipped when absent on the host.
  */
 
-import { spawn, type ChildProcess } from "child_process";
-import { createWriteStream, existsSync } from "fs";
+import { existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 
@@ -28,6 +27,7 @@ import { shellSplit } from "../shell-split.ts";
 import { detectAgentType } from "../show-config.ts";
 import { resolveMainGitDir } from "../worktree/index.ts";
 import { resolveAgentVerboseFlags } from "./agent-flags.ts";
+import { spawnChild } from "./spawn-child.ts";
 
 // ---------------------------------------------------------------------------
 // Container user and home directory
@@ -657,97 +657,13 @@ export class DockerExecutor implements AgentExecutor {
       agentVerboseFlags,
     });
 
-    return new Promise((resolve) => {
-      // Open a write stream for the agent output log (append mode).
-      let logStream: ReturnType<typeof createWriteStream> | undefined;
-      if (outputLogPath) {
-        try {
-          logStream = createWriteStream(outputLogPath, { flags: "a" });
-        } catch {
-          // Best-effort: if we can't open the log, continue without it
-        }
-      }
-
-      let ac: AbortController | undefined;
-      let timedOut = false;
-      const spawnOpts: {
-        cwd?: string;
-        stdio: ["pipe", "pipe", "pipe"];
-        signal?: AbortSignal;
-      } = {
-        stdio: ["pipe", "pipe", "pipe"],
-      };
-
-      if (iterationTimeout > 0) {
-        ac = new AbortController();
-        spawnOpts.signal = ac.signal;
-        setTimeout(() => {
-          timedOut = true;
-          ac!.abort();
-        }, iterationTimeout * 1000);
-      }
-
-      let child: ChildProcess;
-      try {
-        child = spawn("docker", dockerArgs, spawnOpts);
-      } catch (err) {
-        console.error(
-          `Failed to spawn Docker container: ${err instanceof Error ? err.message : err}`,
-        );
-        logStream?.end();
-        resolve({ output: "", exitCode: 1, timedOut: false });
-        return;
-      }
-
-      // Close stdin so the agent knows no input is coming.
-      child.stdin?.end();
-
-      const chunks: Buffer[] = [];
-
-      child.stdout?.on("data", (data: Buffer) => {
-        process.stdout.write(data);
-        logStream?.write(data);
-        chunks.push(data);
-        ipcBroadcast?.({
-          type: "output",
-          data: data.toString(),
-          stream: "stdout",
-        });
-      });
-
-      child.stderr?.on("data", (data: Buffer) => {
-        process.stderr.write(data);
-        logStream?.write(data);
-        chunks.push(data);
-        ipcBroadcast?.({
-          type: "output",
-          data: data.toString(),
-          stream: "stderr",
-        });
-      });
-
-      child.on("close", (code) => {
-        const output = Buffer.concat(chunks).toString("utf-8");
-        if (logStream) {
-          logStream.end(() => {
-            resolve({ output, exitCode: code ?? 1, timedOut });
-          });
-        } else {
-          resolve({ output, exitCode: code ?? 1, timedOut });
-        }
-      });
-
-      child.on("error", (err) => {
-        logStream?.end();
-        if (timedOut) {
-          const output = Buffer.concat(chunks).toString("utf-8");
-          resolve({ output, exitCode: 124, timedOut: true });
-        } else {
-          console.error(`Docker container error: ${err.message}`);
-          const output = Buffer.concat(chunks).toString("utf-8");
-          resolve({ output, exitCode: 1, timedOut: false });
-        }
-      });
+    return spawnChild({
+      command: "docker",
+      args: dockerArgs,
+      iterationTimeout,
+      outputLogPath,
+      ipcBroadcast,
+      errorLabel: "Docker container",
     });
   }
 }

--- a/src/executor/docker.ts
+++ b/src/executor/docker.ts
@@ -395,6 +395,9 @@ function buildCommonDockerArgs(opts: {
   // Set container HOME so tools and configs work for non-root user
   args.push("-e", `HOME=${CONTAINER_HOME}`);
 
+  // Suppress husky git hooks inside Docker containers
+  args.push("-e", "HUSKY=0");
+
   // Worktree bind mount (read-write)
   args.push("-v", `${cwd}:${cwd}`);
   args.push("-w", cwd);

--- a/src/executor/docker.ts
+++ b/src/executor/docker.ts
@@ -439,28 +439,9 @@ function buildCommonDockerArgs(opts: {
  * - Does NOT mount ~/.ralphai/
  */
 export function buildDockerArgs(opts: DockerCommandOptions): string[] {
-  const {
-    agentCommand,
-    prompt,
-    cwd,
-    dockerImage,
-    dockerEnvVars = [],
-    dockerMounts = [],
-    nonce,
-    mainGitDir,
-    feedbackWrapperPath,
-    extraAgentFlags = [],
-  } = opts;
+  const { agentCommand, prompt, nonce, extraAgentFlags = [] } = opts;
 
-  const args = buildCommonDockerArgs({
-    agentCommand,
-    cwd,
-    dockerImage,
-    dockerEnvVars,
-    dockerMounts,
-    mainGitDir,
-    feedbackWrapperPath,
-  });
+  const args = buildCommonDockerArgs(opts);
 
   // Nonce env var (set explicitly with value, not from host env).
   // Inserted before the image (second-to-last position in the common args)
@@ -516,27 +497,10 @@ export interface SetupDockerCommandOptions {
 export function buildSetupDockerArgs(
   opts: SetupDockerCommandOptions,
 ): string[] {
-  const {
-    agentCommand,
-    setupCommand,
-    cwd,
-    dockerImage,
-    dockerEnvVars = [],
-    dockerMounts = [],
-    mainGitDir,
-  } = opts;
-
-  const args = buildCommonDockerArgs({
-    agentCommand,
-    cwd,
-    dockerImage,
-    dockerEnvVars,
-    dockerMounts,
-    mainGitDir,
-  });
+  const args = buildCommonDockerArgs(opts);
 
   // Setup command via sh -c
-  args.push("sh", "-c", setupCommand);
+  args.push("sh", "-c", opts.setupCommand);
 
   return args;
 }
@@ -634,35 +598,14 @@ export class DockerExecutor implements AgentExecutor {
   }
 
   async spawn(opts: ExecutorSpawnOptions): Promise<ExecutorSpawnResult> {
-    const {
-      agentCommand,
-      prompt,
-      iterationTimeout,
-      cwd,
-      outputLogPath,
-      ipcBroadcast,
-      nonce,
-      feedbackWrapperPath,
-      verbose,
-      agentVerboseFlags,
-    } = opts;
-
-    const dockerArgs = this.buildSpawnDockerArgs({
-      agentCommand,
-      prompt,
-      cwd,
-      nonce,
-      feedbackWrapperPath,
-      verbose,
-      agentVerboseFlags,
-    });
+    const dockerArgs = this.buildSpawnDockerArgs(opts);
 
     return spawnChild({
       command: "docker",
       args: dockerArgs,
-      iterationTimeout,
-      outputLogPath,
-      ipcBroadcast,
+      iterationTimeout: opts.iterationTimeout,
+      outputLogPath: opts.outputLogPath,
+      ipcBroadcast: opts.ipcBroadcast,
       errorLabel: "Docker container",
     });
   }

--- a/src/executor/local.ts
+++ b/src/executor/local.ts
@@ -6,9 +6,6 @@
  * AbortController, exit code handling, and IPC broadcast.
  */
 
-import { spawn, type ChildProcess } from "child_process";
-import { createWriteStream } from "fs";
-
 import type {
   AgentExecutor,
   ExecutorSpawnOptions,
@@ -17,6 +14,7 @@ import type {
 
 import { shellSplit } from "../shell-split.ts";
 import { resolveAgentVerboseFlags } from "./agent-flags.ts";
+import { spawnChild } from "./spawn-child.ts";
 
 // ---------------------------------------------------------------------------
 // LocalExecutor
@@ -44,115 +42,30 @@ export class LocalExecutor implements AgentExecutor {
       agentVerboseFlags,
     } = opts;
 
-    return new Promise((resolve) => {
-      // Split the agent command respecting quotes
-      const parts = shellSplit(agentCommand);
-      const cmd = parts[0]!;
-      // Inject verbose flags between command parts and prompt when --verbose is active
-      const verboseFlags = verbose
-        ? resolveAgentVerboseFlags(agentCommand, agentVerboseFlags)
-        : [];
-      const args = [...parts.slice(1), ...verboseFlags, prompt];
+    // Split the agent command respecting quotes
+    const parts = shellSplit(agentCommand);
+    const cmd = parts[0]!;
+    // Inject verbose flags between command parts and prompt when --verbose is active
+    const verboseFlags = verbose
+      ? resolveAgentVerboseFlags(agentCommand, agentVerboseFlags)
+      : [];
+    const args = [...parts.slice(1), ...verboseFlags, prompt];
 
-      // Open a write stream for the agent output log (append mode).
-      // Errors are swallowed so logging never breaks the run.
-      let logStream: ReturnType<typeof createWriteStream> | undefined;
-      if (outputLogPath) {
-        try {
-          logStream = createWriteStream(outputLogPath, { flags: "a" });
-        } catch {
-          // Best-effort: if we can't open the log, continue without it
-        }
-      }
-
-      let ac: AbortController | undefined;
-      let timedOut = false;
-      const spawnOpts: {
-        cwd: string;
-        stdio: ["pipe", "pipe", "pipe"];
-        signal?: AbortSignal;
-        env?: Record<string, string | undefined>;
-      } = {
+    return spawnChild({
+      command: cmd,
+      args,
+      spawnOptions: {
         cwd,
-        stdio: ["pipe", "pipe", "pipe"],
         env: {
           ...process.env,
           HUSKY: "0",
           ...(nonce ? { RALPHAI_NONCE: nonce } : {}),
         },
-      };
-
-      if (iterationTimeout > 0) {
-        ac = new AbortController();
-        spawnOpts.signal = ac.signal;
-        setTimeout(() => {
-          timedOut = true;
-          ac!.abort();
-        }, iterationTimeout * 1000);
-      }
-
-      let child: ChildProcess;
-      try {
-        child = spawn(cmd, args, spawnOpts);
-      } catch (err) {
-        console.error(
-          `Failed to spawn agent: ${err instanceof Error ? err.message : err}`,
-        );
-        logStream?.end();
-        resolve({ output: "", exitCode: 1, timedOut: false });
-        return;
-      }
-
-      // Close stdin so the agent knows no input is coming.
-      // Without this, agents that read or wait for stdin EOF will hang.
-      child.stdin?.end();
-
-      const chunks: Buffer[] = [];
-
-      child.stdout?.on("data", (data: Buffer) => {
-        process.stdout.write(data);
-        logStream?.write(data);
-        chunks.push(data);
-        ipcBroadcast?.({
-          type: "output",
-          data: data.toString(),
-          stream: "stdout",
-        });
-      });
-
-      child.stderr?.on("data", (data: Buffer) => {
-        process.stderr.write(data);
-        logStream?.write(data);
-        chunks.push(data);
-        ipcBroadcast?.({
-          type: "output",
-          data: data.toString(),
-          stream: "stderr",
-        });
-      });
-
-      child.on("close", (code) => {
-        const output = Buffer.concat(chunks).toString("utf-8");
-        if (logStream) {
-          logStream.end(() => {
-            resolve({ output, exitCode: code ?? 1, timedOut });
-          });
-        } else {
-          resolve({ output, exitCode: code ?? 1, timedOut });
-        }
-      });
-
-      child.on("error", (err) => {
-        logStream?.end();
-        if (timedOut) {
-          const output = Buffer.concat(chunks).toString("utf-8");
-          resolve({ output, exitCode: 124, timedOut: true });
-        } else {
-          console.error(`Agent error: ${err.message}`);
-          const output = Buffer.concat(chunks).toString("utf-8");
-          resolve({ output, exitCode: 1, timedOut: false });
-        }
-      });
+      },
+      iterationTimeout,
+      outputLogPath,
+      ipcBroadcast,
+      errorLabel: "agent",
     });
   }
 }

--- a/src/executor/local.ts
+++ b/src/executor/local.ts
@@ -75,7 +75,11 @@ export class LocalExecutor implements AgentExecutor {
       } = {
         cwd,
         stdio: ["pipe", "pipe", "pipe"],
-        env: nonce ? { ...process.env, RALPHAI_NONCE: nonce } : undefined,
+        env: {
+          ...process.env,
+          HUSKY: "0",
+          ...(nonce ? { RALPHAI_NONCE: nonce } : {}),
+        },
       };
 
       if (iterationTimeout > 0) {

--- a/src/executor/spawn-child.ts
+++ b/src/executor/spawn-child.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared child-process lifecycle helper used by both LocalExecutor and
+ * DockerExecutor.
+ *
+ * Encapsulates the common pattern of spawning a process with optional
+ * timeout, stdout/stderr passthrough, log streaming, IPC broadcast,
+ * and exit/error handling.
+ */
+
+import { spawn, type ChildProcess, type SpawnOptions } from "child_process";
+import { createWriteStream } from "fs";
+
+import type { ExecutorSpawnResult } from "./types.ts";
+import type { IpcMessage } from "../ipc-protocol.ts";
+
+/** Options for the shared spawn helper. */
+export interface SpawnChildOptions {
+  /** The command to run (e.g. "claude" or "docker"). */
+  command: string;
+  /** Arguments to the command. */
+  args: string[];
+  /** spawn() options (cwd, env, etc. — stdio is always overridden). */
+  spawnOptions?: Omit<SpawnOptions, "stdio" | "signal">;
+  /** Timeout in seconds (0 = no timeout). */
+  iterationTimeout: number;
+  /** Optional path to append agent output to. */
+  outputLogPath?: string;
+  /** Optional IPC broadcast callback for streaming output. */
+  ipcBroadcast?: (msg: IpcMessage) => void;
+  /** Label for error messages (e.g. "agent" or "Docker container"). */
+  errorLabel: string;
+}
+
+/**
+ * Spawn a child process and manage its lifecycle.
+ *
+ * Handles:
+ * - Optional output log file (append mode, best-effort)
+ * - Optional timeout via AbortController
+ * - stdin close (so the child knows no input is coming)
+ * - stdout/stderr passthrough to the terminal, log file, and IPC
+ * - Exit code and timeout reporting
+ */
+export function spawnChild(
+  opts: SpawnChildOptions,
+): Promise<ExecutorSpawnResult> {
+  const {
+    command,
+    args,
+    spawnOptions = {},
+    iterationTimeout,
+    outputLogPath,
+    ipcBroadcast,
+    errorLabel,
+  } = opts;
+
+  return new Promise((resolve) => {
+    // Open a write stream for the agent output log (append mode).
+    let logStream: ReturnType<typeof createWriteStream> | undefined;
+    if (outputLogPath) {
+      try {
+        logStream = createWriteStream(outputLogPath, { flags: "a" });
+      } catch {
+        // Best-effort: if we can't open the log, continue without it
+      }
+    }
+
+    let ac: AbortController | undefined;
+    let timedOut = false;
+
+    const finalOpts: SpawnOptions = {
+      ...spawnOptions,
+      stdio: ["pipe", "pipe", "pipe"] as const,
+    };
+
+    if (iterationTimeout > 0) {
+      ac = new AbortController();
+      (finalOpts as any).signal = ac.signal;
+      setTimeout(() => {
+        timedOut = true;
+        ac!.abort();
+      }, iterationTimeout * 1000);
+    }
+
+    let child: ChildProcess;
+    try {
+      child = spawn(command, args, finalOpts);
+    } catch (err) {
+      console.error(
+        `Failed to spawn ${errorLabel}: ${err instanceof Error ? err.message : err}`,
+      );
+      logStream?.end();
+      resolve({ output: "", exitCode: 1, timedOut: false });
+      return;
+    }
+
+    // Close stdin so the child knows no input is coming.
+    child.stdin?.end();
+
+    const chunks: Buffer[] = [];
+
+    child.stdout?.on("data", (data: Buffer) => {
+      process.stdout.write(data);
+      logStream?.write(data);
+      chunks.push(data);
+      ipcBroadcast?.({
+        type: "output",
+        data: data.toString(),
+        stream: "stdout",
+      });
+    });
+
+    child.stderr?.on("data", (data: Buffer) => {
+      process.stderr.write(data);
+      logStream?.write(data);
+      chunks.push(data);
+      ipcBroadcast?.({
+        type: "output",
+        data: data.toString(),
+        stream: "stderr",
+      });
+    });
+
+    child.on("close", (code) => {
+      const output = Buffer.concat(chunks).toString("utf-8");
+      if (logStream) {
+        logStream.end(() => {
+          resolve({ output, exitCode: code ?? 1, timedOut });
+        });
+      } else {
+        resolve({ output, exitCode: code ?? 1, timedOut });
+      }
+    });
+
+    child.on("error", (err) => {
+      logStream?.end();
+      if (timedOut) {
+        const output = Buffer.concat(chunks).toString("utf-8");
+        resolve({ output, exitCode: 124, timedOut: true });
+      } else {
+        console.error(`${errorLabel} error: ${err.message}`);
+        const output = Buffer.concat(chunks).toString("utf-8");
+        resolve({ output, exitCode: 1, timedOut: false });
+      }
+    });
+  });
+}

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -2122,6 +2122,7 @@ async function runIssueTarget(
   const activeWorktree = activeWorktrees.find((wt) => wt.branch === branch);
   const shouldResume = activeWorktree !== undefined;
   const hasResumeFlag = runArgs.includes("--resume") || runArgs.includes("-r");
+  const hasAllowDirtyFlag = runArgs.includes("--allow-dirty");
   const runnerRunArgs = runArgs.filter((arg) => arg !== "--drain");
   const worktreeRunOptions: RalphaiOptions = {
     ...options,
@@ -2129,6 +2130,7 @@ async function runIssueTarget(
     runTarget: undefined, // already handled
     runArgs: [
       ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
+      ...(!hasAllowDirtyFlag ? ["--allow-dirty"] : []),
       ...runnerRunArgs,
     ],
   };
@@ -2367,6 +2369,7 @@ async function runPrdIssueTarget(
     const shouldResume = activeWorktree !== undefined || !isFirstSubIssue;
     const hasResumeFlag =
       runArgs.includes("--resume") || runArgs.includes("-r");
+    const hasAllowDirtyFlag = runArgs.includes("--allow-dirty");
     // Strip --drain so the outer PRD loop, not the inner runner loop,
     // controls sub-issue sequencing.
     const runnerRunArgs = runArgs.filter((arg) => arg !== "--drain");
@@ -2376,6 +2379,7 @@ async function runPrdIssueTarget(
       runTarget: undefined,
       runArgs: [
         ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
+        ...(!hasAllowDirtyFlag ? ["--allow-dirty"] : []),
         ...runnerRunArgs,
       ],
     };
@@ -2837,11 +2841,13 @@ async function runRalphaiInManagedWorktree(
       const shouldResume = activeWorktree !== undefined;
       const hasResumeFlag =
         runArgs.includes("--resume") || runArgs.includes("-r");
+      const hasAllowDirtyFlag = runArgs.includes("--allow-dirty");
       const worktreeRunOptions: RalphaiOptions = {
         ...options,
         subcommand: "run",
         runArgs: [
           ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
+          ...(!hasAllowDirtyFlag ? ["--allow-dirty"] : []),
           ...runArgs,
         ],
       };
@@ -3018,12 +3024,14 @@ async function runRalphaiInManagedWorktree(
       plan.source === "in-progress" || activeWorktree !== undefined;
     const hasResumeFlag =
       runArgs.includes("--resume") || runArgs.includes("-r");
+    const hasAllowDirtyFlag = runArgs.includes("--allow-dirty");
     const runnerRunArgs = runArgs.filter((arg) => arg !== "--drain");
     const worktreeRunOptions: RalphaiOptions = {
       ...options,
       subcommand: "run",
       runArgs: [
         ...(shouldResume && !hasResumeFlag ? ["--resume"] : []),
+        ...(!hasAllowDirtyFlag ? ["--allow-dirty"] : []),
         ...runnerRunArgs,
       ],
     };

--- a/src/setup-command-routing.test.ts
+++ b/src/setup-command-routing.test.ts
@@ -321,3 +321,86 @@ describe("executeSetupCommand — error handling", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// HUSKY suppression
+// ---------------------------------------------------------------------------
+
+describe("executeSetupCommand — HUSKY suppression", () => {
+  it("sets HUSKY=0 in process.env during host setup execution", () => {
+    let capturedHusky: string | undefined;
+    restore = setExecImpl(((
+      command: string,
+      options: Record<string, unknown>,
+    ) => {
+      execCalls.push({ command, options });
+      capturedHusky = process.env.HUSKY;
+      return "";
+    }) as any);
+
+    executeSetupCommand("bun install", "/work/my-project");
+
+    expect(capturedHusky).toBe("0");
+  });
+
+  it("restores original HUSKY value after successful host setup", () => {
+    const originalHusky = process.env.HUSKY;
+    process.env.HUSKY = "original-value";
+    restore = mockExecSuccess();
+
+    executeSetupCommand("bun install", "/work/my-project");
+
+    expect(process.env.HUSKY).toBe("original-value");
+    // Clean up
+    if (originalHusky === undefined) {
+      delete process.env.HUSKY;
+    } else {
+      process.env.HUSKY = originalHusky;
+    }
+  });
+
+  it("restores original HUSKY value after failed host setup", () => {
+    const originalHusky = process.env.HUSKY;
+    process.env.HUSKY = "original-value";
+    restore = mockExecFail();
+
+    expect(() => executeSetupCommand("bun install", "/work")).toThrow(
+      "process.exit(1)",
+    );
+
+    expect(process.env.HUSKY).toBe("original-value");
+    // Clean up
+    if (originalHusky === undefined) {
+      delete process.env.HUSKY;
+    } else {
+      process.env.HUSKY = originalHusky;
+    }
+  });
+
+  it("deletes HUSKY from process.env after host setup when it was not previously set", () => {
+    const originalHusky = process.env.HUSKY;
+    delete process.env.HUSKY;
+    restore = mockExecSuccess();
+
+    executeSetupCommand("bun install", "/work/my-project");
+
+    expect(process.env.HUSKY).toBeUndefined();
+    // Clean up
+    if (originalHusky !== undefined) {
+      process.env.HUSKY = originalHusky;
+    }
+  });
+
+  it("includes HUSKY=0 in Docker setup command args", () => {
+    restore = mockExecSuccess();
+    const config: SetupSandboxConfig = {
+      sandbox: "docker",
+      agentCommand: "claude -p",
+    };
+    executeSetupCommand("bun install", "/work/my-project", config);
+
+    const dockerCall = execCalls.find((c) => c.command.startsWith("docker"));
+    expect(dockerCall).toBeDefined();
+    expect(dockerCall!.command).toContain("HUSKY=0");
+  });
+});

--- a/src/setup-command-routing.test.ts
+++ b/src/setup-command-routing.test.ts
@@ -287,10 +287,7 @@ describe("executeSetupCommand — Docker command construction", () => {
     // resolveMainGitDir calls execQuiet which returns "" (not a worktree),
     // so no main git dir mount is added.
     expect(dockerCall!.command).toContain("/work/my-project:/work/my-project");
-    // Count -v mounts: should only have the worktree mount (no git dir mount)
-    const vMatches = dockerCall!.command.match(/-v /g);
-    // There's always at least one -v for the worktree bind mount; there may
-    // be credential mounts too. The key assertion is no .git mount.
+    // The key assertion is no .git mount (credential mounts may exist).
     expect(dockerCall!.command).not.toContain("/.git:");
   });
 });

--- a/src/worktree/management.ts
+++ b/src/worktree/management.ts
@@ -138,7 +138,18 @@ export function executeSetupCommand(
   }
 
   console.log(`Running setup command: ${setupCommand}`);
-  const result = execInherit(setupCommand, worktreeDir);
+  const prevHusky = process.env.HUSKY;
+  process.env.HUSKY = "0";
+  let result: { exitCode: number };
+  try {
+    result = execInherit(setupCommand, worktreeDir);
+  } finally {
+    if (prevHusky === undefined) {
+      delete process.env.HUSKY;
+    } else {
+      process.env.HUSKY = prevHusky;
+    }
+  }
   if (result.exitCode !== 0) {
     console.error(
       `${TEXT}Error:${RESET} Setup command failed: ${setupCommand}`,


### PR DESCRIPTION
PRD #498: Suppress husky and auto-allow dirty state in worktree runs

## Summary

- **#499:** Suppress husky git hooks in all ralphai-managed subprocesses by setting `HUSKY=0` in the environment for Docker containers (both setup and agent execution), local agent spawns, and local setup commands. This prevents husky from installing hooks or running pre-commit/pre-push hooks during autonomous ralphai runs, while preserving the original `HUSKY` env value on the host after local setup completes.
- **#500:** Automatically inject `--allow-dirty` into runner args at all worktree-context call sites so the interactive dirty-state prompt never fires in ralphai-managed worktrees. Setup commands (e.g. lockfile generation) can leave worktrees dirty, and prompting the user about state they didn't create is disruptive. Non-worktree invocations (help, show-config, dry-run, direct `ralphai run`) are unaffected.
- **#501:** Document two worktree-specific behaviors introduced by #499 and #500: husky suppression via `HUSKY=0` during setup and agent execution, and automatic `--allow-dirty` injection for worktree runs. Updates `docs/worktrees.md` with both notes and `docs/cli-reference.md` with the auto-application detail on the `--allow-dirty` flag.

Closes #498
Closes #499
Closes #500
Closes #501

## Completed Sub-Issues

- [x] #499
- [x] #500
- [x] #501

## Changes

### Features

- auto-inject --allow-dirty into runner args for worktree runs
- suppress husky git hooks in all ralphai-managed subprocesses

### Refactoring

- remove redundant destructuring in Docker executor command builders
- extract shared spawn helper to deduplicate executor code

### Documentation

- document husky suppression and auto --allow-dirty in worktrees