### PR TITLE
fix: stop PRD runs after Ctrl-C interrupt

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -226,6 +226,7 @@ PRD behavior:
 - Per-sub-issue PRs are suppressed; one aggregate draft PR is opened at the end
 - Stuck sub-issues are skipped and listed in the PR body; the PRD continues to the next
 - HITL sub-issues (labeled with `issue.hitlLabel`, default `ralphai-subissue-hitl`) and sub-issues blocked by HITL dependencies are skipped; the PRD continues to the next eligible sub-issue
+- `Ctrl+C` stops the PRD run without advancing to later sub-issues or opening the aggregate PR for that interrupted run
 - The aggregate PR title uses `feat: <PRD title>` and includes completed/stuck/HITL checklists
 
 The `ralphai run <number>` form uses label-driven dispatch: it reads the issue's labels to classify it as standalone (`ralphai-standalone`), sub-issue (`ralphai-subissue`), or PRD (`ralphai-prd`). Sub-issues automatically discover their parent PRD and process through the PRD flow. Issues with no recognized label produce an error with guidance. The old unified `ralphai` label is not recognized.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -90,7 +90,7 @@ If a runner crashes without cleaning up its PID file, the next `ralphai run` aut
 
 ## "How do I stop a running agent?"
 
-**Headless (`ralphai run`):** Press Ctrl-C in the terminal where the runner is active. The runner catches SIGINT/SIGTERM, finishes the current iteration cleanly, then exits. Work is preserved in `in-progress/<slug>/`, so you can resume later.
+**Headless (`ralphai run`):** Press Ctrl-C in the terminal where the runner is active. The runner catches SIGINT/SIGTERM, finishes the current iteration cleanly, then exits. Work is preserved in `in-progress/<slug>/`, so you can resume later. During a PRD run, Ralphai stops after the current sub-issue and does not advance to later sub-issues or create the aggregate PR for that interrupted run.
 
 **From another terminal:** Use `ralphai stop` to send SIGTERM to a running plan runner:
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -16,7 +16,7 @@ For multi-step features, use the planning skills to go from idea to executable i
 ralphai run 42           # issue #42: detected as PRD via label, processes sub-issues
 ```
 
-Ralphai creates a single worktree on a `feat/<prd-slug>` branch and processes sub-issues one at a time. Stuck sub-issues are skipped — the PRD continues to the next. Sub-issues labeled with the HITL label (`ralphai-subissue-hitl` by default, configurable via `issue.hitlLabel`) are also skipped — they require human review. Sub-issues that depend on a HITL sub-issue are skipped as blocked. When all sub-issues are done (or skipped), Ralphai opens one aggregate draft PR listing completed, stuck, HITL, and blocked items.
+Ralphai creates a single worktree on a `feat/<prd-slug>` branch and processes sub-issues one at a time. Stuck sub-issues are skipped — the PRD continues to the next. Sub-issues labeled with the HITL label (`ralphai-subissue-hitl` by default, configurable via `issue.hitlLabel`) are also skipped — they require human review. Sub-issues that depend on a HITL sub-issue are skipped as blocked. When all sub-issues are done (or skipped), Ralphai opens one aggregate draft PR listing completed, stuck, HITL, and blocked items. If you press `Ctrl+C` during a PRD run, Ralphai stops the PRD run after the current sub-issue instead of advancing to later sub-issues.
 
 You can also create PRD issues and sub-issues by hand — just apply the `ralphai-prd` label (configurable via `issue.prdLabel`) and add sub-issues. The skills automate this.
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -41,6 +41,7 @@ const ISOLATED = [
   "src/runner-github-drain.test.ts",
   "src/hitl.test.ts",
   "src/plan-detection-race.test.ts",
+  "src/prd-interrupt.test.ts",
 ];
 
 // Inherently slow tests (E2E runner loops, real process spawning, real sockets).

--- a/src/prd-interrupt.test.ts
+++ b/src/prd-interrupt.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests that interrupted PRD sub-issues stop the outer PRD loop.
+ *
+ * Uses mock.module(), so this file must run in isolation.
+ */
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { makeTestResolvedConfig } from "./test-utils.ts";
+import type { RunnerResult } from "./runner.ts";
+
+const mockRunRunner = mock<() => Promise<RunnerResult>>();
+const realRunner = await import("./runner.ts");
+mock.module("./runner.ts", () => {
+  return {
+    ...realRunner,
+    runRunner: mockRunRunner,
+  };
+});
+
+const mockDiscoverPrdTarget = mock();
+const mockFetchIssueWithLabels = mock();
+const mockPullGithubIssueByNumber = mock();
+const mockPrdTransitionInProgress = mock();
+const mockPrdTransitionDone = mock();
+const mockFormatPrdHitlSummary = mock();
+const mockDetectIssueRepo =
+  mock<(cwd: string, configRepo?: string) => string | null>();
+const realIssueLifecycle = await import("./issue-lifecycle.ts");
+mock.module("./issue-lifecycle.ts", () => {
+  return {
+    ...realIssueLifecycle,
+    detectIssueRepo: mockDetectIssueRepo,
+    fetchIssueWithLabels: mockFetchIssueWithLabels,
+    discoverPrdTarget: mockDiscoverPrdTarget,
+    pullGithubIssueByNumber: mockPullGithubIssueByNumber,
+    prdTransitionInProgress: mockPrdTransitionInProgress,
+    prdTransitionDone: mockPrdTransitionDone,
+    formatPrdHitlSummary: mockFormatPrdHitlSummary,
+  };
+});
+
+const mockPrepareWorktree = mock<(cwd: string) => string>();
+const mockListRalphaiWorktrees = mock<() => Array<{ branch: string }>>();
+const realWorktree = await import("./worktree/index.ts");
+mock.module("./worktree/index.ts", () => {
+  return {
+    ...realWorktree,
+    resolveWorktreeInfo: () => ({ isWorktree: false, mainWorktree: "" }),
+    resolveMainRepo: (dir: string) => dir,
+    ensureRepoHasCommit: () => {},
+    prepareWorktree: mockPrepareWorktree,
+    listRalphaiWorktrees: mockListRalphaiWorktrees,
+  };
+});
+
+const mockResolveConfig = mock();
+const mockGetConfigFilePath = mock<(cwd: string) => string>();
+const realConfig = await import("./config.ts");
+mock.module("./config.ts", () => {
+  return {
+    ...realConfig,
+    resolveConfig: mockResolveConfig,
+    getConfigFilePath: mockGetConfigFilePath,
+  };
+});
+
+const mockExecQuiet = mock<(cmd: string, cwd: string) => string | null>();
+const realExec = await import("./exec.ts");
+mock.module("./exec.ts", () => {
+  return {
+    ...realExec,
+    execQuiet: mockExecQuiet,
+  };
+});
+
+const { runRalphai } = await import("./ralphai.ts");
+
+function createRepoDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ralphai-prd-interrupt-"));
+  mkdirSync(join(dir, ".git"), { recursive: true });
+  return dir;
+}
+
+describe("PRD interrupt handling", () => {
+  let dir: string;
+  let envHome: string;
+
+  beforeEach(() => {
+    dir = createRepoDir();
+    envHome = join(dir, ".ralphai-home");
+    mkdirSync(envHome, { recursive: true });
+    const configPath = join(envHome, "config.json");
+    writeFileSync(configPath, "{}");
+
+    mockResolveConfig.mockReturnValue({
+      config: makeTestResolvedConfig({
+        gate: { review: false },
+        issue: { source: "github" },
+      }),
+      warnings: [],
+      configFilePath: configPath,
+    });
+    mockGetConfigFilePath.mockReturnValue(configPath);
+    mockDetectIssueRepo.mockReturnValue("owner/repo");
+    mockFetchIssueWithLabels.mockReturnValue({
+      title: "feat: parent prd",
+      labels: ["ralphai-prd"],
+    });
+    mockDiscoverPrdTarget.mockReturnValue({
+      isPrd: true,
+      prd: { number: 42, title: "feat: parent prd" },
+      subIssues: [101, 102],
+      allCompleted: false,
+    });
+    mockPrepareWorktree.mockReturnValue(dir);
+    mockListRalphaiWorktrees.mockReturnValue([]);
+    mockExecQuiet.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("git rev-parse --abbrev-ref HEAD")) {
+        return "feat/parent-prd";
+      }
+      if (cmd.includes("gh issue view")) {
+        return "";
+      }
+      return null;
+    });
+    mockPullGithubIssueByNumber.mockImplementation(
+      ({ issueNumber }: { issueNumber: number }) => ({
+        pulled: true,
+        message: `Pulled sub-issue #${issueNumber}`,
+        planPath: join(dir, `${issueNumber}.md`),
+      }),
+    );
+    mockFormatPrdHitlSummary.mockReturnValue(["summary"]);
+    mockPrdTransitionInProgress.mockImplementation(() => {});
+    mockPrdTransitionDone.mockImplementation(() => {});
+
+    mockRunRunner.mockResolvedValue({
+      stuckSlugs: [],
+      accumulatedLearnings: [],
+      interrupted: true,
+    });
+  });
+
+  test("stops after an interrupted sub-issue and skips PRD finalization", async () => {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    const originalEnvHome = process.env.RALPHAI_HOME;
+
+    process.env.RALPHAI_HOME = envHome;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    console.error = (...args: unknown[]) =>
+      errors.push(args.map(String).join(" "));
+
+    try {
+      await runRalphai(["run", "42"]);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+      if (originalEnvHome === undefined) delete process.env.RALPHAI_HOME;
+      else process.env.RALPHAI_HOME = originalEnvHome;
+    }
+
+    expect(errors).toEqual([]);
+    expect(mockRunRunner).toHaveBeenCalledTimes(1);
+    expect(mockPullGithubIssueByNumber).toHaveBeenCalledTimes(1);
+    expect(mockPullGithubIssueByNumber.mock.calls[0]?.[0].issueNumber).toBe(
+      101,
+    );
+    expect(logs.join("\n")).toContain(
+      "Sub-issue #101 interrupted — stopping PRD run.",
+    );
+    expect(logs.join("\n")).toContain(
+      "Interrupted during PRD #42. Work is preserved in in-progress — resume with another run.",
+    );
+    expect(logs.join("\n")).not.toContain("Creating PRD pull request...");
+    expect(mockPrdTransitionDone).not.toHaveBeenCalled();
+  });
+});

