### PR TITLE
docs: extract Docker sandbox content into dedicated docs/docker.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Ralphai is a CLI tool that takes plans (markdown files) from a backlog and drive
   - `docs/cli-reference.md` -- all commands, flags, config keys, and env vars. Update when adding or changing CLI surface.
   - `docs/hooks.md` -- hooks, gates, prompt controls, and config reference tables. Update when adding or changing config keys, hooks, gate behavior, or prompt injection.
   - `docs/how-ralphai-works.md` -- technical deep-dive: feedback loops, stuck detection, context rot. Update when changing core loop behavior.
+  - `docs/docker.md` -- Docker sandbox execution flow, credential forwarding, images. Update when changing Docker/sandbox behavior.
   - `docs/workflows.md` -- recipe-based user guide. Update when adding new commands or changing user-facing workflows.
   - `docs/worktrees.md` -- worktree lifecycle and parallel runs. Update when changing worktree behavior.
   - `docs/troubleshooting.md` -- common issues and recovery steps. Update when fixing user-facing bugs or changing error behavior.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,80 @@
+# Docker Sandbox
+
+When `sandbox` is `"docker"`, Ralphai wraps each agent invocation in an ephemeral Docker container instead of spawning the agent as a local child process. The runner's feedback loop, progress extraction, and completion gate work identically — only the process execution layer changes.
+
+Back to the [README](../README.md) for setup and quickstart.
+
+## How it works
+
+The executor abstraction (`src/executor/`) decouples process spawning from the runner loop. A factory selects the strategy:
+
+- `sandbox: "none"` → `LocalExecutor` — spawns the agent as a local child process
+- `sandbox: "docker"` → `DockerExecutor` — spawns `docker run --rm` with the agent command inside
+
+Each `DockerExecutor.spawn()` call builds a `docker run --rm` command with:
+
+1. **Worktree bind-mount** — the worktree directory is mounted at its host path (`-v /path:/path`), so file references in agent output remain valid.
+2. **Credential env vars** — forwarded via `-e VAR` (Docker reads the value from the host environment, preventing value leakage in process listings).
+3. **Credential file mounts** — agent-specific config files mounted read-only (`:ro`).
+4. **Working directory** — set to the worktree path via `-w`.
+5. **Image** — auto-resolved from the agent name or overridden by `dockerImage` config.
+
+The container is ephemeral (`--rm`) — it is created fresh for each agent invocation and removed on exit. The runner streams stdout/stderr from the container the same way it does from a local process, so progress extraction and IPC broadcasting work unchanged.
+
+## Auto-detection
+
+When no explicit `sandbox` value is configured (via config file, env var, or CLI flag), Ralphai probes Docker availability at startup by running `docker info` with a 3-second timeout. The result is cached for the process lifetime.
+
+- **Docker available** → `sandbox` defaults to `"docker"` (source: `auto-detected`)
+- **Docker unavailable** → `sandbox` defaults to `"none"` (source: `auto-detected`)
+
+The behavior differs when Docker becomes unavailable after config resolution:
+
+- **Explicit `sandbox: "docker"`** (set in config/env/CLI) → hard fail with `process.exit(1)` and an actionable error message
+- **Auto-detected `sandbox: "docker"`** → silent fallback to `"none"` (local execution)
+
+Use `ralphai config` to see the resolved value and its source.
+
+## Credential forwarding
+
+Credential forwarding follows a strict allowlist — only explicitly listed env vars and file paths are forwarded, preventing full `process.env` leakage into the container.
+
+**Env vars** are forwarded per-agent:
+
+| Agent    | Agent-specific vars | Common vars (all agents)   |
+| -------- | ------------------- | -------------------------- |
+| Claude   | `ANTHROPIC_API_KEY` | `GITHUB_TOKEN`, `GH_TOKEN` |
+| Codex    | `OPENAI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
+| Gemini   | `GEMINI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
+| Aider    | `OPENAI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
+| Goose    | `OPENAI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
+| OpenCode | _(none)_            | `GITHUB_TOKEN`, `GH_TOKEN` |
+
+Git identity vars (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`) are also forwarded when set on the host. Additional env vars can be forwarded via the `dockerEnvVars` config key.
+
+Env vars that are unset or empty on the host are silently skipped.
+
+**File mounts** are forwarded per-agent as read-only bind mounts:
+
+| Agent    | Mounted files (relative to `~`)                              |
+| -------- | ------------------------------------------------------------ |
+| OpenCode | `.local/share/opencode/auth.json`, `.config/github-copilot/` |
+| All      | `.gitconfig`, `.agents/skills/`                              |
+
+Files that don't exist on the host are silently skipped. Globally-installed skills (via `npx skills add ... -g`) are automatically available to agents in Docker mode through the `.agents/skills/` mount. Additional mounts can be added via the `dockerMounts` config key.
+
+## Pre-built images
+
+Ralphai publishes pre-built Docker images for supported agents:
+
+- `ghcr.io/mfaux/ralphai-sandbox:claude`
+- `ghcr.io/mfaux/ralphai-sandbox:opencode`
+- `ghcr.io/mfaux/ralphai-sandbox:codex`
+
+Images are based on `debian:bookworm-slim` and include git, curl, Node.js (LTS), pnpm (via corepack), Bun, and the agent CLI. The image is auto-resolved from the agent command (e.g., `claude -p` → `:claude`). Unrecognized agents fall back to the `:latest` tag. Override with the `dockerImage` config key for custom images.
+
+At the start of each run, Ralphai pulls the resolved image (`docker pull --quiet`) to ensure the local cache is up to date. The pull is fail-open: if it fails (e.g., no network), the run continues with whatever image is cached locally.
+
+## Stdio-based progress extraction
+
+Because the container's stdout and stderr are piped back to the runner process, all existing progress extraction, learnings extraction, context extraction, and completion sentinel detection work unchanged. The `<progress>`, `<learnings>`, `<context>`, `<promise>`, and `<pr-summary>` sentinel tags are parsed from the container's output stream the same way they are parsed from a local process.

--- a/docs/how-ralphai-works.md
+++ b/docs/how-ralphai-works.md
@@ -508,84 +508,9 @@ Key properties:
 
 The prompt asks agents to report specific categories of information in their learnings — architectural constraints or patterns observed, error messages encountered with how they were resolved, and behavioral lessons worth applying to future iterations. Context notes should capture session-specific details — file paths discovered, API surfaces explored, and decisions made. The format for both is free-form prose; the categories are guidance, not schema enforcement.
 
-## Docker Execution Flow
+## Docker Sandbox
 
-When `sandbox` is `"docker"`, Ralphai wraps each agent invocation in an ephemeral Docker container instead of spawning the agent as a local child process. The runner's feedback loop, progress extraction, and completion gate work identically — only the process execution layer changes.
-
-### How it works
-
-The executor abstraction (`src/executor/`) decouples process spawning from the runner loop. A factory selects the strategy:
-
-- `sandbox: "none"` → `LocalExecutor` — spawns the agent as a local child process
-- `sandbox: "docker"` → `DockerExecutor` — spawns `docker run --rm` with the agent command inside
-
-Each `DockerExecutor.spawn()` call builds a `docker run --rm` command with:
-
-1. **Worktree bind-mount** — the worktree directory is mounted at its host path (`-v /path:/path`), so file references in agent output remain valid.
-2. **Credential env vars** — forwarded via `-e VAR` (Docker reads the value from the host environment, preventing value leakage in process listings).
-3. **Credential file mounts** — agent-specific config files mounted read-only (`:ro`).
-4. **Working directory** — set to the worktree path via `-w`.
-5. **Image** — auto-resolved from the agent name or overridden by `dockerImage` config.
-
-The container is ephemeral (`--rm`) — it is created fresh for each agent invocation and removed on exit. The runner streams stdout/stderr from the container the same way it does from a local process, so progress extraction and IPC broadcasting work unchanged.
-
-### Auto-detection
-
-When no explicit `sandbox` value is configured (via config file, env var, or CLI flag), Ralphai probes Docker availability at startup by running `docker info` with a 3-second timeout. The result is cached for the process lifetime.
-
-- **Docker available** → `sandbox` defaults to `"docker"` (source: `auto-detected`)
-- **Docker unavailable** → `sandbox` defaults to `"none"` (source: `auto-detected`)
-
-The behavior differs when Docker becomes unavailable after config resolution:
-
-- **Explicit `sandbox: "docker"`** (set in config/env/CLI) → hard fail with `process.exit(1)` and an actionable error message
-- **Auto-detected `sandbox: "docker"`** → silent fallback to `"none"` (local execution)
-
-Use `ralphai config` to see the resolved value and its source.
-
-### Credential forwarding
-
-Credential forwarding follows a strict allowlist — only explicitly listed env vars and file paths are forwarded, preventing full `process.env` leakage into the container.
-
-**Env vars** are forwarded per-agent:
-
-| Agent    | Agent-specific vars | Common vars (all agents)   |
-| -------- | ------------------- | -------------------------- |
-| Claude   | `ANTHROPIC_API_KEY` | `GITHUB_TOKEN`, `GH_TOKEN` |
-| Codex    | `OPENAI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
-| Gemini   | `GEMINI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
-| Aider    | `OPENAI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
-| Goose    | `OPENAI_API_KEY`    | `GITHUB_TOKEN`, `GH_TOKEN` |
-| OpenCode | _(none)_            | `GITHUB_TOKEN`, `GH_TOKEN` |
-
-Git identity vars (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`) are also forwarded when set on the host. Additional env vars can be forwarded via the `dockerEnvVars` config key.
-
-Env vars that are unset or empty on the host are silently skipped.
-
-**File mounts** are forwarded per-agent as read-only bind mounts:
-
-| Agent    | Mounted files (relative to `~`)                              |
-| -------- | ------------------------------------------------------------ |
-| OpenCode | `.local/share/opencode/auth.json`, `.config/github-copilot/` |
-| All      | `.gitconfig`, `.agents/skills/`                              |
-
-Files that don't exist on the host are silently skipped. Globally-installed skills (via `npx skills add ... -g`) are automatically available to agents in Docker mode through the `.agents/skills/` mount. Additional mounts can be added via the `dockerMounts` config key.
-
-### Pre-built images
-
-Ralphai publishes pre-built Docker images for supported agents:
-
-- `ghcr.io/mfaux/ralphai-sandbox:claude`
-- `ghcr.io/mfaux/ralphai-sandbox:opencode`
-- `ghcr.io/mfaux/ralphai-sandbox:codex`
-
-Images are based on `debian:bookworm-slim` and include git, curl, Node.js (LTS), pnpm (via corepack), Bun, and the agent CLI. The image is auto-resolved from the agent command (e.g., `claude -p` → `:claude`). Unrecognized agents fall back to the `:latest` tag. Override with the `dockerImage` config key for custom images.
-
-At the start of each run, Ralphai pulls the resolved image (`docker pull --quiet`) to ensure the local cache is up to date. The pull is fail-open: if it fails (e.g., no network), the run continues with whatever image is cached locally.
-
-### Stdio-based progress extraction
-
-Because the container's stdout and stderr are piped back to the runner process, all existing progress extraction, learnings extraction, context extraction, and completion sentinel detection work unchanged. The `<progress>`, `<learnings>`, `<context>`, `<promise>`, and `<pr-summary>` sentinel tags are parsed from the container's output stream the same way they are parsed from a local process.
+Ralphai can run agents inside ephemeral Docker containers instead of spawning them as local child processes. The runner's feedback loop, progress extraction, and completion gate work identically — only the process execution layer changes. See [Docker Sandbox](docker.md) for the full execution flow, credential forwarding, and image reference.
 
 ## Progress Extraction
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -174,7 +174,7 @@ Mounts use standard Docker bind-mount syntax (`host:container[:options]`). Env v
 
 The exact flag depends on which agent you use — check your agent's CLI reference for the correct option.
 
-For details on the Docker execution flow and credential forwarding, see [How Ralphai Works](how-ralphai-works.md#docker-execution-flow). For all Docker-related config keys, see [Hooks, Gates, and Prompt Controls](hooks.md#top-level-keys).
+For details on the Docker execution flow and credential forwarding, see [Docker Sandbox](docker.md). For all Docker-related config keys, see [Hooks, Gates, and Prompt Controls](hooks.md#top-level-keys).
 
 ## Test a plan without changing anything
 


### PR DESCRIPTION
## Summary

- Moves the **Docker Execution Flow** section from `docs/how-ralphai-works.md` into a new `docs/docker.md` file, keeping `how-ralphai-works.md` focused on the core loop (feedback, completion gate, stuck detection, context rot).
- Replaces the removed section with a short summary paragraph linking to the new file.
- Updates the cross-reference in `docs/workflows.md` to point to `docker.md` instead of the old anchor.
- Adds `docs/docker.md` to the doc inventory in `AGENTS.md`.