### PR TITLE
fix: include git error details in push failure messages

### DIFF
--- a/src/pr-lifecycle.test.ts
+++ b/src/pr-lifecycle.test.ts
@@ -77,6 +77,8 @@ describe("pushBranch", () => {
     const result = pushBranch("main", ctx.dir, true);
     expect(result.ok).toBe(false);
     expect(result.message).toContain("Failed to push");
+    // The error message should include the underlying git error reason
+    expect(result.message).toContain("Reason:");
   });
 });
 

--- a/src/pr-lifecycle.ts
+++ b/src/pr-lifecycle.ts
@@ -11,7 +11,7 @@
  */
 import { existsSync, mkdirSync, renameSync } from "fs";
 import { basename, dirname, join } from "path";
-import { execQuiet, execWithStdin } from "./exec.ts";
+import { execQuiet, execRun, execWithStdin } from "./exec.ts";
 import { extractIssueFrontmatter } from "./plan-lifecycle.ts";
 import {
   checkGhAvailable,
@@ -445,10 +445,13 @@ export function pushBranch(
   setUpstream = true,
 ): PushResult {
   const flag = setUpstream ? " -u" : "";
-  if (execQuiet(`git push${flag} origin "${branch}"`, cwd) === null) {
+  const result = execRun(`git push${flag} origin "${branch}"`, cwd);
+  if (result.exitCode !== 0) {
+    const detail = (result.stderr || result.stdout).trim();
+    const reason = detail ? ` Reason: ${detail}` : "";
     return {
       ok: false,
-      message: `Failed to push branch '${branch}'. Branch left intact for manual push.`,
+      message: `Failed to push branch '${branch}'. Branch left intact for manual push.${reason}`,
     };
   }
   return { ok: true, message: `Pushed ${branch} to origin` };


### PR DESCRIPTION
## Summary

- `pushBranch()` used `execQuiet()` which silently discards stderr on failure, making it impossible to diagnose why a git push failed (auth errors, remote rejections, network issues, etc.)
- Switched to `execRun()` which captures stderr, and appends the underlying git error as a `Reason:` suffix in the failure message
- Added test assertion to verify the error reason is included in failure output