--- a/src/ralphai.ts
+++ b/src/ralphai.ts
@@ -2329,6 +2329,7 @@ async function runPrdIssueTarget(
   const subIssueSummaries = new Map<number, string>();
   const prdLearnings: string[] = [];
   let completedCount = 0;
+  let prdInterrupted = false;
 
   for (const subIssueNumber of eligibleSubIssues) {
     console.log();
@@ -2421,6 +2422,13 @@ async function runPrdIssueTarget(
         },
         { skipPrCreation: true },
       );
+      if (result.interrupted) {
+        prdInterrupted = true;
+        console.log(
+          `Sub-issue #${subIssueNumber} interrupted — stopping PRD run.`,
+        );
+        break;
+      }
       if (result.stuckSlugs.length > 0) {
         // Runner returned normally but the sub-issue got stuck
         stuckSubIssues.push(subIssueNumber);
@@ -2450,6 +2458,14 @@ async function runPrdIssueTarget(
         `Skipping sub-issue #${subIssueNumber} — continuing to next.`,
       );
     }
+  }
+
+  if (prdInterrupted) {
+    console.log();
+    console.log(
+      `Interrupted during PRD #${prd.number}. Work is preserved in in-progress — resume with another run.`,
+    );
+    return;
   }
 
   // --- Summary ---
