### PR TITLE
chore: disable renovate TypeScript major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": ["config:recommended", "group:allNonMajor"],
   "labels": ["dependencies"],
   "semanticCommitScope": "",
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- disable Renovate TypeScript major updates in `renovate.json`
- avoid reopening a known failing update path where the TS 6 upgrade required a coordinated `tsconfig.json` change in addition to the package bump
- reduce stale dashboard noise while keeping non-major dependency automation intact