### PR TITLE
chore: override renovate silent mode with full mode

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "group:allNonMajor"],
+  "mode": "full",
   "labels": ["dependencies"],
   "semanticCommitScope": "",
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
## Summary
- Add `"mode": "full"` to `renovate.json` to override the Mend platform's `mode=silent` default
- This was the root cause of the stuck dependency dashboard: silent mode prevents Renovate from creating/updating branches, PRs, and the dashboard issue
- After merge, the next Renovate run should refresh issue #448 and create PRs for pending updates (ink v7, docker/build-push-action v7, typescript patch 6.0.3)