@@ -3107,7 +3123,7 @@ async function runRalphaiRunner(
   // --- Handle --help ---
   if (runArgs.includes("--help") || runArgs.includes("-h")) {
     showRunHelp();
-    return { stuckSlugs: [], accumulatedLearnings: [] };
+    return { stuckSlugs: [], accumulatedLearnings: [], interrupted: false };
   }
 
   // --- Reject unrecognized flags ---
@@ -3170,7 +3186,7 @@ async function runRalphaiRunner(
       workspaces: configValues(config).workspaces,
     });
     console.log(text);
-    return { stuckSlugs: [], accumulatedLearnings: [] };
+    return { stuckSlugs: [], accumulatedLearnings: [], interrupted: false };
   }
 
   // Check that ralphai has been initialized (global config exists).

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -355,6 +355,7 @@ describe("runRunner — RunnerResult", () => {
     const result = await runRunner(opts);
 
     expect(result.stuckSlugs).toEqual([]);
+    expect(result.interrupted).toBe(false);
   });
 
   test("returns accumulated learnings from the run", async () => {
@@ -414,6 +415,7 @@ describe("runRunner — RunnerResult", () => {
 
     expect(result.stuckSlugs).toEqual([]);
     expect(result.accumulatedLearnings).toEqual([]);
+    expect(result.interrupted).toBe(false);
   });
 });
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -226,6 +226,8 @@ export interface RunnerResult {
   lastPrSummary?: string;
   /** Learnings accumulated across all iterations of this run. */
   accumulatedLearnings: string[];
+  /** True when the runner was interrupted by SIGINT or SIGTERM. */
+  interrupted: boolean;
 }
 
 /** Options passed from the CLI layer to the runner. */
@@ -710,7 +712,7 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
   // --- Dry-run mode ---
   if (dryRun) {
     runDryRun(opts, dirs, cfg, effectiveSandbox);
-    return { stuckSlugs: [], accumulatedLearnings: [] };
+    return { stuckSlugs: [], accumulatedLearnings: [], interrupted: false };
   }
 
   // --- Signal handling ---
@@ -1538,5 +1540,5 @@ export async function runRunner(opts: RunnerOptions): Promise<RunnerResult> {
   process.removeListener("SIGINT", handleSignal);
   process.removeListener("SIGTERM", handleSignal);
 
-  return { stuckSlugs, lastPrSummary, accumulatedLearnings };
+  return { stuckSlugs, lastPrSummary, accumulatedLearnings, interrupted };
 }


### PR DESCRIPTION
## Summary
- propagate runner interrupt state so PRD orchestration can distinguish Ctrl+C from a successful sub-issue run
- stop PRD processing immediately after an interrupted sub-issue and skip aggregate PR/finalization for that interrupted run
- add isolated regression coverage and document the updated Ctrl+C behavior for PRD runs

## Testing
- bun test src/runner.test.ts
- bun test src/prd-interrupt.test.ts
- bun run test:fast